### PR TITLE
fix broken links to faq and contributing to avoid 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Next Right Now
 
 # FAQ
 
-[Go to our community FAQ](https://unlyed.github.io/next-right-now/FAQ).
+[Go to our community FAQ](https://unlyed.github.io/next-right-now/faq).
 
 ---
 
 # Contributing
 
-[Go to our contributing guide](https://unlyed.github.io/next-right-now/CONTRIBUTING).
+[Go to our contributing guide](https://unlyed.github.io/next-right-now/contributing).
 
 ---
 


### PR DESCRIPTION
### I changed the links to fix the 404 errors.
![image](https://user-images.githubusercontent.com/1839603/79014350-b4cde980-7b38-11ea-96dc-340ae5989647.png)

