### PR TITLE
Avoid GHA failure when too many commits are pushed (moving HEAD was leading to comment failure)

### DIFF
--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Finding Pull Request ID
         uses: jwalton/gh-find-current-pr@v1
         id: pr_id_finder
-        if: always() # We want to get the PR ID, even when it fails.
+        if: always() # It forces the job to be always executed, even if a previous job fail.
         with:
           github-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
 
@@ -151,7 +151,7 @@ jobs:
       - name: Finding Pull Request ID
         uses: jwalton/gh-find-current-pr@v1
         id: pr_id_finder
-        if: always() # We want to get the PR ID, even when it fails.
+        if: always() # It forces the job to be always executed, even if a previous job fail.
         with:
           github-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -77,9 +77,15 @@ jobs:
       - name: Comment PR (Deployment failure)
         uses: github-actions-up-and-running/pr-comment@v1.0.0
         if: failure()
+        env:
+          PR_ID: ${{ steps.pr_id_finder.outputs.number }}
         with:
-          repo-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
-          message: "[GitHub Actions]\nDeployment FAILED\n\t Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }} (click to see logs)"
+          token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          issue-number: ${{ steps.pr_id_finder.outputs.number }}
+          body: |
+            [GitHub Actions]
+            \tDeployment **FAILED**
+            \tCommit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }} ([click to see logs](https://github.com/UnlyEd/next-right-now/pull/$PR_ID/checks))"
 
       # On deployment success, add a comment to the PR
       - name: Comment PR (Deployment success)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -148,20 +148,36 @@ jobs:
           name: videos
           path: cypress/videos/
 
+      # We need to find the PR id to be able to comment it.
+      # It avoids, on many push at the same time, issues about the pull request (HEAD moving).
+      - name: Finding Pull Request ID
+        uses: jwalton/gh-find-current-pr@v1
+        id: pr_id_finder
+        if: always() # We want to get the PR ID, even when it fails.
+        with:
+          github-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+
       # On E2E failure, add a comment to the PR with additional information
       - name: Comment PR (E2E failure)
-        uses: unsplash/comment-on-pr@master
+        uses: peter-evans/create-or-update-comment@v1
         if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_CI_PR_COMMENT }}
         with:
-          msg: "[GitHub Actions]\nE2E tests FAILED\n  Download artifacts (screenshots + videos) from `checks` section at the top"
+          token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          issue-number: ${{ steps.pr_id_finder.outputs.number }}
+          body: |
+            [GitHub Actions]
+            E2E tests **FAILED**
+            Download artifacts (screenshots + videos) from `checks` section at the top
 
       # On E2E success, add a comment to the PR
       - name: Comment PR (E2E success)
-        uses: unsplash/comment-on-pr@master
+        uses: peter-evans/create-or-update-comment@v1
         if: success()
+        with:
+          token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          issue-number: ${{ steps.pr_id_finder.outputs.number }}
+          body: |
+            [GitHub Actions]
+            E2E tests **SUCCESS**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_CI_PR_COMMENT }}
-        with:
-          msg: "[GitHub Actions]\nE2E tests SUCCESS"

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           msg: "[GitHub Actions]\nDeployment SUCCESS\n\t Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}\n\tDeployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}"
 
+
   # Runs E2E tests against the Zeit deployment
   run-2e2-tests:
     name: Run end to end (E2E) tests (Ubuntu 18.04)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Finding Pull Request ID
         uses: jwalton/gh-find-current-pr@v1
         id: pr_id_finder
+        if: always() # We want to get the PR ID, even when it fails.
         with:
           github-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -167,7 +167,7 @@ jobs:
           body: |
             [GitHub Actions]
             E2E tests **FAILED**
-            Download artifacts (screenshots + videos) from `checks` section at the top
+            Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks) section
 
       # On E2E success, add a comment to the PR
       - name: Comment PR (E2E success)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -84,7 +84,6 @@ jobs:
         with:
           msg: "[GitHub Actions]\nDeployment SUCCESS\n\t Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}\n\tDeployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}"
 
-
   # Runs E2E tests against the Zeit deployment
   run-2e2-tests:
     name: Run end to end (E2E) tests (Ubuntu 18.04)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -62,7 +62,6 @@ jobs:
           echo "::set-env name=ZEIT_DEPLOYMENT_ALIAS::https://$ZEIT_DEPLOYMENT_ALIAS"
 
           npx now alias $ZEIT_DEPLOYMENT_URL https://$ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN
-          exit 1
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to worker

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -83,6 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_CI_PR_COMMENT }}
         with:
           msg: "[GitHub Actions]\nDeployment SUCCESS\n\t Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}\n\tDeployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}"
+          check_for_duplicate_msg: true
 
   # Runs E2E tests against the Zeit deployment
   run-2e2-tests:

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -62,11 +62,13 @@ jobs:
           echo "::set-env name=ZEIT_DEPLOYMENT_ALIAS::https://$ZEIT_DEPLOYMENT_ALIAS"
 
           npx now alias $ZEIT_DEPLOYMENT_URL https://$ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN
+          exit 1
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to worker
 
-      # We need to find the PR id to be able to comment it
+      # We need to find the PR id to be able to comment it.
+      # It avoids, on many push at the same time, issues about the pull request (HEAD moving).
       - name: Finding Pull Request ID
         uses: jwalton/gh-find-current-pr@v1
         id: pr_id_finder
@@ -84,8 +86,8 @@ jobs:
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             [GitHub Actions]
-            \tDeployment **FAILED**
-            \tCommit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }} ([click to see logs](https://github.com/UnlyEd/next-right-now/pull/$PR_ID/checks))"
+            Deployment **FAILED**
+            Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }} ([click to see logs](https://github.com/UnlyEd/next-right-now/pull/$PR_ID/checks))"
 
       # On deployment success, add a comment to the PR
       - name: Comment PR (Deployment success)
@@ -96,9 +98,9 @@ jobs:
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             [GitHub Actions]
-            \tDeployment **SUCCESS**
-            \tCommit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}
-            \tDeployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}
+            Deployment **SUCCESS**
+            Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}
+            Deployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}
 
   # Runs E2E tests against the Zeit deployment
   run-2e2-tests:

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -80,15 +80,13 @@ jobs:
       - name: Comment PR (Deployment failure)
         uses: github-actions-up-and-running/pr-comment@v1.0.0
         if: failure()
-        env:
-          PR_ID: ${{ steps.pr_id_finder.outputs.number }}
         with:
           token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             [GitHub Actions]
             Deployment **FAILED**
-            Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }} ([click to see logs](https://github.com/UnlyEd/next-right-now/pull/$PR_ID/checks))"
+            Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }} ([click to see logs](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks))"
 
       # On deployment success, add a comment to the PR
       - name: Comment PR (Deployment success)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -68,12 +68,11 @@ jobs:
 
       # On deployment failure, add a comment to the PR
       - name: Comment PR (Deployment failure)
-        uses: unsplash/comment-on-pr@master
+        uses: github-actions-up-and-running/pr-comment@v1.0.0
         if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_CI_PR_COMMENT }}
         with:
-          msg: "[GitHub Actions]\nDeployment FAILED\n\t Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }} (click to see logs)"
+          repo-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          message: "[GitHub Actions]\nDeployment FAILED\n\t Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }} (click to see logs)"
 
       # On deployment success, add a comment to the PR
       - name: Comment PR (Deployment success)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -66,6 +66,11 @@ jobs:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to worker
 
+      # We need to find the PR id to be able to comment it
+      - name: Find Pull Request ID
+        id: pr_id_finder
+        run: jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH"
+
       # On deployment failure, add a comment to the PR
       - name: Comment PR (Deployment failure)
         uses: github-actions-up-and-running/pr-comment@v1.0.0
@@ -80,6 +85,7 @@ jobs:
         if: success()
         with:
           token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          issue-number: ${{ steps.pr_id_finder.outputs }}
           body: |
             [GitHub Actions]
             Deployment **SUCCESS**

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -77,13 +77,11 @@ jobs:
 
       # On deployment success, add a comment to the PR
       - name: Comment PR (Deployment success)
-        uses: unsplash/comment-on-pr@master
+        uses: github-actions-up-and-running/pr-comment@v1.0.0
         if: success()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_CI_PR_COMMENT }}
         with:
-          msg: "[GitHub Actions]\nDeployment SUCCESS\n\t Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}\n\tDeployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}"
-          check_for_duplicate_msg: true
+          repo-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          message: "[GitHub Actions]\nDeployment SUCCESS\n\t Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}\n\tDeployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}"
 
   # Runs E2E tests against the Zeit deployment
   run-2e2-tests:

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -66,8 +66,7 @@ jobs:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to worker
 
-      # We need to find the PR id to be able to comment it.
-      # It avoids, on many push at the same time, issues about the pull request (HEAD moving).
+      # We need to find the PR id. Will be used later to comment on that PR.
       - name: Finding Pull Request ID
         uses: jwalton/gh-find-current-pr@v1
         id: pr_id_finder
@@ -148,8 +147,7 @@ jobs:
           name: videos
           path: cypress/videos/
 
-      # We need to find the PR id to be able to comment it.
-      # It avoids, on many push at the same time, issues about the pull request (HEAD moving).
+      # We need to find the PR id. Will be used later to comment on that PR.
       - name: Finding Pull Request ID
         uses: jwalton/gh-find-current-pr@v1
         id: pr_id_finder

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -78,7 +78,7 @@ jobs:
 
       # On deployment failure, add a comment to the PR
       - name: Comment PR (Deployment failure)
-        uses: github-actions-up-and-running/pr-comment@v1.0.0
+        uses: peter-evans/create-or-update-comment@v1
         if: failure()
         with:
           token: ${{ secrets.GITHUB_CI_PR_COMMENT }}

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -90,9 +90,9 @@ jobs:
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             [GitHub Actions]
-            Deployment **SUCCESS**
-              Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}
-              Deployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}
+            \tDeployment **SUCCESS**
+            \tCommit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}
+            \tDeployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}
 
   # Runs E2E tests against the Zeit deployment
   run-2e2-tests:

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -76,11 +76,15 @@ jobs:
 
       # On deployment success, add a comment to the PR
       - name: Comment PR (Deployment success)
-        uses: github-actions-up-and-running/pr-comment@v1.0.0
+        uses: peter-evans/create-or-update-comment@v1
         if: success()
         with:
-          repo-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
-          message: "[GitHub Actions]\nDeployment SUCCESS\n\t Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}\n\tDeployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}"
+          token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          body: |
+            [GitHub Actions]
+            Deployment **SUCCESS**
+              Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}
+              Deployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}
 
   # Runs E2E tests against the Zeit deployment
   run-2e2-tests:

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -68,8 +68,10 @@ jobs:
 
       # We need to find the PR id to be able to comment it
       - name: Finding Pull Request ID
+        uses: jwalton/gh-find-current-pr@v1
         id: pr_id_finder
-        run: echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }' # Found it here: https://github.com/actions/checkout/issues/58
+        with:
+          github-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
 
       # On deployment failure, add a comment to the PR
       - name: Comment PR (Deployment failure)
@@ -85,7 +87,7 @@ jobs:
         if: success()
         with:
           token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
-          issue-number: ${{ steps.pr_id_finder.outputs }}
+          issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             [GitHub Actions]
             Deployment **SUCCESS**

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -67,9 +67,9 @@ jobs:
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to worker
 
       # We need to find the PR id to be able to comment it
-      - name: Find Pull Request ID
+      - name: Finding Pull Request ID
         id: pr_id_finder
-        run: jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH"
+        run: echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }' # Found it here: https://github.com/actions/checkout/issues/58
 
       # On deployment failure, add a comment to the PR
       - name: Comment PR (Deployment failure)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -86,7 +86,8 @@ jobs:
           body: |
             [GitHub Actions]
             Deployment **FAILED**
-            Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }} ([click to see logs](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks))"
+            Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }}
+            [click to see logs](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks)
 
       # On deployment success, add a comment to the PR
       - name: Comment PR (Deployment success)


### PR DESCRIPTION
Sometimes when we pushed few commits in the same time, the job commenting the pull request fails because it cannot find a PR at HEAD.
We are using another action to comment, it uses an ID to comment; it's not based on the commit SHA.

In order to do that, we:

- Find the ID by using an action (job always executed)
- Comment the PR with the text

Something unexpected: we can put a link redirecting to the logs, making the review faster.