### PR TITLE
Force Bearer prefix of GraphQL authorization

### DIFF
--- a/src/hoc/withUniversalGraphQLDataLoader.ts
+++ b/src/hoc/withUniversalGraphQLDataLoader.ts
@@ -14,7 +14,7 @@ const link = createHttpLink({
   // See the use of the "options" when running a graphQL query to specify options per-request at https://www.apollographql.com/docs/react/api/react-hooks/#options
   headers: {
     'gcms-locale-no-default': false,
-    'authorization': process.env.GRAPHQL_API_KEY,
+    'authorization': `Bearer ${process.env.GRAPHQL_API_KEY}`,
   },
   credentials: 'same-origin', // XXX See https://www.apollographql.com/docs/react/recipes/authentication#cookie
 });


### PR DESCRIPTION
When deployed in `eu-central-1`, GraphCMS returns an HTTP 400 if the `authorization` header is set without the `Bearer` prefix.

The sample application uses `api-euwest` which still accepts an authorization header set directly.

Fixes #40 
