### PR TITLE
Replacing non-ascii chars to avoid Zeit's domain alias issues

### DIFF
--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -46,7 +46,7 @@ jobs:
           else
             ZEIT_DEPLOYMENT_ALIAS=$(cat now.json | jq -r '.name')-${CURRENT_BRANCH##*/}
           fi
-          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr "`(seq 0 47 ; seq 58 64 ; seq 91 94 ; seq 96 96 && seq 123 127) | awk '{printf("%c",$1)}'`" -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh") and replace each forbidden characters by '-' to avoid issues with zeit subdomains
+          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr "`(seq 0 47 ; seq 58 64 ; seq 91 96 && seq 123 127) | awk '{printf("%c",$1)}'`" -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh") and replace each forbidden characters by '-' to avoid issues with zeit subdomains
           echo "::set-env name=ZEIT_DEPLOYMENT_ALIAS::https://$ZEIT_DEPLOYMENT_ALIAS"
 
           npx now alias $ZEIT_DEPLOYMENT_URL https://$ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -46,7 +46,7 @@ jobs:
           else
             ZEIT_DEPLOYMENT_ALIAS=$(cat now.json | jq -r '.name')-${CURRENT_BRANCH##*/}
           fi
-          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh")
+          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr . -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh") and replace each '.' by '-' to avoid issues with zeit subdomains
           echo "::set-env name=ZEIT_DEPLOYMENT_ALIAS::https://$ZEIT_DEPLOYMENT_ALIAS"
 
           npx now alias $ZEIT_DEPLOYMENT_URL https://$ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -46,7 +46,7 @@ jobs:
           else
             ZEIT_DEPLOYMENT_ALIAS=$(cat now.json | jq -r '.name')-${CURRENT_BRANCH##*/}
           fi
-          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr "`(seq 0 47 ; seq 58 64 ; seq 91 96 && seq 123 127) | awk '{printf("%c",$1)}'`" -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh") and replace each forbidden characters by '-' to avoid issues with zeit subdomains
+          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr "`(seq 0 47 ; seq 58 64 ; seq 91 96 && seq 123 127) | awk '{printf("%c",$1)}'`" -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh"). In order to remove forbidden characters, we create a sequence from ascii numbers from range of number (so basically we forbid characters from `seq X Y` and we add others by using ';'). You can find this numbers equivalence by tapping `man ascii`. When we have a string with the ascii numbers, we use awk to translate them to characters.
           echo "::set-env name=ZEIT_DEPLOYMENT_ALIAS::https://$ZEIT_DEPLOYMENT_ALIAS"
 
           npx now alias $ZEIT_DEPLOYMENT_URL https://$ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -49,7 +49,8 @@ jobs:
           
           # Zeit alias only allows 53 characters in the domain name, so we only keep the first 46 characters (because Zeit needs 7 chars for ".now.sh" at the end of the domain name)
           # Also, in order to remove forbidden characters, we create a sequence from ascii numbers using ranges of numbers (we forbid characters by using `seq X Y` and we add others by using ';'). 
-          # All special characters are converted to `-`, and only 0-9 and a-Z chars are kept intact. We then use awk to translate them back into characters.
+          # All special characters are converted to `-` (using `tr $0 $1` where $0 is replaced by $1), and only 0-9 and a-Z chars are kept intact. 
+          # We then use `awk` to convert "ascii numbers" back into actual characters.
           # You can find the numbers equivalence by tapping `man ascii` and look at the "decimal" set. 
           ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr "`(seq 0 47 ; seq 58 64 ; seq 91 96 && seq 123 127) | awk '{printf("%c",$1)}'`" -).now.sh
           echo "::set-env name=ZEIT_DEPLOYMENT_ALIAS::https://$ZEIT_DEPLOYMENT_ALIAS"

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -46,7 +46,7 @@ jobs:
           else
             ZEIT_DEPLOYMENT_ALIAS=$(cat now.json | jq -r '.name')-${CURRENT_BRANCH##*/}
           fi
-          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr `(seq 0 47 ; seq 58 64 ; seq 91 94 ; seq 96 96 && seq 123 127) | awk '{printf("%c",$1)}'` -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh") and replace each forbidden characters by '-' to avoid issues with zeit subdomains
+          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr "`(seq 0 47 ; seq 58 64 ; seq 91 94 ; seq 96 96 && seq 123 127) | awk '{printf("%c",$1)}'`" -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh") and replace each forbidden characters by '-' to avoid issues with zeit subdomains
           echo "::set-env name=ZEIT_DEPLOYMENT_ALIAS::https://$ZEIT_DEPLOYMENT_ALIAS"
 
           npx now alias $ZEIT_DEPLOYMENT_URL https://$ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -46,7 +46,12 @@ jobs:
           else
             ZEIT_DEPLOYMENT_ALIAS=$(cat now.json | jq -r '.name')-${CURRENT_BRANCH##*/}
           fi
-          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr "`(seq 0 47 ; seq 58 64 ; seq 91 96 && seq 123 127) | awk '{printf("%c",$1)}'`" -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh"). In order to remove forbidden characters, we create a sequence from ascii numbers from range of number (so basically we forbid characters from `seq X Y` and we add others by using ';'). You can find this numbers equivalence by tapping `man ascii`. When we have a string with the ascii numbers, we use awk to translate them to characters.
+          
+          # Zeit alias only allows 53 characters in the domain name, so we only keep the first 46 characters (because Zeit needs 7 chars for ".now.sh" at the end of the domain name)
+          # Also, in order to remove forbidden characters, we create a sequence from ascii numbers using ranges of numbers (we forbid characters by using `seq X Y` and we add others by using ';'). 
+          # All special characters are converted to `-`, and only 0-9 and a-Z chars are kept intact. We then use awk to translate them back into characters.
+          # You can find the numbers equivalence by tapping `man ascii` and look at the "decimal" set. 
+          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr "`(seq 0 47 ; seq 58 64 ; seq 91 96 && seq 123 127) | awk '{printf("%c",$1)}'`" -).now.sh
           echo "::set-env name=ZEIT_DEPLOYMENT_ALIAS::https://$ZEIT_DEPLOYMENT_ALIAS"
 
           npx now alias $ZEIT_DEPLOYMENT_URL https://$ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -46,7 +46,7 @@ jobs:
           else
             ZEIT_DEPLOYMENT_ALIAS=$(cat now.json | jq -r '.name')-${CURRENT_BRANCH##*/}
           fi
-          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr ._ -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh") and replace each '.' by '-' to avoid issues with zeit subdomains
+          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr `(seq 0 47 ; seq 58 64 ; seq 91 94 ; seq 96 96 && seq 123 127) | awk '{printf("%c",$1)}'` -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh") and replace each forbidden characters by '-' to avoid issues with zeit subdomains
           echo "::set-env name=ZEIT_DEPLOYMENT_ALIAS::https://$ZEIT_DEPLOYMENT_ALIAS"
 
           npx now alias $ZEIT_DEPLOYMENT_URL https://$ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -46,7 +46,7 @@ jobs:
           else
             ZEIT_DEPLOYMENT_ALIAS=$(cat now.json | jq -r '.name')-${CURRENT_BRANCH##*/}
           fi
-          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr . -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh") and replace each '.' by '-' to avoid issues with zeit subdomains
+          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 46 | tr ._ -).now.sh # Zeit alias only allows 53 characters in the domain name, so we are the first 46 characters (because it'll need 7 other chars for ".now.sh") and replace each '.' by '-' to avoid issues with zeit subdomains
           echo "::set-env name=ZEIT_DEPLOYMENT_ALIAS::https://$ZEIT_DEPLOYMENT_ALIAS"
 
           npx now alias $ZEIT_DEPLOYMENT_URL https://$ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN


### PR DESCRIPTION
Replace non-ascii chars by `-` when building the zeit alias domain url.

Fix issues where using valid `.` or `_` chars in branch name would result in deployment alias failure