### PR TITLE
Fix wrong API typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "9.4.1",
-    "@now/node": "1.6.1",
     "@svgr/cli": "5.4.0",
     "@types/amplitude-js": "5.11.0",
     "@types/cookies": "0.7.4",

--- a/src/middlewares/localeMiddleware.ts
+++ b/src/middlewares/localeMiddleware.ts
@@ -1,7 +1,8 @@
 import { createLogger } from '@unly/utils-simple-logger';
+import { NextApiRequest, NextApiResponse } from 'next';
 import { supportedLocales } from '../i18nConfig';
-import { acceptLanguageHeaderLookup, DEFAULT_LOCALE } from '../utils/i18n/i18n';
 import redirect from '../utils/app/redirect';
+import { acceptLanguageHeaderLookup, DEFAULT_LOCALE } from '../utils/i18n/i18n';
 
 const fileLabel = 'utils/localeMiddleware';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -18,7 +19,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * @param req
  * @param res
  */
-export const localeMiddleware = (req, res): void => {
+export const localeMiddleware = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   logger.debug('Detecting browser locale...');
   const detections: string[] = acceptLanguageHeaderLookup(req) || [];
   let localeFound; // Will contain the most preferred browser locale (e.g: fr-FR, fr, en-US, en, etc.)

--- a/src/pages/api/autoRedirectToLocalisedPage.ts
+++ b/src/pages/api/autoRedirectToLocalisedPage.ts
@@ -1,4 +1,5 @@
+import { NextApiRequest, NextApiResponse } from 'next';
 import localeMiddleware from '../../middlewares/localeMiddleware';
 
-export default (req, res): void => localeMiddleware(req, res);
+export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => localeMiddleware(req, res);
 

--- a/src/pages/api/error.test.ts
+++ b/src/pages/api/error.test.ts
@@ -1,4 +1,4 @@
-import { NowRequest, NowResponse } from '@now/node/dist';
+import { NextApiRequest, NextApiResponse } from 'next';
 
 import { mockRequest, mockResponse } from '../../utils/testing/tests-mocks';
 import error from './error';
@@ -15,8 +15,8 @@ describe('error', () => {
   });
 
   test('should return expected variables', async () => {
-    const req: NowRequest = mockRequest({}, {});
-    const res: NowResponse = mockResponse();
+    const req: NextApiRequest = mockRequest({}, {});
+    const res: NextApiResponse = mockResponse();
     await error(req, res);
 
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ // https://stackoverflow.com/a/55569458/2391795

--- a/src/pages/api/error.ts
+++ b/src/pages/api/error.ts
@@ -1,5 +1,5 @@
-import { NowRequest, NowResponse } from '@now/node';
 import { createLogger } from '@unly/utils-simple-logger';
+import { NextApiRequest, NextApiResponse } from 'next';
 
 import Sentry, { configureReq } from '../../utils/monitoring/sentry';
 
@@ -8,7 +8,7 @@ const logger = createLogger({
   label: fileLabel,
 });
 
-export const error = async (req: NowRequest, res: NowResponse): Promise<void> => {
+export const error = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   try {
     configureReq(req);
 

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -1,22 +1,14 @@
-import { NowRequest, NowRequestQuery, NowResponse } from '@now/node';
 import { createLogger } from '@unly/utils-simple-logger';
+import { NextApiRequest, NextApiResponse } from 'next';
+
 import { PreviewData } from '../../types/nextjs/PreviewData';
 import { filterExternalAbsoluteUrl } from '../../utils/js/url';
-
 import Sentry, { configureReq } from '../../utils/monitoring/sentry';
 
 const fileLabel = 'api/preview';
 const logger = createLogger({
   label: fileLabel,
 });
-
-/**
- * Those types should be part of @now/node but aren't yet.
- */
-type NextPreview = {
-  clearPreviewData: () => void;
-  setPreviewData: (previewData: PreviewData) => void;
-}
 
 type PreviewModeAPIQuery = {
   stop: string;
@@ -34,14 +26,14 @@ type PreviewModeAPIQuery = {
  * @see https://nextjs.org/docs/advanced-features/preview-mode#step-1-create-and-access-a-preview-api-route
  * @see https://nextjs.org/docs/advanced-features/preview-mode#clear-the-preview-mode-cookies
  */
-export const preview = async (req: NowRequest, res: NowResponse & NextPreview): Promise<void> => {
+export const preview = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   try {
     configureReq(req);
 
     const {
       stop = 'false',
       redirectTo = '/',
-    }: PreviewModeAPIQuery = req.query as NowRequestQuery & PreviewModeAPIQuery;
+    }: PreviewModeAPIQuery = req.query as PreviewModeAPIQuery;
     const safeRedirectUrl = filterExternalAbsoluteUrl(redirectTo as string);
 
     // XXX You may want to enable preview mode during non-production stages only

--- a/src/pages/api/status.test.ts
+++ b/src/pages/api/status.test.ts
@@ -1,4 +1,4 @@
-import { NowRequest, NowResponse } from '@now/node/dist';
+import { NextApiRequest, NextApiResponse } from 'next';
 
 import { mockRequest, mockResponse } from '../../utils/testing/tests-mocks';
 import status from './status';
@@ -9,8 +9,8 @@ describe('status', () => {
   });
 
   test('should return expected variables', async () => {
-    const req: NowRequest = mockRequest({}, { param1: 'test-sentry-reporting-context' });
-    const res: NowResponse = mockResponse();
+    const req: NextApiRequest = mockRequest({}, { param1: 'test-sentry-reporting-context' });
+    const res: NextApiResponse = mockResponse();
     await status(req, res);
 
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ // https://stackoverflow.com/a/55569458/2391795

--- a/src/pages/api/status.ts
+++ b/src/pages/api/status.ts
@@ -1,5 +1,5 @@
-import { NowRequest, NowResponse } from '@now/node';
 import { createLogger } from '@unly/utils-simple-logger';
+import { NextApiRequest, NextApiResponse } from 'next';
 
 import Sentry, { configureReq } from '../../utils/monitoring/sentry';
 
@@ -8,7 +8,7 @@ const logger = createLogger({
   label: fileLabel,
 });
 
-export const status = async (req: NowRequest, res: NowResponse): Promise<void> => {
+export const status = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   try {
     configureReq(req);
 

--- a/src/utils/monitoring/sentry.ts
+++ b/src/utils/monitoring/sentry.ts
@@ -1,7 +1,7 @@
-import { NowRequest } from '@now/node/dist';
 import * as Sentry from '@sentry/node';
 import { isBrowser } from '@unly/utils';
 import get from 'lodash.get';
+import { NextApiRequest } from 'next';
 
 // Don't initialise Sentry if SENTRY_DSN isn't defined (won't crash the app, usage of the Sentry lib is resilient to this and doesn't cause any issue)
 if (process.env.SENTRY_DSN) {
@@ -39,7 +39,7 @@ if (process.env.SENTRY_DSN) {
  *
  * @param req
  */
-export const configureReq = (req: NowRequest): void => {
+export const configureReq = (req: NextApiRequest): void => {
   Sentry.configureScope((scope) => {
     scope.setTag('host', get(req, 'headers.host'));
     scope.setTag('url', get(req, 'url'));

--- a/src/utils/testing/tests-mocks.ts
+++ b/src/utils/testing/tests-mocks.ts
@@ -1,13 +1,12 @@
-import { NowRequest, NowResponse } from '@now/node';
+import { NextApiRequest, NextApiResponse } from 'next';
 
-export const mockRequest = (sessionData, body): NowRequest => ({
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+export const mockRequest = (sessionData, body): NextApiRequest => ({
   // @ts-expect-error
   session: { data: sessionData },
   body,
 });
 
-export const mockResponse = (): NowResponse => {
+export const mockResponse = (): NextApiResponse => {
   const res: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
   res.status = jest.fn().mockReturnValue(res);
   res.json = jest.fn().mockReturnValue(res);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1651,13 +1651,6 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@now/node@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@now/node/-/node-1.6.1.tgz#d478bfbc98af05d3eae7b5b01b26d1a1c638819b"
-  integrity sha512-EdSdOS4HSJRexibxIbrKCLZZ1sc0+oaD0P7kvhf26CbXSNlrZP0Iycpb+fbO4Qc2EcmGR2am90DhoX548B5a7g==
-  dependencies:
-    "@types/node" "*"
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
Remove @now/node devDep and use types from Next.js instead (replace NowRequest/NowResponse types by NextApiRequest/NextApiResponse)