### PR TITLE
Optimisations

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
     // XXX we must specify a custom tsconfig for tests because we need the typescript transform
     //  to transform jsx into js rather than leaving it jsx such as the next build requires.  you
     //  can see this setting in tsconfig.jest.json -> "jsx": "react"
-    //  See https://github.com/zeit/next.js/issues/8663
+    //  See https://github.com/vercel/next.js/issues/8663
     'ts-jest': {
       tsConfig: 'tsconfig.jest.json',
     },

--- a/next.config.js
+++ b/next.config.js
@@ -20,7 +20,7 @@ module.exports = withBundleAnalyzer(withSourceMaps({
     // XXX All env variables defined in ".env*" files that aren't public (don't start with "NEXT_PUBLIC_") must manually be made available at build time below
     //  See https://nextjs.org/docs/api-reference/next.config.js/environment-variables
     // XXX Duplication of the environment variables, this is only used locally
-    //  while now.json:build:env will be used on the Now platform (See https://zeit.co/docs/v2/build-step/#providing-environment-variables)
+    //  while now.json:build:env will be used on the Now platform (See https://vercel.com/docs/v2/build-step/#providing-environment-variables)
     GRAPHQL_API_ENDPOINT: process.env.GRAPHQL_API_ENDPOINT,
     GRAPHQL_API_KEY: process.env.GRAPHQL_API_KEY,
     LOCIZE_API_KEY: process.env.LOCIZE_API_KEY,
@@ -37,13 +37,13 @@ module.exports = withBundleAnalyzer(withSourceMaps({
     redirects() {
       const redirects = [
         {
-          // Redirect root link with trailing slash to non-trailing slash, avoids 404 - See https://github.com/zeit/next.js/discussions/10651#discussioncomment-8270
+          // Redirect root link with trailing slash to non-trailing slash, avoids 404 - See https://github.com/vercel/next.js/discussions/10651#discussioncomment-8270
           source: '/:locale/',
           destination: '/:locale',
           permanent: process.env.NEXT_PUBLIC_APP_STAGE !== 'development', // Do not use permanent redirect locally to avoid browser caching when working on it
         },
         {
-          // Redirect link with trailing slash to non-trailing slash (any depth), avoids 404 - See https://github.com/zeit/next.js/discussions/10651#discussioncomment-8270
+          // Redirect link with trailing slash to non-trailing slash (any depth), avoids 404 - See https://github.com/vercel/next.js/discussions/10651#discussioncomment-8270
           source: '/:locale/:path*/',
           destination: '/:locale/:path*',
           permanent: process.env.NEXT_PUBLIC_APP_STAGE !== 'development', // Do not use permanent redirect locally to avoid browser caching when working on it
@@ -95,7 +95,7 @@ module.exports = withBundleAnalyzer(withSourceMaps({
       fs: 'empty',
     };
 
-    // XXX See https://github.com/zeit/next.js/blob/canary/examples/with-sentry-simple/next.config.js
+    // XXX See https://github.com/vercel/next.js/blob/canary/examples/with-sentry-simple/next.config.js
     // In `pages/_app.js`, Sentry is imported from @sentry/node. While
     // @sentry/browser will run in a Node.js environment, @sentry/node will use
     // Node.js-only APIs to catch even more unhandled exceptions.

--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,7 @@ const supportedLocales = i18nConfig.supportedLocales.map((supportedLocale) => {
 const noRedirectBlacklistedPaths = ['_next', 'api']; // Paths that mustn't have rewrite applied to them, to avoid the whole app to behave inconsistently
 const publicBasePaths = ['robots', 'static', 'favicon.ico']; // All items (folders, files) under /public directory should be added there, to avoid redirection when an asset isn't found
 const noRedirectBasePaths = [...supportedLocales, ...publicBasePaths, ...noRedirectBlacklistedPaths]; // Will disable url rewrite for those items (should contain all supported languages and all public base paths)
-const withBundleAnalyzer = require('@next/bundle-analyzer')({ // Run with "yarn next:bundle" - See https://www.npmjs.com/package/@next/bundle-analyzer
+const withBundleAnalyzer = require('@next/bundle-analyzer')({ // Run with "yarn analyse:bundle" - See https://www.npmjs.com/package/@next/bundle-analyzer
   enabled: process.env.ANALYZE_BUNDLE === 'true',
 })
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "next dev --port 8888",
     "build": "yarn test:once && next build",
-    "next:bundle": "ANALYZE_BUNDLE=true yarn start",
+    "analyse:bundle": "ANALYZE_BUNDLE=true yarn start",
     "svg": "npx svgr -d src/svg src/svg --ext tsx --template src/utils/svg/svgTemplate.ts",
     "deploy": "yarn deploy:customer1",
     "deploy:all": "yarn deploy:customer1 && yarn deploy:customer2",

--- a/public/static/fonts/NeuzeitGrotesk/font.css
+++ b/public/static/fonts/NeuzeitGrotesk/font.css
@@ -7,6 +7,7 @@
   url('NeuzeitGrotesk-light.ttf') format('truetype');
   font-style: normal;
   font-weight: 200;
+  font-display: swap; /* Perf optimization - See https://web.dev/font-display */
 }
 
 @font-face {
@@ -18,6 +19,7 @@
   url('NeuzeitGrotesk-regular.ttf') format('truetype');
   font-style: normal;
   font-weight: 900;
+  font-display: swap; /* Perf optimization - See https://web.dev/font-display */
 }
 
 @font-face {
@@ -29,6 +31,7 @@
   url('NeuzeitGrotesk-bold.ttf') format('truetype');
   font-style: normal;
   font-weight: 400;
+  font-display: swap; /* Perf optimization - See https://web.dev/font-display */
 }
 
 @font-face {
@@ -40,4 +43,5 @@
   url('NeuzeitGrotesk-black.ttf') format('truetype');
   font-style: normal;
   font-weight: 700;
+  font-display: swap; /* Perf optimization - See https://web.dev/font-display */
 }

--- a/public/static/fonts/NeuzeitGrotesk/font.css
+++ b/public/static/fonts/NeuzeitGrotesk/font.css
@@ -1,10 +1,13 @@
+/**
+ * TL;DR Only use WOFF/WOFF2 format, never use TTF or OTF
+ *
+ * @see https://stackoverflow.com/questions/11002820/why-should-we-include-ttf-eot-woff-svg-in-a-font-face
+ * @see https://stackoverflow.com/questions/36105194/are-eot-ttf-and-svg-still-necessary-in-the-font-face-declaration/36110385#36110385
+ **/
+
 @font-face {
   font-family: 'neuzeit-grotesk';
-  src: url('NeuzeitGrotesk-light.eot');
-  src: url('NeuzeitGrotesk-light.eot?#iefix') format('embedded-opentype'),
-  url('NeuzeitGrotesk-light.woff2') format('woff2'),
-  url('NeuzeitGrotesk-light.woff') format('woff'),
-  url('NeuzeitGrotesk-light.ttf') format('truetype');
+  src: url('NeuzeitGrotesk-light.woff2') format('woff2'), url('NeuzeitGrotesk-light.woff') format('woff');
   font-style: normal;
   font-weight: 200;
   font-display: swap; /* Perf optimization - See https://web.dev/font-display */
@@ -12,11 +15,7 @@
 
 @font-face {
   font-family: 'neuzeit-grotesk';
-  src: url('NeuzeitGrotesk-regular.eot');
-  src: url('NeuzeitGrotesk-regular.eot?#iefix') format('embedded-opentype'),
-  url('NeuzeitGrotesk-regular.woff2') format('woff2'),
-  url('NeuzeitGrotesk-regular.woff') format('woff'),
-  url('NeuzeitGrotesk-regular.ttf') format('truetype');
+  src: url('NeuzeitGrotesk-regular.woff2') format('woff2'), url('NeuzeitGrotesk-regular.woff') format('woff');
   font-style: normal;
   font-weight: 900;
   font-display: swap; /* Perf optimization - See https://web.dev/font-display */
@@ -24,11 +23,7 @@
 
 @font-face {
   font-family: 'neuzeit-grotesk';
-  src: url('NeuzeitGrotesk-bold.eot');
-  src: url('NeuzeitGrotesk-bold.eot?#iefix') format('embedded-opentype'),
-  url('NeuzeitGrotesk-bold.woff2') format('woff2'),
-  url('NeuzeitGrotesk-bold.woff') format('woff'),
-  url('NeuzeitGrotesk-bold.ttf') format('truetype');
+  src: url('NeuzeitGrotesk-bold.woff2') format('woff2'), url('NeuzeitGrotesk-bold.woff') format('woff');
   font-style: normal;
   font-weight: 400;
   font-display: swap; /* Perf optimization - See https://web.dev/font-display */
@@ -36,11 +31,7 @@
 
 @font-face {
   font-family: 'neuzeit-grotesk';
-  src: url('NeuzeitGrotesk-black.eot');
-  src: url('NeuzeitGrotesk-black.eot?#iefix') format('embedded-opentype'),
-  url('NeuzeitGrotesk-black.woff2') format('woff2'),
-  url('NeuzeitGrotesk-black.woff') format('woff'),
-  url('NeuzeitGrotesk-black.ttf') format('truetype');
+  src: url('NeuzeitGrotesk-black.woff2') format('woff2'), url('NeuzeitGrotesk-black.woff') format('woff');
   font-style: normal;
   font-weight: 700;
   font-display: swap; /* Perf optimization - See https://web.dev/font-display */

--- a/src/components/appBootstrap/MultiversalAppBootstrap.tsx
+++ b/src/components/appBootstrap/MultiversalAppBootstrap.tsx
@@ -125,7 +125,7 @@ const MultiversalAppBootstrap: React.FunctionComponent<Props> = (props): JSX.Ele
      * XXX If you're concerned regarding React rehydration, read our talk with Josh, author of https://joshwcomeau.com/react/the-perils-of-rehydration/
      *  https://twitter.com/Vadorequest/status/1257658553361408002
      *
-     * XXX There may be more rendering modes - See https://github.com/zeit/next.js/discussions/12558#discussioncomment-12303
+     * XXX There may be more rendering modes - See https://github.com/vercel/next.js/discussions/12558#discussioncomment-12303
      */
     let browserPageBootstrapProps: BrowserPageBootstrapProps;
     let serverPageBootstrapProps: ServerPageBootstrapProps;

--- a/src/components/appBootstrap/UniversalGlobalStyles.tsx
+++ b/src/components/appBootstrap/UniversalGlobalStyles.tsx
@@ -143,6 +143,10 @@ const UniversalGlobalStyles: React.FunctionComponent<Props> = (props): JSX.Eleme
              display: inline-block; // Necessary so that <a> and <button> behave identically
           }
 
+          .btn-link {
+            padding: 0; // Avoid padding to make it display as a link would
+          }
+
           label {
             cursor: pointer;
           }

--- a/src/components/appBootstrap/UniversalGlobalStyles.tsx
+++ b/src/components/appBootstrap/UniversalGlobalStyles.tsx
@@ -144,7 +144,9 @@ const UniversalGlobalStyles: React.FunctionComponent<Props> = (props): JSX.Eleme
           }
 
           .btn-link {
-            padding: 0; // Avoid padding to make it display as a link would
+            @media (min-width: 992px) {
+              padding: 0; // Avoid padding to make it display as a link would for desktop only
+            }
           }
 
           label {

--- a/src/components/doc/BuiltInFeaturesSection.tsx
+++ b/src/components/doc/BuiltInFeaturesSection.tsx
@@ -62,8 +62,8 @@ const BuiltInFeaturesSection: React.FunctionComponent<Props> = (props): JSX.Elem
 
         <Card>
           <CardBody>
-            <CardTitle><h3>B2B MST</h3></CardTitle>
-            <CardSubtitle>&ldquo;Multi Single Tenancy for B2B businesses who need it&rdquo;</CardSubtitle>
+            <CardTitle><h3>SaaS B2B MST</h3></CardTitle>
+            <CardSubtitle>&ldquo;Multi Single Tenancy for SaaS B2B businesses who need it&rdquo;</CardSubtitle>
             <CardText tag={'div'}>
               <Alert color={'info'}>
                 <code>MST</code> is similar to the <code>monorepo</code> design, where the same source code can be used to deploy multiple instances.

--- a/src/components/doc/BuiltInFeaturesSidebar.tsx
+++ b/src/components/doc/BuiltInFeaturesSidebar.tsx
@@ -84,11 +84,11 @@ const BuiltInFeaturesSidebar: React.FunctionComponent<Props> = (props): JSX.Elem
       >
         {
           map(BUILT_IN_FEATURES_SIDEBAR_LINKS, (link: SidebarLink) => {
-            const { label, href } = link;
+            const { label, href, params = null } = link;
 
             return (
               <NavItem key={href}>
-                <I18nLink href={href} wrapChildrenAsLink={false}>
+                <I18nLink href={href} params={params} wrapChildrenAsLink={false}>
                   <NavLink active={router.pathname.replace('/[locale]', '') === href}>
                     {label}
                   </NavLink>

--- a/src/components/doc/BuiltInUtilitiesSidebar.tsx
+++ b/src/components/doc/BuiltInUtilitiesSidebar.tsx
@@ -72,11 +72,11 @@ const BuiltInUtilitiesSidebar: React.FunctionComponent<Props> = (props): JSX.Ele
       >
         {
           map(BUILT_IN_UTILITIES_SIDEBAR_LINKS, (link: SidebarLink) => {
-            const { label, href } = link;
+            const { label, href, params = null } = link;
 
             return (
               <NavItem key={href}>
-                <I18nLink href={href} wrapChildrenAsLink={false}>
+                <I18nLink href={href} params={params} wrapChildrenAsLink={false}>
                   <NavLink active={router.pathname.replace('/[locale]', '') === href}>
                     {label}
                   </NavLink>

--- a/src/components/doc/IntroductionSection.tsx
+++ b/src/components/doc/IntroductionSection.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx } from '@emotion/core';
+import { jsx, css } from '@emotion/core';
 import React from 'react';
 import { Alert, Jumbotron } from 'reactstrap';
 
@@ -27,12 +27,14 @@ const IntroductionSection: React.FunctionComponent<Props> = (props): JSX.Element
       className={'center'}
     >
       <h1>Next Right Now Demo</h1>
-      <h3>
+      <h2 css={css`
+        font-size: 20px;
+      `}>
         This demo uses the preset
         <ExternalLink href={`https://github.com/UnlyEd/next-right-now/tree/${process.env.NEXT_PUBLIC_NRN_PRESET}`}>
           <code>{process.env.NEXT_PUBLIC_NRN_PRESET}</code>
         </ExternalLink>
-      </h3>
+      </h2>
 
       <ExternalLink
         href={'https://unlyed.github.io/next-right-now/concepts/presets'}

--- a/src/components/doc/NativeFeaturesSection.tsx
+++ b/src/components/doc/NativeFeaturesSection.tsx
@@ -157,7 +157,7 @@ const NativeFeaturesSection: React.FunctionComponent<Props> = (props): JSX.Eleme
 
               <Alert color={'warning'}>
                 Be aware that this feature is still in beta (as of v9.4), and the prop name is <code>unstable_revalidate</code> to make this obvious.<br />
-                The <ExternalLink href={'https://github.com/zeit/next.js/discussions/11552'}>RFC</ExternalLink> is still being discussed, don't hesitate to participate!<br />
+                The <ExternalLink href={'https://github.com/vercel/next.js/discussions/11552'}>RFC</ExternalLink> is still being discussed, don't hesitate to participate!<br />
                 API-based regeneration (e.g: regenerate pages based on a CMS update) is still being discussed in the RFC.
               </Alert>
             </CardText>

--- a/src/components/pageLayouts/Head.tsx
+++ b/src/components/pageLayouts/Head.tsx
@@ -66,11 +66,7 @@ const Head: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
       <link rel="icon" href={favicon} />
 
       {/* Perf optimisation (preload normal and bold fonts because they're the most used) - See https://web.dev/uses-rel-preload*/}
-      <link rel="preload" as="style" href={'/static/fonts/NeuzeitGrotesk/font.css'} />
-      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff'} type="font/woff" />
-      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff2'} type="font/woff2" />
-      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff'} type="font/woff" />
-      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff2'} type="font/woff2" />
+      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/font.css'} />
 
       {
         SUPPORTED_LOCALES.map((supportedLocale: I18nLocale) => {

--- a/src/components/pageLayouts/Head.tsx
+++ b/src/components/pageLayouts/Head.tsx
@@ -46,7 +46,7 @@ const Head: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
     WebFontLoader.load({
       custom: {
         families: ['neuzeit-grotesk'],
-        urls: ['/static/fonts/NeuzeitGrotesk/font.css']
+        urls: ['/static/fonts/NeuzeitGrotesk/font.css'],
       },
     });
   }
@@ -64,6 +64,9 @@ const Head: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
       <link rel="apple-touch-icon" href="/touch-icon.png" />
       <link rel="mask-icon" href="/favicon-mask.svg" color="#49B882" />
       <link rel="icon" href={favicon} />
+
+      {/* Perf optimisation - See https://web.dev/uses-rel-preload*/}
+      <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/font.css'} as={'style'} />
 
       {
         SUPPORTED_LOCALES.map((supportedLocale: I18nLocale) => {

--- a/src/components/pageLayouts/Head.tsx
+++ b/src/components/pageLayouts/Head.tsx
@@ -65,8 +65,12 @@ const Head: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
       <link rel="mask-icon" href="/favicon-mask.svg" color="#49B882" />
       <link rel="icon" href={favicon} />
 
-      {/* Perf optimisation - See https://web.dev/uses-rel-preload*/}
+      {/* Perf optimisation (preload normal and bold fonts because they're the most used) - See https://web.dev/uses-rel-preload*/}
       <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/font.css'} as={'style'} />
+      <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff'} />
+      <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff2'} />
+      <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff'} />
+      <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff2'} />
 
       {
         SUPPORTED_LOCALES.map((supportedLocale: I18nLocale) => {

--- a/src/components/pageLayouts/Head.tsx
+++ b/src/components/pageLayouts/Head.tsx
@@ -18,7 +18,7 @@ export type HeadProps = {
 /**
  * Custom Head component
  *
- * https://github.com/zeit/next.js#populating-head
+ * https://github.com/vercel/next.js#populating-head
  */
 const Head: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
   const defaultDescription = 'Flexible production-grade boilerplate with Next.js 9, Zeit and TypeScript. Includes multiple opt-in presets using GraphQL, Analytics, CSS-in-JS, Monitoring, End-to-end testing, Internationalization, CI/CD and SaaS B2B multiple single-tenants (monorepo) support';

--- a/src/components/pageLayouts/Head.tsx
+++ b/src/components/pageLayouts/Head.tsx
@@ -66,11 +66,11 @@ const Head: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
       <link rel="icon" href={favicon} />
 
       {/* Perf optimisation (preload normal and bold fonts because they're the most used) - See https://web.dev/uses-rel-preload*/}
-      <link rel="preload" as="style" href={'/static/fonts/NeuzeitGrotesk/font.css'} crossOrigin="anonymous" />
-      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff'} type="font/woff" crossOrigin="anonymous" />
-      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff2'} type="font/woff2" crossOrigin="anonymous" />
-      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff'} type="font/woff" crossOrigin="anonymous" />
-      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff2'} type="font/woff2" crossOrigin="anonymous" />
+      <link rel="preload" as="style" href={'/static/fonts/NeuzeitGrotesk/font.css'} />
+      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff'} type="font/woff" />
+      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff2'} type="font/woff2" />
+      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff'} type="font/woff" />
+      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff2'} type="font/woff2" />
 
       {
         SUPPORTED_LOCALES.map((supportedLocale: I18nLocale) => {

--- a/src/components/pageLayouts/Head.tsx
+++ b/src/components/pageLayouts/Head.tsx
@@ -66,11 +66,11 @@ const Head: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
       <link rel="icon" href={favicon} />
 
       {/* Perf optimisation (preload normal and bold fonts because they're the most used) - See https://web.dev/uses-rel-preload*/}
-      <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/font.css'} as={'style'} />
-      <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff'} />
-      <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff2'} />
-      <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff'} />
-      <link rel="preload" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff2'} />
+      <link rel="preload" as="style" href={'/static/fonts/NeuzeitGrotesk/font.css'} crossOrigin="anonymous" />
+      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff'} type="font/woff" crossOrigin="anonymous" />
+      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-bold.woff2'} type="font/woff2" crossOrigin="anonymous" />
+      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff'} type="font/woff" crossOrigin="anonymous" />
+      <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/NeuzeitGrotesk-black.woff2'} type="font/woff2" crossOrigin="anonymous" />
 
       {
         SUPPORTED_LOCALES.map((supportedLocale: I18nLocale) => {

--- a/src/components/pageLayouts/Head.tsx
+++ b/src/components/pageLayouts/Head.tsx
@@ -60,9 +60,9 @@ const Head: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
         content={description}
       />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <link rel="icon" sizes="192x192" href="/touch-icon.png" />
-      <link rel="apple-touch-icon" href="/touch-icon.png" />
-      <link rel="mask-icon" href="/favicon-mask.svg" color="#49B882" />
+      {/*<link rel="icon" sizes="192x192" href="/touch-icon.png" />*/}
+      {/*<link rel="apple-touch-icon" href="/touch-icon.png" />*/}
+      {/*<link rel="mask-icon" href="/favicon-mask.svg" color="#49B882" />*/}
       <link rel="icon" href={favicon} />
 
       {/* Perf optimisation (preload normal and bold fonts because they're the most used) - See https://web.dev/uses-rel-preload*/}

--- a/src/components/pageLayouts/Head.tsx
+++ b/src/components/pageLayouts/Head.tsx
@@ -21,7 +21,7 @@ export type HeadProps = {
  * https://github.com/zeit/next.js#populating-head
  */
 const Head: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
-  const defaultDescription = 'Flexible production-grade boilerplate with Next.js 9, Zeit and TypeScript. Includes multiple opt-in presets using GraphQL, Analytics, CSS-in-JS, Monitoring, End-to-end testing, Internationalization, CI/CD and B2B multiple single-tenants (monorepo) support';
+  const defaultDescription = 'Flexible production-grade boilerplate with Next.js 9, Zeit and TypeScript. Includes multiple opt-in presets using GraphQL, Analytics, CSS-in-JS, Monitoring, End-to-end testing, Internationalization, CI/CD and SaaS B2B multiple single-tenants (monorepo) support';
   const defaultOGURL = 'https://github.com/UnlyEd/next-right-now';
   const defaultOGImage = 'https://storage.googleapis.com/the-funding-place/assets/images/Logo_TFP_quadri_horizontal.svg';
   const defaultFavicon = 'https://storage.googleapis.com/the-funding-place/assets/images/default_favicon.ico';

--- a/src/components/pageLayouts/Head.tsx
+++ b/src/components/pageLayouts/Head.tsx
@@ -66,6 +66,7 @@ const Head: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
       <link rel="icon" href={favicon} />
 
       {/* Perf optimisation (preload normal and bold fonts because they're the most used) - See https://web.dev/uses-rel-preload*/}
+      {/* TODO See if it's actually a good thing, seems to conflict with WebFontLoader - See https://github.com/GoogleChrome/lighthouse/issues/10892 */}
       <link rel="preload" as="font" href={'/static/fonts/NeuzeitGrotesk/font.css'} />
 
       {

--- a/src/components/pageLayouts/Nav.tsx
+++ b/src/components/pageLayouts/Nav.tsx
@@ -16,6 +16,7 @@ import { isActive, resolveI18nHomePage } from '../../utils/app/router';
 import GraphCMSAsset from '../assets/GraphCMSAsset';
 import { BUILT_IN_FEATURES_SIDEBAR_LINKS } from '../doc/BuiltInFeaturesSidebar';
 import { BUILT_IN_UTILITIES_SIDEBAR_LINKS } from '../doc/BuiltInUtilitiesSidebar';
+import { NATIVE_FEATURES_SIDEBAR_LINKS } from '../doc/NativeFeaturesSidebar';
 import I18nLink from '../i18n/I18nLink';
 
 type Props = {};
@@ -151,20 +152,29 @@ const Nav: React.FunctionComponent<Props> = () => {
                 </DropdownToggle>
                 <DropdownMenu>
                   <DropdownItem header>Native features</DropdownItem>
-                  {/*<DropdownItem tag={'span'}>*/}
-                  {/*  <I18nLink href={'/'}>*/}
-                  {/*    Native features*/}
-                  {/*  </I18nLink>*/}
-                  {/*</DropdownItem>*/}
+                  {
+                    map(NATIVE_FEATURES_SIDEBAR_LINKS, (link: SidebarLink) => {
+                      const { label, href, params = null } = link;
+                      return (
+                        <DropdownItem tag={'span'} key={href}>
+                          <I18nLink href={href} params={params} wrapChildrenAsLink={false}>
+                            <NavLink id={`nav-link-examples-${kebabCase(label)}`} active={router.pathname.replace('/[locale]', '') === href}>
+                              {label}
+                            </NavLink>
+                          </I18nLink>
+                        </DropdownItem>
+                      );
+                    })
+                  }
                   <DropdownItem divider />
 
                   <DropdownItem header>Built-in features</DropdownItem>
                   {
                     map(BUILT_IN_FEATURES_SIDEBAR_LINKS, (link: SidebarLink) => {
-                      const { label, href } = link;
+                      const { label, href, params = null } = link;
                       return (
                         <DropdownItem tag={'span'} key={href}>
-                          <I18nLink href={href} wrapChildrenAsLink={false}>
+                          <I18nLink href={href} params={params} wrapChildrenAsLink={false}>
                             <NavLink id={`nav-link-examples-${kebabCase(label)}`} active={router.pathname.replace('/[locale]', '') === href}>
                               {label}
                             </NavLink>
@@ -178,11 +188,11 @@ const Nav: React.FunctionComponent<Props> = () => {
                   <DropdownItem header>Built-in utilities</DropdownItem>
                   {
                     map(BUILT_IN_UTILITIES_SIDEBAR_LINKS, (link: SidebarLink) => {
-                      const { label, href } = link;
+                      const { label, href, params = null } = link;
                       return (
                         <DropdownItem tag={'span'} key={href}>
-                          <I18nLink href={href} wrapChildrenAsLink={false}>
-                            <NavLink active={router.pathname.replace('/[locale]', '') === href}>
+                          <I18nLink href={href} params={params} wrapChildrenAsLink={false}>
+                            <NavLink id={`nav-link-examples-${kebabCase(label)}`} active={router.pathname.replace('/[locale]', '') === href}>
                               {label}
                             </NavLink>
                           </I18nLink>

--- a/src/components/pageLayouts/PreviewModeBanner.tsx
+++ b/src/components/pageLayouts/PreviewModeBanner.tsx
@@ -6,6 +6,7 @@ import Alert from 'reactstrap/lib/Alert';
 import usePreviewMode from '../../hooks/usePreviewMode';
 import ExternalLink from '../utils/ExternalLink';
 import Tooltip from '../utils/Tooltip';
+import { Button } from 'reactstrap';
 
 type Props = {}
 
@@ -85,15 +86,13 @@ const PreviewModeBanner: React.FunctionComponent<Props> = (props): JSX.Element =
               </Tooltip>
             </span>
             <span className={'right'}>
-              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-              <a
-                role={'button'}
-                tabIndex={0}
+              <Button
+                color={'link'}
                 onClick={stopPreviewMode}
                 onKeyPress={stopPreviewMode}
               >
                 Leave preview mode
-              </a>
+              </Button>
             </span>
           </div>
         ) : (
@@ -108,15 +107,13 @@ const PreviewModeBanner: React.FunctionComponent<Props> = (props): JSX.Element =
               </Tooltip>
             </span>
             <span className={'right'}>
-              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-              <a
-                role={'button'}
-                tabIndex={0}
+              <Button
+                color={'link'}
                 onClick={startPreviewMode}
                 onKeyPress={startPreviewMode}
               >
                 Start preview mode
-              </a>
+              </Button>
             </span>
           </div>
         )

--- a/src/components/utils/Cards.tsx
+++ b/src/components/utils/Cards.tsx
@@ -51,6 +51,7 @@ const Cards: React.FunctionComponent<Props> = (props): JSX.Element => {
           .buttons {
             display: flex;
             flex-direction: column;
+            margin-bottom: 20px;
           }
         }
       `}

--- a/src/components/utils/ExternalLink.tsx
+++ b/src/components/utils/ExternalLink.tsx
@@ -8,6 +8,7 @@ type Props = {
   href: string;
   id?: string;
   nofollow?: boolean;
+  noopener?: boolean;
   noreferrer?: boolean;
   onClick?: (any) => void;
   prefix?: string;
@@ -25,8 +26,9 @@ const ExternalLink: React.FunctionComponent<Props> = (props): JSX.Element => {
   const {
     children,
     href,
-    nofollow = true,
-    noreferrer = false,
+    nofollow = true, // Tell bots not to follow the link when crawling (you may want to disable this depending on your use case)
+    noopener = true, // Security, avoids external site opened through your site to have control over your site (always apply "noopener" unless you know what you're doing)
+    noreferrer = false, // SEO, avoids external site opened through your site to know they have been opened from your site (don't apply "noreferrer" unless you know what you're doing)
     prefix = ' ', // Helper to avoid link to "stick" with text
     suffix = ' ', // Helper to avoid link to "stick" with text
     ...rest
@@ -36,7 +38,7 @@ const ExternalLink: React.FunctionComponent<Props> = (props): JSX.Element => {
     <a
       href={href}
       target={'_blank'} // eslint-disable-line react/jsx-no-target-blank
-      rel={`${nofollow ? 'nofollow' : ''} ${noreferrer ? 'noreferrer' : ''}`}
+      rel={`${nofollow ? 'nofollow' : ''} ${noopener ? 'noopener' : ''} ${noreferrer ? 'noreferrer' : ''}`}
       {...rest}
     >
       {prefix}{children}{suffix}

--- a/src/hocs/withApollo.tsx
+++ b/src/hocs/withApollo.tsx
@@ -8,7 +8,7 @@ import Head from 'next/head';
 import React, { ReactNode } from 'react';
 import createApolloClient from '../utils/gql/graphql';
 
-// XXX Inspired by https://github.com/zeit/next.js/blob/canary/examples/with-apollo/lib/apollo.js
+// XXX Inspired by https://github.com/vercel/next.js/blob/canary/examples/with-apollo/lib/apollo.js
 // On the client, we store the Apollo Client in the following variable.
 // This prevents the client from reinitializing between page transitions.
 let globalApolloClient: ApolloClient<NormalizedCacheObject> = null;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -22,7 +22,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -10,7 +10,7 @@ import { StaticParams } from '../types/nextjs/StaticParams';
 import { SoftPageProps } from '../types/pageProps/SoftPageProps';
 import { SSGPageProps } from '../types/pageProps/SSGPageProps';
 import { DEFAULT_LOCALE, LANG_EN, LANG_FR } from '../utils/i18n/i18n';
-import { getCommonStaticProps } from '../utils/nextjs/SSG';
+import { getExamplesCommonStaticProps } from '../utils/nextjs/SSG';
 
 const fileLabel = 'pages/404';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -25,7 +25,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/analytics.tsx
+++ b/src/pages/[locale]/examples/built-in-features/analytics.tsx
@@ -14,7 +14,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/analytics';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -25,7 +25,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -35,7 +35,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/analytics.tsx
+++ b/src/pages/[locale]/examples/built-in-features/analytics.tsx
@@ -32,7 +32,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-features/animations.tsx
+++ b/src/pages/[locale]/examples/built-in-features/animations.tsx
@@ -14,7 +14,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/animations';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -25,7 +25,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -35,7 +35,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/animations.tsx
+++ b/src/pages/[locale]/examples/built-in-features/animations.tsx
@@ -32,7 +32,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-features/css-in-js.tsx
+++ b/src/pages/[locale]/examples/built-in-features/css-in-js.tsx
@@ -14,7 +14,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/css-in-js';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -25,7 +25,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -35,7 +35,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/css-in-js.tsx
+++ b/src/pages/[locale]/examples/built-in-features/css-in-js.tsx
@@ -32,7 +32,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-features/docs-site.tsx
+++ b/src/pages/[locale]/examples/built-in-features/docs-site.tsx
@@ -13,7 +13,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/docs-site';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -24,7 +24,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/docs-site.tsx
+++ b/src/pages/[locale]/examples/built-in-features/docs-site.tsx
@@ -31,7 +31,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-features/graphql.tsx
+++ b/src/pages/[locale]/examples/built-in-features/graphql.tsx
@@ -31,7 +31,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-features/graphql.tsx
+++ b/src/pages/[locale]/examples/built-in-features/graphql.tsx
@@ -13,7 +13,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/graphql';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -24,7 +24,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/hosting.tsx
+++ b/src/pages/[locale]/examples/built-in-features/hosting.tsx
@@ -14,7 +14,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/hosting';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -25,7 +25,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -35,7 +35,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/hosting.tsx
+++ b/src/pages/[locale]/examples/built-in-features/hosting.tsx
@@ -32,7 +32,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
@@ -76,11 +76,11 @@ const HostingPage: NextPage<Props> = (props): JSX.Element => {
 
         <Alert color={'warning'}>
           We are a bit wary about recent changes and decisions made by the Vercel team, in particular regarding their 2020 April Pricing changes, and
-          <ExternalLink href={'https://github.com/zeit/now/discussions/4029'} suffix={null}>we led a discussion about it</ExternalLink>.<br />
+          <ExternalLink href={'https://github.com/vercel/now/discussions/4029'} suffix={null}>we led a discussion about it</ExternalLink>.<br />
           <br />
           Currently, the most controversial decision they've made is about the 12-24 max serverless functions. <br />
           We suggest you
-          <ExternalLink href={'https://github.com/zeit/now/discussions/4029#discussioncomment-8449'}>learn heavily about that</ExternalLink>
+          <ExternalLink href={'https://github.com/vercel/now/discussions/4029#discussioncomment-8449'}>learn heavily about that</ExternalLink>
           if you're considering Vercel.
         </Alert>
 

--- a/src/pages/[locale]/examples/built-in-features/icons.tsx
+++ b/src/pages/[locale]/examples/built-in-features/icons.tsx
@@ -14,7 +14,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/icons';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -25,7 +25,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -35,7 +35,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/icons.tsx
+++ b/src/pages/[locale]/examples/built-in-features/icons.tsx
@@ -32,7 +32,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-features/manual-deployments.tsx
+++ b/src/pages/[locale]/examples/built-in-features/manual-deployments.tsx
@@ -31,7 +31,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-features/manual-deployments.tsx
+++ b/src/pages/[locale]/examples/built-in-features/manual-deployments.tsx
@@ -13,7 +13,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/manual-deployments';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -24,7 +24,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/monitoring.tsx
+++ b/src/pages/[locale]/examples/built-in-features/monitoring.tsx
@@ -13,7 +13,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/monitoring';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -24,7 +24,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/monitoring.tsx
+++ b/src/pages/[locale]/examples/built-in-features/monitoring.tsx
@@ -31,7 +31,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-features/stages-and-secrets.tsx
+++ b/src/pages/[locale]/examples/built-in-features/stages-and-secrets.tsx
@@ -14,7 +14,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/stages-and-secrets';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -25,7 +25,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -35,7 +35,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/stages-and-secrets.tsx
+++ b/src/pages/[locale]/examples/built-in-features/stages-and-secrets.tsx
@@ -32,7 +32,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
@@ -96,7 +96,7 @@ const StagesAndSecretsPage: NextPage<Props> = (props): JSX.Element => {
           Before, only <code>secrets</code> existed, but since <code>now@18</code> they've introduced the concept of <code>environment variables</code>.<br />
           It can be a bit hard to understand how the 2 should be used together.<br />
           Basically put, <code>secrets</code> are global and shared across all projects, while <code>env vars</code> are scoped by project.<br />
-          <ExternalLink href={'https://github.com/zeit/now/discussions/4065'}>There are other differences</ExternalLink>, though.<br />
+          <ExternalLink href={'https://github.com/vercel/now/discussions/4065'}>There are other differences</ExternalLink>, though.<br />
         </Alert>
 
         <Alert color={'info'}>

--- a/src/pages/[locale]/examples/built-in-features/static-i18n.tsx
+++ b/src/pages/[locale]/examples/built-in-features/static-i18n.tsx
@@ -15,7 +15,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 import BuiltInFeaturesSidebar from '../../../../components/doc/BuiltInFeaturesSidebar';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/static-i18n';
@@ -27,7 +27,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -37,7 +37,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/static-i18n.tsx
+++ b/src/pages/[locale]/examples/built-in-features/static-i18n.tsx
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-features/ui-components.tsx
+++ b/src/pages/[locale]/examples/built-in-features/ui-components.tsx
@@ -14,7 +14,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 import Tooltip from '../../../../components/utils/Tooltip';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/ui-components';
@@ -26,7 +26,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -36,7 +36,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-features/ui-components.tsx
+++ b/src/pages/[locale]/examples/built-in-features/ui-components.tsx
@@ -33,7 +33,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/api.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/api.tsx
@@ -12,7 +12,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/api';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -23,7 +23,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -33,7 +33,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/api.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/api.tsx
@@ -30,7 +30,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/bundle-analysis.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/bundle-analysis.tsx
@@ -12,7 +12,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/bundle-analysis';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -23,7 +23,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -33,7 +33,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/bundle-analysis.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/bundle-analysis.tsx
@@ -65,7 +65,7 @@ const AnalyseBundlePage: NextPage<Props> = (props): JSX.Element => {
         </p>
 
         <Code
-          text={`yarn next:bundle`}
+          text={`yarn analyse:bundle`}
         />
 
       </DocPage>

--- a/src/pages/[locale]/examples/built-in-utilities/bundle-analysis.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/bundle-analysis.tsx
@@ -30,7 +30,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/errors-handling.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/errors-handling.tsx
@@ -33,7 +33,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/errors-handling.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/errors-handling.tsx
@@ -15,7 +15,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/errors-handling';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -26,7 +26,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -36,7 +36,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/hocs.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/hocs.tsx
@@ -13,7 +13,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/hocs';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -24,7 +24,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/hocs.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/hocs.tsx
@@ -31,7 +31,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/hooks.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/hooks.tsx
@@ -33,7 +33,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/hooks.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/hooks.tsx
@@ -15,7 +15,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/hooks';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -26,7 +26,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -36,7 +36,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/i18nLink-component.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/i18nLink-component.tsx
@@ -14,7 +14,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/i18nLink-component';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -25,7 +25,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -35,7 +35,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/i18nLink-component.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/i18nLink-component.tsx
@@ -32,7 +32,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/interactive-error.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/interactive-error.tsx
@@ -30,7 +30,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/interactive-error.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/interactive-error.tsx
@@ -12,7 +12,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/interactive-error';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -23,7 +23,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -33,7 +33,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/packages-upgrade.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/packages-upgrade.tsx
@@ -32,7 +32,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
@@ -100,7 +100,7 @@ const PackagesUpgradePage: NextPage<Props> = (props): JSX.Element => {
             ? Choose which packages to update. (Press <space> to select, <a> to toggle all, <i> to invert selection)
              devDependencies
                name                              range   from       to      url
-            ❯◯ @next/bundle-analyzer             latest  9.4.1   ❯  9.4.2   https://github.com/zeit/next.js#readme
+            ❯◯ @next/bundle-analyzer             latest  9.4.1   ❯  9.4.2   https://github.com/vercel/next.js#readme
              ◯ @types/jest                       latest  25.2.2  ❯  25.2.3  https://github.com/DefinitelyTyped/DefinitelyTyped.git
              ◯ @types/webfontloader              latest  1.6.30  ❯  1.6.31  https://github.com/DefinitelyTyped/DefinitelyTyped.git
              ◯ @typescript-eslint/eslint-plugin  latest  2.33.0  ❯  3.0.0   https://github.com/typescript-eslint/typescript-eslint#readme

--- a/src/pages/[locale]/examples/built-in-utilities/packages-upgrade.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/packages-upgrade.tsx
@@ -13,7 +13,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 import { Alert } from 'reactstrap';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/packages-upgrade';
@@ -25,7 +25,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -35,7 +35,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/security-audit.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/security-audit.tsx
@@ -12,7 +12,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 import { Alert } from 'reactstrap';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/security-audit';
@@ -24,7 +24,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/security-audit.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/security-audit.tsx
@@ -31,7 +31,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/svg-to-react.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/svg-to-react.tsx
@@ -15,7 +15,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 import { Alert } from 'reactstrap';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/svg-to-react';
@@ -27,7 +27,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -37,7 +37,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/svg-to-react.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/svg-to-react.tsx
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/top-level-500-error.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/top-level-500-error.tsx
@@ -11,7 +11,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/top-level-500-error';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -22,7 +22,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -32,7 +32,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/built-in-utilities/top-level-500-error.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/top-level-500-error.tsx
@@ -29,7 +29,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/tracking-useless-re-renders.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/tracking-useless-re-renders.tsx
@@ -33,7 +33,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/built-in-utilities/tracking-useless-re-renders.tsx
+++ b/src/pages/[locale]/examples/built-in-utilities/tracking-useless-re-renders.tsx
@@ -15,7 +15,7 @@ import withApollo from '../../../../hocs/withApollo';
 import { StaticParams } from '../../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-utilities/tracking-useless-re-renders';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -26,7 +26,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -36,7 +36,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/index.tsx
+++ b/src/pages/[locale]/examples/index.tsx
@@ -33,7 +33,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/examples/index.tsx
+++ b/src/pages/[locale]/examples/index.tsx
@@ -14,7 +14,7 @@ import withApollo from '../../../hocs/withApollo';
 import { StaticParams } from '../../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../utils/nextjs/SSG';
 import ExternalFeaturesSection from '../../../components/doc/ExternalFeaturesSection';
 
 const fileLabel = 'pages/[locale]/examples/index';
@@ -26,7 +26,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -36,7 +36,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/examples/native-features/example-with-ssg-and-fallback/[albumId].tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg-and-fallback/[albumId].tsx
@@ -57,7 +57,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = async (): Promise<St
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {

--- a/src/pages/[locale]/examples/native-features/example-with-ssg-and-fallback/[albumId].tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg-and-fallback/[albumId].tsx
@@ -21,7 +21,7 @@ import { StaticPropsOutput } from '../../../../../types/nextjs/StaticPropsOutput
 import { OnlyBrowserPageProps } from '../../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../../types/pageProps/SSGPageProps';
 import { getRandomInt } from '../../../../../utils/math/random';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../../utils/nextjs/SSG';
 import waitFor from '../../../../../utils/timers/waitFor';
 
 const fileLabel = 'pages/[locale]/examples/native-features/example-with-ssg-and-fallback/[albumId]';
@@ -34,7 +34,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
 export const getStaticPaths: GetStaticPaths<StaticParams> = async (): Promise<StaticPathsOutput> => {
-  const commonStaticPaths: StaticPathsOutput = await getCommonStaticPaths();
+  const commonStaticPaths: StaticPathsOutput = await getExamplesCommonStaticPaths();
   const { paths } = commonStaticPaths;
   const albumIdsToPreBuild = ['1']; // Only '/album-1-with-ssg-and-fallback' is generated at build time, other will be generated on-demand
 
@@ -61,7 +61,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = async (): Promise<St
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {
-  const commonStaticProps: StaticPropsOutput = await getCommonStaticProps(props);
+  const commonStaticProps: StaticPropsOutput = await getExamplesCommonStaticProps(props);
   const { params: { albumId } } = props;
 
   // Simulate API call by awaiting

--- a/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
@@ -45,7 +45,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {

--- a/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
@@ -24,7 +24,7 @@ import { StaticPropsOutput } from '../../../../types/nextjs/StaticPropsOutput';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
 import { createApolloClient } from '../../../../utils/gql/graphql';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 import timeDifference from '../../../../utils/time/timeDifference';
 
 const fileLabel = 'pages/[locale]/examples/native-features/example-with-ssg-and-revalidate';
@@ -38,7 +38,7 @@ const regenerationDelay = 30; // Seconds
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -49,7 +49,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {
-  const commonStaticProps: StaticPropsOutput = await getCommonStaticProps(props);
+  const commonStaticProps: StaticPropsOutput = await getExamplesCommonStaticProps(props);
   const { customerRef, gcmsLocales } = commonStaticProps.props;
 
   const apolloClient = createApolloClient();

--- a/src/pages/[locale]/examples/native-features/example-with-ssg.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg.tsx
@@ -43,7 +43,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {

--- a/src/pages/[locale]/examples/native-features/example-with-ssg.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg.tsx
@@ -25,7 +25,7 @@ import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPag
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
 import { createApolloClient } from '../../../../utils/gql/graphql';
 import { SUPPORTED_LOCALES } from '../../../../utils/i18n/i18n';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/native-features/example-with-ssg';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -36,7 +36,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -47,7 +47,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {
-  const commonStaticProps: StaticPropsOutput = await getCommonStaticProps(props);
+  const commonStaticProps: StaticPropsOutput = await getExamplesCommonStaticProps(props);
   const { customerRef, gcmsLocales } = commonStaticProps.props;
 
   const apolloClient = createApolloClient();

--- a/src/pages/[locale]/examples/native-features/example-with-ssr.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssr.tsx
@@ -20,7 +20,7 @@ import { GetServerSidePropsContext } from '../../../../types/nextjs/GetServerSid
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
 import { SSRPageProps } from '../../../../types/pageProps/SSRPageProps';
-import { getCommonServerSideProps, GetCommonServerSidePropsResults } from '../../../../utils/nextjs/SSR';
+import { getExamplesCommonServerSideProps, GetCommonServerSidePropsResults } from '../../../../utils/nextjs/SSR';
 
 const fileLabel = 'pages/[locale]/examples/native-features/example-with-ssr';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -47,7 +47,7 @@ export const getServerSideProps: GetServerSideProps<GetServerSidePageProps> = as
     apolloClient,
     layoutQueryOptions,
     ...pageData
-  }: GetCommonServerSidePropsResults = await getCommonServerSideProps(context);
+  }: GetCommonServerSidePropsResults = await getExamplesCommonServerSideProps(context);
   const queryOptions = { // Override query (keep existing variables and headers)
     ...layoutQueryOptions,
     displayName: 'EXAMPLE_WITH_SSR_QUERY',

--- a/src/pages/[locale]/pageTemplateSSG.tsx
+++ b/src/pages/[locale]/pageTemplateSSG.tsx
@@ -9,7 +9,7 @@ import withApollo from '../../hocs/withApollo';
 import { StaticParams } from '../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../types/pageProps/SSGPageProps';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/pageTemplateSSG';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -20,7 +20,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -30,7 +30,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/pageTemplateSSG.tsx
+++ b/src/pages/[locale]/pageTemplateSSG.tsx
@@ -9,7 +9,7 @@ import withApollo from '../../hocs/withApollo';
 import { StaticParams } from '../../types/nextjs/StaticParams';
 import { OnlyBrowserPageProps } from '../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../types/pageProps/SSGPageProps';
-import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../utils/nextjs/SSG';
+import { getCommonStaticPaths, getCommonStaticProps } from '../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/pageTemplateSSG';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -20,7 +20,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -30,7 +30,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonSta
  * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
-export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getExamplesCommonStaticProps;
+export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;
 
 /**
  * SSG pages are first rendered by the server (during static bundling)

--- a/src/pages/[locale]/pageTemplateSSG.tsx
+++ b/src/pages/[locale]/pageTemplateSSG.tsx
@@ -27,7 +27,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = getCommonStaticProps;

--- a/src/pages/[locale]/pageTemplateSSR.tsx
+++ b/src/pages/[locale]/pageTemplateSSR.tsx
@@ -14,7 +14,7 @@ import { GetServerSidePropsContext } from '../../types/nextjs/GetServerSideProps
 import { OnlyBrowserPageProps } from '../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../types/pageProps/SSGPageProps';
 import { SSRPageProps } from '../../types/pageProps/SSRPageProps';
-import { getExamplesCommonServerSideProps, GetCommonServerSidePropsResults } from '../../utils/nextjs/SSR';
+import { getCommonServerSideProps, GetCommonServerSidePropsResults } from '../../utils/nextjs/SSR';
 
 const fileLabel = 'pages/[locale]/pageTemplateSSR';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -41,7 +41,7 @@ export const getServerSideProps: GetServerSideProps<GetServerSidePageProps> = as
     apolloClient,
     layoutQueryOptions,
     ...pageData
-  }: GetCommonServerSidePropsResults = await getExamplesCommonServerSideProps(context);
+  }: GetCommonServerSidePropsResults = await getCommonServerSideProps(context);
   const queryOptions = { // Override query (keep existing variables and headers)
     ...layoutQueryOptions,
     displayName: 'LAYOUT_QUERY',

--- a/src/pages/[locale]/pageTemplateSSR.tsx
+++ b/src/pages/[locale]/pageTemplateSSR.tsx
@@ -14,7 +14,7 @@ import { GetServerSidePropsContext } from '../../types/nextjs/GetServerSideProps
 import { OnlyBrowserPageProps } from '../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../types/pageProps/SSGPageProps';
 import { SSRPageProps } from '../../types/pageProps/SSRPageProps';
-import { getCommonServerSideProps, GetCommonServerSidePropsResults } from '../../utils/nextjs/SSR';
+import { getExamplesCommonServerSideProps, GetCommonServerSidePropsResults } from '../../utils/nextjs/SSR';
 
 const fileLabel = 'pages/[locale]/pageTemplateSSR';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -41,7 +41,7 @@ export const getServerSideProps: GetServerSideProps<GetServerSidePageProps> = as
     apolloClient,
     layoutQueryOptions,
     ...pageData
-  }: GetCommonServerSidePropsResults = await getCommonServerSideProps(context);
+  }: GetCommonServerSidePropsResults = await getExamplesCommonServerSideProps(context);
   const queryOptions = { // Override query (keep existing variables and headers)
     ...layoutQueryOptions,
     displayName: 'LAYOUT_QUERY',

--- a/src/pages/[locale]/terms.tsx
+++ b/src/pages/[locale]/terms.tsx
@@ -20,7 +20,7 @@ import { OnlyBrowserPageProps } from '../../types/pageProps/OnlyBrowserPageProps
 import { SSGPageProps } from '../../types/pageProps/SSGPageProps';
 import { createApolloClient } from '../../utils/gql/graphql';
 import { replaceAllOccurrences } from '../../utils/js/string';
-import { getCommonStaticPaths, getCommonStaticProps } from '../../utils/nextjs/SSG';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/terms';
 const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
@@ -31,7 +31,7 @@ const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-
  * Only executed on the server side at build time
  * Necessary when a page has dynamic routes and uses "getStaticProps"
  */
-export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths;
+export const getStaticPaths: GetStaticPaths<StaticParams> = getExamplesCommonStaticPaths;
 
 /**
  * Only executed on the server side at build time.
@@ -42,7 +42,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {
-  const commonStaticProps: StaticPropsOutput = await getCommonStaticProps(props);
+  const commonStaticProps: StaticPropsOutput = await getExamplesCommonStaticProps(props);
   const { customerRef, gcmsLocales } = commonStaticProps.props;
 
   const apolloClient = createApolloClient();

--- a/src/pages/[locale]/terms.tsx
+++ b/src/pages/[locale]/terms.tsx
@@ -38,7 +38,7 @@ export const getStaticPaths: GetStaticPaths<StaticParams> = getCommonStaticPaths
  *
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -49,7 +49,7 @@ process.on('uncaughtException', (e: Error): void => {
  *
  * Used to inject <html lang=""> tag
  *
- * See https://github.com/zeit/next.js/#custom-document
+ * See https://github.com/vercel/next.js/#custom-document
  */
 class AppDocument extends Document<DocumentRenderProps> {
   static async getInitialProps(ctx: DocumentContext): Promise<DocumentGetInitialPropsOutput> {

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -44,8 +44,8 @@ export type ErrorProps = {
  *   />
  *
  * @param props
- * @see https://github.com/zeit/next.js/blob/canary/examples/with-sentry-simple/pages/_error.js Inspiration about Sentry implementation
- * @see https://github.com/zeit/next.js/discussions/12913 Discussion about hybrid SSG/SSR apps considerations
+ * @see https://github.com/vercel/next.js/blob/canary/examples/with-sentry-simple/pages/_error.js Inspiration about Sentry implementation
+ * @see https://github.com/vercel/next.js/discussions/12913 Discussion about hybrid SSG/SSR apps considerations
  */
 const ErrorPage = (props: ErrorPageProps): JSX.Element => {
   const { statusCode, isReadyToRender, err, children = null } = props;
@@ -56,7 +56,7 @@ const ErrorPage = (props: ErrorPageProps): JSX.Element => {
 
   // TODO rename to "forceLogTopLevelError" = true and provide false in "DefaultErrorLayout"
   if (!isReadyToRender && err) {
-    // XXX getInitialProps is not called for top-level errors - See https://github.com/zeit/next.js/issues/8592
+    // XXX getInitialProps is not called for top-level errors - See https://github.com/vercel/next.js/issues/8592
     // As a workaround, we pass err via _app and src/components/appBootstrap/MultiversalAppBootstrap.tsx so it can be captured
     Sentry.captureException(err);
   }
@@ -93,7 +93,7 @@ ErrorPage.getInitialProps = async (props: NextPageContext): Promise<ErrorProps> 
     console.debug('ErrorPage.getInitialProps - Unexpected error caught, it was captured and sent to Sentry. Error details:', err);
   }
 
-  // Workaround for https://github.com/zeit/next.js/issues/8592, mark when
+  // Workaround for https://github.com/vercel/next.js/issues/8592, mark when
   // getInitialProps has run
   errorInitialProps.isReadyToRender = true;
 

--- a/src/types/nextjs/MultiversalAppBootstrapProps.ts
+++ b/src/types/nextjs/MultiversalAppBootstrapProps.ts
@@ -14,7 +14,7 @@ export declare type MultiversalAppBootstrapProps<PP extends MultiversalPageProps
   pageProps?: PP; // Props forwarded to the Page component
   router?: NextRouter;
 
-  // XXX Next.js internals (unstable API) - See https://github.com/zeit/next.js/discussions/12558#discussioncomment-9177
+  // XXX Next.js internals (unstable API) - See https://github.com/vercel/next.js/discussions/12558#discussioncomment-9177
   __N_SSG?: boolean; // Stands for "server-side generated" or "static site generation", indicates the page was generated through getStaticProps
   __N_SSR?: boolean; // Stands for "server-side rendering", indicates the page was generated through getServerSideProps
   __N_SSP?: boolean; // Stands for "server-side props"

--- a/src/utils/app/ignoreNoisyWarningsHacks.ts
+++ b/src/utils/app/ignoreNoisyWarningsHacks.ts
@@ -5,7 +5,7 @@ const originalError = console.error;
 // eslint-disable-next-line no-console
 console.error = (...args): void => {
   if (/Warning.*Function components cannot be given refs/.test(args[0])) {
-    // HACK: Muting error, fix as soon as https://github.com/zeit/next.js/issues/7915 gets resolved
+    // HACK: Muting error, fix as soon as https://github.com/vercel/next.js/issues/7915 gets resolved
     return;
   }else if (/Warning.*Expected server HTML to contain a matching/.test(args[0]) && /Footer/.test(args[3])) {
     // XXX Silent false-positive warning (server doesn't render that part because it can't on server when using SSG, perfectly normal and not an actual issue)

--- a/src/utils/nextjs/SSG.ts
+++ b/src/utils/nextjs/SSG.ts
@@ -36,6 +36,7 @@ export const getCommonStaticPaths: GetStaticPaths<StaticParams> = async (): Prom
   // TODO Make your own implementation.
   // XXX Having this as separate function helps making your own pages without affecting existing examples under "pages/[locale]/examples".
   //  For instance, you may want to replace the GraphQL query by your own API query, while keeping the existing example pages working.
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   return getExamplesCommonStaticPaths();
 };
 
@@ -59,6 +60,7 @@ export const getCommonStaticProps: GetStaticProps<SSGPageProps, StaticParams> = 
   // TODO Make your own implementation.
   // XXX Having this as separate function helps making your own pages without affecting existing examples under "pages/[locale]/examples".
   //  For instance, you may want to replace the GraphQL query by your own API query, while keeping the existing example pages working.
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   return getExamplesCommonStaticProps(props);
 };
 

--- a/src/utils/nextjs/SSG.ts
+++ b/src/utils/nextjs/SSG.ts
@@ -20,6 +20,27 @@ import { fetchTranslations, I18nextResources } from '../i18n/i18nextLocize';
 
 /**
  * Only executed on the server side at build time.
+ * Computes all static paths that should be available for all SSG pages
+ * Necessary when a page has dynamic routes and uses "getStaticProps", in order to build the HTML pages
+ *
+ * You can use "fallback" option to avoid building all page variants and allow runtime fallback
+ *
+ * Meant to avoid code duplication
+ * Can be overridden for per-page customisation (e.g: deepmerge)
+ *
+ * @return
+ *
+ * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation
+ */
+export const getCommonStaticPaths: GetStaticPaths<StaticParams> = async (): Promise<StaticPathsOutput> => {
+  // TODO Make your own implementation.
+  // XXX Having this as separate function helps making your own pages without affecting existing examples under "pages/[locale]/examples".
+  //  For instance, you may want to replace the GraphQL query by your own API query, while keeping the existing example pages working.
+  return getExamplesCommonStaticPaths();
+};
+
+/**
+ * Only executed on the server side at build time.
  * Computes all static props that should be available for all SSG pages
  *
  * Note that when a page uses "getStaticProps", then "_app:getInitialProps" is executed (if defined) but not actually used by the page,
@@ -35,6 +56,64 @@ import { fetchTranslations, I18nextResources } from '../i18n/i18nextLocize';
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getCommonStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {
+  // TODO Make your own implementation.
+  // XXX Having this as separate function helps making your own pages without affecting existing examples under "pages/[locale]/examples".
+  //  For instance, you may want to replace the GraphQL query by your own API query, while keeping the existing example pages working.
+  return getExamplesCommonStaticProps(props);
+};
+
+/**
+ * XXX This method is meant for people creating their own project based on NRN.
+ *  It's meant to be deleted eventually when you don't need to keep the examples around.
+ *
+ * Only executed on the server side at build time.
+ * Computes all static paths that should be available for all SSG pages
+ * Necessary when a page has dynamic routes and uses "getStaticProps", in order to build the HTML pages
+ *
+ * You can use "fallback" option to avoid building all page variants and allow runtime fallback
+ *
+ * Meant to avoid code duplication
+ * Can be overridden for per-page customisation (e.g: deepmerge)
+ *
+ * @return
+ *
+ * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation
+ */
+export const getExamplesCommonStaticPaths: GetStaticPaths<StaticParams> = async (): Promise<StaticPathsOutput> => {
+  const paths: StaticPath[] = map(supportedLocales, (supportedLocale: I18nLocale): StaticPath => {
+    return {
+      params: {
+        locale: supportedLocale.name,
+      },
+    };
+  });
+
+  return {
+    fallback: false,
+    paths,
+  };
+};
+
+/**
+ * XXX This method is meant for people creating their own project based on NRN.
+ *  It's meant to be deleted eventually when you don't need to keep the examples around.
+ *
+ * Only executed on the server side at build time.
+ * Computes all static props that should be available for all SSG pages
+ *
+ * Note that when a page uses "getStaticProps", then "_app:getInitialProps" is executed (if defined) but not actually used by the page,
+ * only the results from getStaticProps are actually injected into the page (as "SSGPageProps").
+ *
+ * Meant to avoid code duplication
+ * Can be overridden for per-page customisation (e.g: deepmerge)
+ *
+ * @param props
+ * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
+ *
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
+ * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
+ */
+export const getExamplesCommonStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {
   const customerRef: string = process.env.NEXT_PUBLIC_CUSTOMER_REF;
   const preview: boolean = props?.preview || false;
   const previewData: PreviewData = props?.previewData || null;
@@ -99,31 +178,3 @@ export const getCommonStaticProps: GetStaticProps<SSGPageProps, StaticParams> = 
   };
 };
 
-/**
- * Only executed on the server side at build time.
- * Computes all static paths that should be available for all SSG pages
- * Necessary when a page has dynamic routes and uses "getStaticProps", in order to build the HTML pages
- *
- * You can use "fallback" option to avoid building all page variants and allow runtime fallback
- *
- * Meant to avoid code duplication
- * Can be overridden for per-page customisation (e.g: deepmerge)
- *
- * @return
- *
- * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation
- */
-export const getCommonStaticPaths: GetStaticPaths<StaticParams> = async (): Promise<StaticPathsOutput> => {
-  const paths: StaticPath[] = map(supportedLocales, (supportedLocale: I18nLocale): StaticPath => {
-    return {
-      params: {
-        locale: supportedLocale.name,
-      },
-    };
-  });
-
-  return {
-    fallback: false,
-    paths,
-  };
-};

--- a/src/utils/nextjs/SSG.ts
+++ b/src/utils/nextjs/SSG.ts
@@ -31,7 +31,7 @@ import { fetchTranslations, I18nextResources } from '../i18n/i18nextLocize';
  * @param props
  * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
  *
- * @see https://github.com/zeit/next.js/discussions/10949#discussioncomment-6884
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
  * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
  */
 export const getCommonStaticProps: GetStaticProps<SSGPageProps, StaticParams> = async (props: StaticPropsInput): Promise<StaticPropsOutput> => {

--- a/src/utils/nextjs/SSR.ts
+++ b/src/utils/nextjs/SSR.ts
@@ -4,20 +4,20 @@ import { IncomingMessage } from 'http';
 import get from 'lodash.get';
 import NextCookies from 'next-cookies';
 import { LAYOUT_QUERY } from '../../gql/common/layoutQuery';
-import { ApolloQueryOptions } from '../../types/gql/ApolloQueryOptions';
 import { Cookies } from '../../types/Cookies';
+import { ApolloQueryOptions } from '../../types/gql/ApolloQueryOptions';
 import { GetServerSidePropsContext } from '../../types/nextjs/GetServerSidePropsContext';
 import { PublicHeaders } from '../../types/pageProps/PublicHeaders';
 import { SSRPageProps } from '../../types/pageProps/SSRPageProps';
 import { UserSemiPersistentSession } from '../../types/UserSemiPersistentSession';
+import UniversalCookiesManager from '../cookies/UniversalCookiesManager';
 import { prepareGraphCMSLocaleHeader } from '../gql/graphcms';
 import { createApolloClient } from '../gql/graphql';
 import { DEFAULT_LOCALE, resolveFallbackLanguage } from '../i18n/i18n';
 import { fetchTranslations, I18nextResources } from '../i18n/i18nextLocize';
-import UniversalCookiesManager from '../cookies/UniversalCookiesManager';
 
 /**
- * getCommonServerSideProps returns only part of the props expected in SSRPageProps
+ * getExamplesCommonServerSideProps returns only part of the props expected in SSRPageProps
  * To avoid TS issue, we omit those that we don't return, and add those necessary to the getServerSideProps function
  */
 export type GetCommonServerSidePropsResults = Omit<SSRPageProps, 'apolloState' | 'customer'> & {
@@ -40,6 +40,27 @@ export type GetCommonServerSidePropsResults = Omit<SSRPageProps, 'apolloState' |
  * @see https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
  */
 export const getCommonServerSideProps = async (context: GetServerSidePropsContext): Promise<GetCommonServerSidePropsResults> => {
+  // TODO Make your own implementation.
+  // XXX Having this as separate function helps making your own pages without affecting existing examples under "pages/[locale]/examples".
+  //  For instance, you may want to replace the GraphQL query by your own API query, while keeping the existing example pages working.
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  return getExamplesCommonServerSideProps(context);
+};
+
+/**
+ * Only executed on the server side, for every request.
+ * Computes some dynamic props that should be available for all SSR pages that use getServerSideProps
+ *
+ * Because the exact GQL query will depend on the consumer (AKA "caller"), this helper doesn't run any query by itself, but rather return all necessary props to allow the consumer to perform its own queries
+ * This improves performances, by only running one GQL query instead of many (consumer's choice)
+ *
+ * Meant to avoid code duplication
+ *
+ * @param context
+ *
+ * @see https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
+ */
+export const getExamplesCommonServerSideProps = async (context: GetServerSidePropsContext): Promise<GetCommonServerSidePropsResults> => {
   const {
     query,
     params,


### PR DESCRIPTION
- Make it simpler to extend/customise the boilerplate without breaking existing Example pages
- Rename Zeit to Vercel
- Add missing Examples dropdown links
- Use `preload` to improve perfs when loading fonts
  - This may not work perfectly right, see https://github.com/GoogleChrome/lighthouse/issues/10892
- Ditched fonts except for WOFF/WOFF2
- Fix security issue with `ExternalLink` component
- Use `font-display: swap` to avoid page blink