### PR TITLE
Use deployment URL as a Github deployenvironment

### DIFF
--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
       - uses: chrnorm/deployment-action@releases/v1
-          name: Create GitHub deployment
+          name: "Create GitHub deployment for staging"
           id: deployment
           with:
             token: "${{ github.token }}"
@@ -77,7 +77,7 @@ jobs:
         uses: chrnorm/deployment-status@releases/v1
         with:
           token: "${{ github.token }}"
-          target_url: ${{ env.ZEIT_DEPLOYMENT_URL }}
+          target_url: "${{ env.ZEIT_DEPLOYMENT_URL }}"
           state: "success"
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
       - name: Update deployment status (failure)
@@ -85,7 +85,7 @@ jobs:
         uses: chrnorm/deployment-status@releases/v1
         with:
           token: "${{ github.token }}"
-          target_url: ${{ env.ZEIT_DEPLOYMENT_URL }}
+          target_url: "${{ env.ZEIT_DEPLOYMENT_URL }}"
           state: "failure"
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -35,7 +35,7 @@ jobs:
         id: deployment
         with:
           token: "${{ github.token }}"
-          target_url: http://test_url.net
+          target_urls: https://vercel.com/dashboard # Sadly, we don't know the deployment url at this time
           environment: staging
       - name: Deploying on Zeit
         # Workflow:
@@ -72,15 +72,15 @@ jobs:
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to worker
-      - name: Update deployment status (success)
+      - name: Update deployment status (success) # On success, it sets the good deployment url and the state as a success
         if: success()
-        uses: chrnorm/deployment-status@releases/v1
+        uses: chrnorm/deployment-status@releases/v1w
         with:
           token: "${{ github.token }}"
           target_url: "${{ env.ZEIT_DEPLOYMENT_URL }}"
           state: "success"
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-      - name: Update deployment status (failure)
+      - name: Update deployment status (failure) # On failure, it sets a deployment url and the state as a failure
         if: failure()
         uses: chrnorm/deployment-status@releases/v1
         with:

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -30,13 +30,6 @@ jobs:
     needs: setup-environment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
-      - uses: chrnorm/deployment-action@releases/v1
-        name: "Create GitHub deployment for staging"
-        id: deployment
-        with:
-          token: "${{ github.token }}"
-          target_urls: https://vercel.com/dashboard # Sadly, we don't know the deployment url at this time
-          environment: staging
       - name: Deploying on Zeit
         # Workflow:
         #   - Get stdout from deploy command (stderr shows build steps and stdout shows final url, what we are looking for)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -31,12 +31,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
       - uses: chrnorm/deployment-action@releases/v1
-          name: "Create GitHub deployment for staging"
-          id: deployment
-          with:
-            token: "${{ github.token }}"
-            target_url: http://test_url.net
-            environment: staging
+        name: "Create GitHub deployment for staging"
+        id: deployment
+        with:
+          token: "${{ github.token }}"
+          target_url: http://test_url.net
+          environment: staging
       - name: Deploying on Zeit
         # Workflow:
         #   - Get stdout from deploy command (stderr shows build steps and stdout shows final url, what we are looking for)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -30,6 +30,13 @@ jobs:
     needs: setup-environment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
+      - uses: chrnorm/deployment-action@releases/v1
+          name: Create GitHub deployment
+          id: deployment
+          with:
+            token: "${{ github.token }}"
+            target_url: http://test_url.net
+            environment: staging
       - name: Deploying on Zeit
         # Workflow:
         #   - Get stdout from deploy command (stderr shows build steps and stdout shows final url, what we are looking for)
@@ -65,6 +72,23 @@ jobs:
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to worker
+      - name: Update deployment status (success)
+        if: success()
+        uses: chrnorm/deployment-status@releases/v1
+        with:
+          token: "${{ github.token }}"
+          target_url: ${{ env.ZEIT_DEPLOYMENT_URL }}
+          state: "success"
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+      - name: Update deployment status (failure)
+        if: failure()
+        uses: chrnorm/deployment-status@releases/v1
+        with:
+          token: "${{ github.token }}"
+          target_url: ${{ env.ZEIT_DEPLOYMENT_URL }}
+          state: "failure"
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+
 
       # On deployment failure, add a comment to the PR
       - name: Comment PR (Deployment failure)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -30,6 +30,13 @@ jobs:
     needs: setup-environment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
+      - uses: chrnorm/deployment-action@releases/v1
+        name: "Create GitHub deployment for staging"
+        id: deployment
+        with:
+          token: "${{ github.token }}"
+          target_urls: https://vercel.com/dashboard # Sadly, we don't know the deployment url at this time
+          environment: staging
       - name: Deploying on Zeit
         # Workflow:
         #   - Get stdout from deploy command (stderr shows build steps and stdout shows final url, what we are looking for)
@@ -67,7 +74,7 @@ jobs:
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to worker
       - name: Update deployment status (success) # On success, it sets the good deployment url and the state as a success
         if: success()
-        uses: chrnorm/deployment-status@releases/v1w
+        uses: chrnorm/deployment-status@releases/v1
         with:
           token: "${{ github.token }}"
           target_url: "${{ env.ZEIT_DEPLOYMENT_URL }}"


### PR DESCRIPTION
Hello Captain!
Here is the most insane feature you've ever seen! It creates a Github deployment each time you push on a pull request.
Now that we have that kind of things, we could think about deleting the "comment on pr" because it's just spam.