### PR TITLE
Fix links js disabled

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -84,16 +84,20 @@ const Footer: React.FunctionComponent<Props> = (props: Props) => {
           </p>
           <Link
             href={`/terms`}
+            passHref={true}
           >
-            <div
-              css={{
-                marginTop: '20px',
-                textDecoration: 'underline',
-                cursor: 'pointer',
-              }}
-            >
-              {t('footer.terms.link', 'Conditions générales d\'utilisation')}
-            </div>
+            <a>
+              <div
+                css={{
+                  marginTop: '20px',
+                  textDecoration: 'underline',
+                  cursor: 'pointer',
+                  color: 'white',
+                }}
+              >
+                {t('footer.terms.link', 'Conditions générales d\'utilisation')}
+              </div>
+            </a>
           </Link>
         </Col>
         <Col md={4} xs={12} className={'text-md-right text-center mt-3'}>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -332,6 +332,10 @@ const Layout: React.FunctionComponent<Props> = (props: Props): JSX.Element => {
                 animation-duration: 6s;
               }
             }
+
+            .fade {
+              opacity: 1 !important; // Overrides default bootstrap behaviour to avoid make-believe SSR doesn't work on the demo, when JS is disabled - See https://github.com/UnlyEd/next-right-now/issues/9
+            }
           }
         `}
       ></Global>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -177,40 +177,28 @@ const Nav: React.FunctionComponent<Props> = (props: Props) => {
               <Link
                 href={`/index`}
                 as={'/'}
+                passHref={true}
               >
-                <Col className={'navItemsMenu'}>
-                  <Row className={'justify-content-center navItemsLogo'}>
-                    <i className={classnames('fas fa-comments', { active: isActive(router, 'index') })} />
-                  </Row>
-                  <Row className={'justify-content-center'}>
-                    <NavLink
-                      id={'nav-link-home'}
-                      active={isActive(router, '') || isActive(router, 'index')}
-                    >
-                      {t('nav.indexPage.link', 'Accueil')}
-                    </NavLink>
-                  </Row>
-                </Col>
+                <NavLink
+                  id={'nav-link-home'}
+                  active={isActive(router, '') || isActive(router, 'index')}
+                >
+                  {t('nav.indexPage.link', 'Accueil')}
+                </NavLink>
               </Link>
             </NavItem>
 
             <NavItem>
               <Link
                 href={`/examples`}
+                passHref={true}
               >
-                <Col className={'navItemsMenu'}>
-                  <Row className={'justify-content-center navItemsLogo'}>
-                    <i className={classnames('fas fa-comments', { active: isActive(router, 'examples') })} />
-                  </Row>
-                  <Row className={'justify-content-center'}>
-                    <NavLink
-                      id={'nav-link-examples'}
-                      active={isActive(router, 'examples')}
-                    >
-                      {t('nav.examplesPage.link', 'Exemples')}
-                    </NavLink>
-                  </Row>
-                </Col>
+                <NavLink
+                  id={'nav-link-examples'}
+                  active={isActive(router, 'examples')}
+                >
+                  {t('nav.examplesPage.link', 'Exemples')}
+                </NavLink>
               </Link>
             </NavItem>
 


### PR DESCRIPTION
See https://github.com/zeit/next.js/issues/10880

Links were broken because of some useless components between the <Link> component and the <a> element. Also, usage of passHref is required to avoid duplicating the url in both.