### PR TITLE
Implement preview mode

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const i18nConfig = require('./src/i18nConfig');
 const supportedLocales = i18nConfig.supportedLocales.map((supportedLocale) => {
   return supportedLocale.name;
 });
-const noRedirectBlacklistedPaths = ['_next']; // Paths that mustn't have rewrite applied to them, to avoid the whole app to behave inconsistently
+const noRedirectBlacklistedPaths = ['_next', 'api']; // Paths that mustn't have rewrite applied to them, to avoid the whole app to behave inconsistently
 const publicBasePaths = ['robots', 'static', 'favicon.ico']; // All items (folders, files) under /public directory should be added there, to avoid redirection when an asset isn't found
 const noRedirectBasePaths = [...supportedLocales, ...publicBasePaths, ...noRedirectBlacklistedPaths]; // Will disable url rewrite for those items (should contain all supported languages and all public base paths)
 const withBundleAnalyzer = require('@next/bundle-analyzer')({ // Run with "yarn next:bundle" - See https://www.npmjs.com/package/@next/bundle-analyzer

--- a/src/components/pageLayouts/DefaultLayout.tsx
+++ b/src/components/pageLayouts/DefaultLayout.tsx
@@ -78,9 +78,10 @@ const DefaultLayout: React.FunctionComponent<Props> = (props): JSX.Element => {
       ></div>
 
       {
-        process.env.APP_STAGE !== 'production' && (
-          <PreviewModeBanner />
-        )
+        // XXX You may want to enable preview mode during non-production stages only
+        // process.env.APP_STAGE !== 'production' && (
+        <PreviewModeBanner />
+        // )
       }
 
       {

--- a/src/components/pageLayouts/DefaultLayout.tsx
+++ b/src/components/pageLayouts/DefaultLayout.tsx
@@ -8,10 +8,11 @@ import ErrorPage from '../../pages/_error';
 import { SoftPageProps } from '../../types/pageProps/SoftPageProps';
 import Sentry from '../../utils/monitoring/sentry';
 import DefaultErrorLayout from '../errors/DefaultErrorLayout';
+import DefaultPageContainer from './DefaultPageContainer';
 import Footer from './Footer';
 import Head, { HeadProps } from './Head';
 import Nav from './Nav';
-import DefaultPageContainer from './DefaultPageContainer';
+import PreviewModeBanner from './PreviewModeBanner';
 
 const fileLabel = 'components/pageLayouts/DefaultLayout';
 const logger = createLogger({
@@ -75,6 +76,12 @@ const DefaultLayout: React.FunctionComponent<Props> = (props): JSX.Element => {
         id="outdated"
         style={{ display: 'none' }}
       ></div>
+
+      {
+        process.env.APP_STAGE !== 'production' && (
+          <PreviewModeBanner />
+        )
+      }
 
       {
         !isInIframe && (

--- a/src/components/pageLayouts/PreviewModeBanner.tsx
+++ b/src/components/pageLayouts/PreviewModeBanner.tsx
@@ -1,0 +1,127 @@
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React from 'react';
+import Alert from 'reactstrap/lib/Alert';
+import usePreviewMode from '../../hooks/usePreviewMode';
+import ExternalLink from '../utils/ExternalLink';
+import Tooltip from '../utils/Tooltip';
+
+type Props = {}
+
+const stopPreviewMode = async (): Promise<void> => {
+  window.location.href = `/api/preview?stop=true&redirectTo=${window.location.pathname}`;
+};
+
+const startPreviewMode = async (): Promise<void> => {
+  window.location.href = `/api/preview?redirectTo=${window.location.pathname}`;
+};
+
+const ExplanationTooltipOverlay: React.FunctionComponent = (): JSX.Element => {
+  return (
+    <span>
+      When <b>preview mode</b> is enabled, SSG is by-passed and all pages behave as if they were using SSR.<br />
+      It's a great feature when you want to preview content on staging without having to rebuild your whole application.<br />
+      <ExternalLink href={'https://nextjs.org/docs/advanced-features/preview-mode'}>Learn more</ExternalLink><br />
+      <br />
+      Disabling <b>preview mode</b> will make SSG pages go back to their normal behaviour.<br />
+    </span>
+  );
+};
+
+/**
+ * Displays the banner that warns about whether preview mode is enabled or disabled
+ *
+ * Display a link to enable/disable it
+ *
+ * @param props
+ */
+const PreviewModeBanner: React.FunctionComponent<Props> = (props): JSX.Element => {
+  const { preview } = usePreviewMode();
+
+  return (
+    <Alert
+      color={'warning'}
+      css={css`
+        display: flex;
+        position: relative;
+        flex-direction: row;
+        justify-content: center;
+        text-align: center;
+
+        @media (max-width: 991.98px) {
+          flex-direction: column;
+
+          .right {
+            display: block;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .right {
+            position: absolute;
+            right: 20px;
+          }
+        }
+      `}
+    >
+      {
+        preview ? (
+          <div>
+            <span>
+              Preview mode is enabled&nbsp;
+              <Tooltip
+                overlay={<ExplanationTooltipOverlay />}
+                placement={'bottom'}
+              >
+                <FontAwesomeIcon icon={['fas', 'question']} size={'xs'} />
+              </Tooltip>
+            </span>
+            <span className={'right'}>
+              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+              <a
+                role={'button'}
+                tabIndex={0}
+                onClick={stopPreviewMode}
+                onKeyPress={stopPreviewMode}
+              >
+                Leave preview mode&nbsp;
+                <Tooltip
+                  overlay={<span>This is a tooltip</span>}
+                  placement={'bottom'}
+                >
+                  <FontAwesomeIcon icon={['fas', 'question']} size={'xs'} />
+                </Tooltip>
+              </a>
+            </span>
+          </div>
+        ) : (
+          <div>
+            <span>
+              Preview mode is disabled&nbsp;
+              <Tooltip
+                overlay={<ExplanationTooltipOverlay />}
+                placement={'bottom'}
+              >
+                <FontAwesomeIcon icon={['fas', 'question']} />
+              </Tooltip>
+            </span>
+            <span className={'right'}>
+              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+              <a
+                role={'button'}
+                tabIndex={0}
+                onClick={startPreviewMode}
+                onKeyPress={startPreviewMode}
+              >
+                Start preview mode
+              </a>
+            </span>
+          </div>
+        )
+      }
+    </Alert>
+  );
+};
+
+export default PreviewModeBanner;

--- a/src/components/pageLayouts/PreviewModeBanner.tsx
+++ b/src/components/pageLayouts/PreviewModeBanner.tsx
@@ -25,6 +25,9 @@ const ExplanationTooltipOverlay: React.FunctionComponent = (): JSX.Element => {
       <ExternalLink href={'https://nextjs.org/docs/advanced-features/preview-mode'}>Learn more</ExternalLink><br />
       <br />
       Disabling <b>preview mode</b> will make SSG pages go back to their normal behaviour.<br />
+      <br />
+      <i><b>Tip</b>: Make sure to hard refresh the page (<code>cmd+shift+r</code> on MacOs) after enabling it, to refresh the browser cache.</i><br />
+      <i><b>Tip</b>: We enabled <b>preview mode</b> on the <code>production</code> stage for showcase purpose</i><br />
     </span>
   );
 };
@@ -63,6 +66,10 @@ const PreviewModeBanner: React.FunctionComponent<Props> = (props): JSX.Element =
             right: 20px;
           }
         }
+
+        [class*="fa-"] {
+          margin-bottom: 1px
+        }
       `}
     >
       {
@@ -74,7 +81,7 @@ const PreviewModeBanner: React.FunctionComponent<Props> = (props): JSX.Element =
                 overlay={<ExplanationTooltipOverlay />}
                 placement={'bottom'}
               >
-                <FontAwesomeIcon icon={['fas', 'question']} size={'xs'} />
+                <FontAwesomeIcon icon={['fas', 'question-circle']} size={'xs'} />
               </Tooltip>
             </span>
             <span className={'right'}>
@@ -85,13 +92,7 @@ const PreviewModeBanner: React.FunctionComponent<Props> = (props): JSX.Element =
                 onClick={stopPreviewMode}
                 onKeyPress={stopPreviewMode}
               >
-                Leave preview mode&nbsp;
-                <Tooltip
-                  overlay={<span>This is a tooltip</span>}
-                  placement={'bottom'}
-                >
-                  <FontAwesomeIcon icon={['fas', 'question']} size={'xs'} />
-                </Tooltip>
+                Leave preview mode
               </a>
             </span>
           </div>
@@ -103,7 +104,7 @@ const PreviewModeBanner: React.FunctionComponent<Props> = (props): JSX.Element =
                 overlay={<ExplanationTooltipOverlay />}
                 placement={'bottom'}
               >
-                <FontAwesomeIcon icon={['fas', 'question']} />
+                <FontAwesomeIcon icon={['fas', 'question-circle']} size={'xs'} />
               </Tooltip>
             </span>
             <span className={'right'}>

--- a/src/hooks/usePreviewMode.tsx
+++ b/src/hooks/usePreviewMode.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import previewModeContext, { PreviewModeContext } from '../stores/previewModeContext';
+
+export type PreviewMode = PreviewModeContext
+
+/**
+ * Hook to access Next.js preview mode data
+ *
+ * Uses previewModeContext internally (provides an identical API)
+ *
+ * This hook should be used by components in favor of previewModeContext directly,
+ * because it grants higher flexibility if you ever need to change the implementation (e.g: use something else than React.Context, like Redux/MobX)
+ *
+ * @see https://nextjs.org/docs/advanced-features/preview-mode
+ */
+const usePreviewMode = (): PreviewModeContext => {
+  return React.useContext(previewModeContext);
+};
+
+export default usePreviewMode;

--- a/src/pages/[locale]/examples/native-features/example-with-ssg-and-fallback/[albumId].tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg-and-fallback/[albumId].tsx
@@ -68,7 +68,7 @@ export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async 
   const awaitForMs = getRandomInt(1000, 4000);
   await waitFor(awaitForMs);
 
-  let songId = parseInt(albumId);
+  let songId = parseInt(albumId, 10);
 
   if (songId > songs.length - 1) { // Handle overflow
     songId = 0;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,7 +2,7 @@ import { config, library } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { faTimesCircle } from '@fortawesome/free-regular-svg-icons';
-import { faArrowCircleLeft, faArrowCircleRight, faBook, faBookReader, faCoffee, faHome, faQuestion, faUserCog } from '@fortawesome/free-solid-svg-icons';
+import { faArrowCircleLeft, faArrowCircleRight, faBook, faBookReader, faCoffee, faHome, faQuestionCircle, faUserCog } from '@fortawesome/free-solid-svg-icons';
 import 'animate.css/animate.min.css'; // Loads animate.css CSS file. See https://github.com/daneden/animate.css
 import 'bootstrap/dist/css/bootstrap.min.css'; // Loads bootstrap CSS file. See https://stackoverflow.com/a/50002905/2391795
 import 'rc-tooltip/assets/bootstrap.css';
@@ -22,7 +22,7 @@ import '../utils/monitoring/sentry';
 config.autoAddCss = false; // Tell Font Awesome to skip adding the CSS automatically since it's being imported above
 library.add(
   faGithub,
-  faArrowCircleLeft, faArrowCircleRight, faBook, faBookReader, faCoffee, faHome, faQuestion, faUserCog,
+  faArrowCircleLeft, faArrowCircleRight, faBook, faBookReader, faCoffee, faHome, faQuestionCircle, faUserCog,
   faTimesCircle,
 );
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,7 +2,7 @@ import { config, library } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { faTimesCircle } from '@fortawesome/free-regular-svg-icons';
-import { faArrowCircleLeft, faArrowCircleRight, faBook, faBookReader, faCoffee, faHome, faUserCog } from '@fortawesome/free-solid-svg-icons';
+import { faArrowCircleLeft, faArrowCircleRight, faBook, faBookReader, faCoffee, faHome, faQuestion, faUserCog } from '@fortawesome/free-solid-svg-icons';
 import 'animate.css/animate.min.css'; // Loads animate.css CSS file. See https://github.com/daneden/animate.css
 import 'bootstrap/dist/css/bootstrap.min.css'; // Loads bootstrap CSS file. See https://stackoverflow.com/a/50002905/2391795
 import 'rc-tooltip/assets/bootstrap.css';
@@ -22,7 +22,7 @@ import '../utils/monitoring/sentry';
 config.autoAddCss = false; // Tell Font Awesome to skip adding the CSS automatically since it's being imported above
 library.add(
   faGithub,
-  faArrowCircleLeft, faArrowCircleRight, faBook, faBookReader, faCoffee, faHome, faUserCog,
+  faArrowCircleLeft, faArrowCircleRight, faBook, faBookReader, faCoffee, faHome, faQuestion, faUserCog,
   faTimesCircle,
 );
 

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -1,0 +1,40 @@
+import { NowRequest, NowResponse } from '@now/node';
+import { createLogger } from '@unly/utils-simple-logger';
+
+import Sentry, { configureReq } from '../../utils/monitoring/sentry';
+
+const fileLabel = 'api/preview';
+const logger = createLogger({
+  label: fileLabel,
+});
+
+export const error = async (req: NowRequest, res: NowResponse & { setPreviewData: (any) => void }): Promise<void> => {
+  try {
+    configureReq(req);
+
+    if (process.env.APP_STAGE !== 'production') {
+      res.setPreviewData({});
+
+      console.log('Preview mode enabled'); // eslint-disable-line no-console
+    } else {
+      console.error('Preview mode is not allowed in production'); // eslint-disable-line no-console
+    }
+
+    res.writeHead(307, { Location: '/' });
+    res.end();
+  } catch (e) {
+    logger.error(e.message);
+
+    Sentry.withScope((scope): void => {
+      scope.setTag('fileLabel', fileLabel);
+      Sentry.captureException(e);
+    });
+
+    res.json({
+      error: true,
+      message: process.env.APP_STAGE === 'production' ? undefined : e.message,
+    });
+  }
+};
+
+export default error;

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -44,20 +44,21 @@ export const preview = async (req: NowRequest, res: NowResponse & NextPreview): 
     }: PreviewModeAPIQuery = req.query as NowRequestQuery & PreviewModeAPIQuery;
     const safeRedirectUrl = filterExternalAbsoluteUrl(redirectTo as string);
 
-    if (process.env.APP_STAGE !== 'production') {
-      if (stop === 'true') {
-        res.clearPreviewData();
+    // XXX You may want to enable preview mode during non-production stages only
+    // if (process.env.APP_STAGE !== 'production') {
+    if (stop === 'true') {
+      res.clearPreviewData();
 
-        logger.info('Preview mode stopped');
-      } else {
-        res.setPreviewData({});
-
-        logger.info('Preview mode enabled');
-      }
+      logger.info('Preview mode stopped');
     } else {
-      logger.error('Preview mode is not allowed in production');
-      Sentry.captureMessage('Preview mode is not allowed in production', Sentry.Severity.Warning);
+      res.setPreviewData({});
+
+      logger.info('Preview mode enabled');
     }
+    // } else {
+    //   logger.error('Preview mode is not allowed in production');
+    //   Sentry.captureMessage('Preview mode is not allowed in production', Sentry.Severity.Warning);
+    // }
 
     res.writeHead(307, { Location: safeRedirectUrl });
     res.end();

--- a/src/stores/previewModeContext.tsx
+++ b/src/stores/previewModeContext.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { PreviewData } from '../types/nextjs/PreviewData';
+
+export type PreviewModeContext = {
+  preview: boolean;
+  previewData: PreviewData;
+}
+
+/**
+ * Uses native React Context API
+ *
+ * @example Usage
+ *  import previewModeContext from './src/stores/previewModeContext';
+ *  const { preview, previewData }: PreviewModeContext = React.useContext(previewModeContext);
+ *
+ * @see https://reactjs.org/docs/context.html
+ * @see https://medium.com/better-programming/react-hooks-usecontext-30eb560999f for useContext hook example (open in anonymous browser #paywall)
+ */
+export const previewModeContext = React.createContext<PreviewModeContext>(null);
+
+export default previewModeContext;

--- a/src/types/nextjs/PreviewData.ts
+++ b/src/types/nextjs/PreviewData.ts
@@ -1,0 +1,10 @@
+/**
+ * Preview data type, set when preview mode is enabled
+ * XXX Currently "unused", doesn't store any data
+ *
+ * Set to "undefined" when preview mode is disabled (by Next.js)
+ * We override any falsy value to "null" to avoid a serialisation issue ("undefined" cannot be serialised)
+ *
+ * @see https://nextjs.org/docs/advanced-features/preview-mode#step-2-update-getstaticprops
+ */
+export type PreviewData = null | {};

--- a/src/types/nextjs/StaticPropsInput.ts
+++ b/src/types/nextjs/StaticPropsInput.ts
@@ -1,10 +1,11 @@
 import { StaticParams } from './StaticParams';
+import { PreviewData } from './PreviewData';
 
 /**
  * Static props given as inputs for getStaticProps
  */
 export type StaticPropsInput = {
   params?: StaticParams;
-  preview?: boolean;
-  previewData?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  preview: boolean;
+  previewData: PreviewData;
 }

--- a/src/types/pageProps/SSGPageProps.ts
+++ b/src/types/pageProps/SSGPageProps.ts
@@ -1,4 +1,5 @@
 import { MultiversalAppBootstrapPageProps } from '../nextjs/MultiversalAppBootstrapPageProps';
+import { PreviewData } from '../nextjs/PreviewData';
 import { MultiversalPageProps } from './MultiversalPageProps';
 
 /**
@@ -14,6 +15,8 @@ import { MultiversalPageProps } from './MultiversalPageProps';
 export type SSGPageProps<E extends {} = {}> = {
   // Props that are specific to SSG
   isStaticRendering: boolean;
+  preview: boolean;
+  previewData: PreviewData;
 } & MultiversalPageProps // Generic props that are provided immediately, no matter what
   & Partial<MultiversalAppBootstrapPageProps> // Pages served by SSG eventually benefit from props injected by the MultiversalAppBootstrap component
   & E;

--- a/src/utils/js/url.test.ts
+++ b/src/utils/js/url.test.ts
@@ -1,4 +1,4 @@
-import { decodeQueryParameter, encodeQueryParameter } from './url';
+import { decodeQueryParameter, encodeQueryParameter, filterExternalAbsoluteUrl } from './url';
 
 export const data = {
   'organisation': {
@@ -47,6 +47,24 @@ describe(`utils/url.ts`, () => {
 
       const _decodedDataAgain: object = decodeQueryParameter(_encodedData);
       expect(_decodedDataAgain).toEqual(data);
+    });
+  });
+
+  describe(`filterExternalAbsoluteUrl`, () => {
+    test(`should not allow external absolute urls (use default fallback)`, async () => {
+      expect(filterExternalAbsoluteUrl('')).toEqual('/');
+      expect(filterExternalAbsoluteUrl('https://google.com')).toEqual('/');
+      expect(filterExternalAbsoluteUrl('http://google.com')).toEqual('/');
+      expect(filterExternalAbsoluteUrl('//google.com')).toEqual('/');
+    });
+
+    test(`should fallback to given fallback value when provided`, async () => {
+      expect(filterExternalAbsoluteUrl('', '/test')).toEqual('/test');
+    });
+
+    test(`should allow internal relative urls`, async () => {
+      expect(filterExternalAbsoluteUrl('/google.com')).toEqual('/google.com');
+      expect(filterExternalAbsoluteUrl('/google.com?test')).toEqual('/google.com?test');
     });
   });
 });

--- a/src/utils/js/url.ts
+++ b/src/utils/js/url.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node';
 import StringifySafe from 'json-stringify-safe';
+import startsWith from 'lodash.startswith';
 
 /**
  * Converts a JSON object into a string that is url-friendly
@@ -33,5 +34,28 @@ export const decodeQueryParameter = (query: string): object => {
 
     // Return an empty object, we consider there was no data
     return {};
+  }
+};
+
+/**
+ * Meant to be used to avoid redirecting to external websites
+ * This is a security control to avoid external attackers using our own internal redirects for their own purposes (avoid make believe the redirection is legit)
+ *
+ * If the url is an external url, then use the fallback value
+ * A url is considered external and absolute if it starts with "//", or if it doesn't start with "/"
+ *
+ * @example filterExternalAbsoluteUrl('https://google.com') => /
+ * @example filterExternalAbsoluteUrl('http://google.com') => /
+ * @example filterExternalAbsoluteUrl('//google.com') => /
+ * @example filterExternalAbsoluteUrl('/google.com') => /google.com
+ *
+ * @param url
+ * @param fallbackValue
+ */
+export const filterExternalAbsoluteUrl = (url: string, fallbackValue = '/'): string => {
+  if (typeof url !== 'string' || startsWith(url, '//') || !startsWith(url, '/')) {
+    return fallbackValue;
+  } else {
+    return url;
   }
 };

--- a/src/utils/nextjs/SSG.ts
+++ b/src/utils/nextjs/SSG.ts
@@ -6,12 +6,13 @@ import { LAYOUT_QUERY } from '../../gql/common/layoutQuery';
 import { supportedLocales } from '../../i18nConfig';
 import { Customer } from '../../types/data/Customer';
 import { I18nLocale } from '../../types/i18n/I18nLocale';
+import { PreviewData } from '../../types/nextjs/PreviewData';
 import { StaticParams } from '../../types/nextjs/StaticParams';
 import { StaticPath } from '../../types/nextjs/StaticPath';
 import { StaticPathsOutput } from '../../types/nextjs/StaticPathsOutput';
-import { SSGPageProps } from '../../types/pageProps/SSGPageProps';
 import { StaticPropsInput } from '../../types/nextjs/StaticPropsInput';
 import { StaticPropsOutput } from '../../types/nextjs/StaticPropsOutput';
+import { SSGPageProps } from '../../types/pageProps/SSGPageProps';
 import { prepareGraphCMSLocaleHeader } from '../gql/graphcms';
 import { createApolloClient } from '../gql/graphql';
 import { DEFAULT_LOCALE, resolveFallbackLanguage } from '../i18n/i18n';
@@ -35,6 +36,8 @@ import { fetchTranslations, I18nextResources } from '../i18n/i18nextLocize';
  */
 export const getCommonStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {
   const customerRef: string = process.env.CUSTOMER_REF;
+  const preview: boolean = props?.preview || false;
+  const previewData: PreviewData = props?.previewData || null;
   const hasLocaleFromUrl = !!props?.params?.locale;
   const locale: string = hasLocaleFromUrl ? props?.params?.locale : DEFAULT_LOCALE; // If the locale isn't found (e.g: 404 page)
   const lang: string = locale.split('-')?.[0];
@@ -89,6 +92,8 @@ export const getCommonStaticProps: GetStaticProps<SSGPageProps, StaticParams> = 
       isStaticRendering: true,
       lang,
       locale,
+      preview,
+      previewData,
     },
     // unstable_revalidate: false,
   };

--- a/src/utils/nextjs/previewMode.ts
+++ b/src/utils/nextjs/previewMode.ts
@@ -1,7 +1,0 @@
-import { isBrowser } from '@unly/utils';
-
-export const isPreviewModeEnabled = (): boolean => {
-  if (isBrowser()) {
-    return false;
-  }
-};

--- a/src/utils/nextjs/previewMode.ts
+++ b/src/utils/nextjs/previewMode.ts
@@ -1,0 +1,7 @@
+import { isBrowser } from '@unly/utils';
+
+export const isPreviewModeEnabled = (): boolean => {
+  if (isBrowser()) {
+    return false;
+  }
+};


### PR DESCRIPTION
Allow end-user to toggle preview mode in ~~staging~~ all environment, so that content gets updated immediately while preview mode is enabled. (bypass static pages)

Initially thought I'd only enable it in staging, but then it won't be showcased on the NRN official demos (which run under production stage), so I eventually decided to enable it on all stages. (but real use-cases will most likely want to limit this to development/staging)