### PR TITLE
Code Climate test coverage integration using GitHub Actions

### DIFF
--- a/.github/workflows/update-codeclimate-coverage.yml
+++ b/.github/workflows/update-codeclimate-coverage.yml
@@ -2,7 +2,7 @@
 # Run Unit and coverage tests, then upload it to Code Climate dashboard
 # Read ./README.md for extensive documentation
 
-name: Update Code Climate Coverage
+name: Update Code Climate test coverage
 
 on:
   push:
@@ -10,6 +10,8 @@ on:
       - 'v2-mst-aptd-gcms-lcz-sty' # Change this branch name by your "main" branch use
 
 jobs:
+  # Configures the deployment environment, install dependencies (like node, npm, etc.) that are requirements for the upcoming jobs
+  # Ex: Necessary to run `yarn test:coverage`
   setup-environment:
     name: Setup deployment environment (Ubuntu 18.04 - Node 12.x)
     runs-on: ubuntu-18.04
@@ -19,7 +21,7 @@ jobs:
         with:
           node-version: '12.x' # Use the same node.js version as the one Zeit's uses (currently node12.x)
   run-tests-coverage:
-    name: Run tests coverage
+    name: Run tests coverage and send report to Code Climate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -27,6 +29,6 @@ jobs:
         run: yarn install
       - uses: paambaati/codeclimate-action@v2.6.0
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }} # Fill this secret to make it works for you.
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }} # XXX Define this secret in "Github repo > Settings > Secrets", you can get it from Code Climate in "Repo settings > Test coverage".
         with:
           coverageCommand: yarn test:coverage

--- a/.github/workflows/update-codeclimate-coverage.yml
+++ b/.github/workflows/update-codeclimate-coverage.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-node@v1 # Used to install node environment - XXX https://github.com/actions/setup-node
         with:
           node-version: '12.x' # Use the same node.js version as the one Zeit's uses (currently node12.x)
+      - name: Installing dependencies
+        run: yarn install
   run-tests-coverage:
     name: Run tests coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/update-codeclimate-coverage.yml
+++ b/.github/workflows/update-codeclimate-coverage.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - 'v2-mst-aptd-gcms-lcz-sty' # Change this branch name by your "main" branch use
+      - 'CodeClimate-integration'
 
 jobs:
   run-tests-coverage:

--- a/.github/workflows/update-codeclimate-coverage.yml
+++ b/.github/workflows/update-codeclimate-coverage.yml
@@ -19,13 +19,13 @@ jobs:
         uses: actions/setup-node@v1 # Used to install node environment - XXX https://github.com/actions/setup-node
         with:
           node-version: '12.x' # Use the same node.js version as the one Zeit's uses (currently node12.x)
-      - name: Installing dependencies
-        run: yarn install
   run-tests-coverage:
     name: Run tests coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Installing dependencies
+        run: yarn install
       - uses: paambaati/codeclimate-action@v2.6.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }} # Fill this secret to make it works for you.

--- a/.github/workflows/update-codeclimate-coverage.yml
+++ b/.github/workflows/update-codeclimate-coverage.yml
@@ -11,19 +11,21 @@ on:
       - 'CodeClimate-integration'
 
 jobs:
+  setup-environment:
+    name: Setup deployment environment (Ubuntu 18.04 - Node 12.x)
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Installing node.js
+        uses: actions/setup-node@v1 # Used to install node environment - XXX https://github.com/actions/setup-node
+        with:
+          node-version: '12.x' # Use the same node.js version as the one Zeit's uses (currently node12.x)
   run-tests-coverage:
     name: Run tests coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@master
-        with:
-          node-version: '12.x'
-      - run: npm install -g yarn
-      - run: yarn install
+      - uses: actions/checkout@v1
       - uses: paambaati/codeclimate-action@v2.6.0
         env:
-          CC_TEST_REPORTER_ID: 1977a1d86aebb0b8ad0fde9af8f081c5703d7320763258db0031142a0e196d76
-          #CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }} # Fill this secret to make it works for you.
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }} # Fill this secret to make it works for you.
         with:
           coverageCommand: yarn test:coverage

--- a/.github/workflows/update-codeclimate-coverage.yml
+++ b/.github/workflows/update-codeclimate-coverage.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - 'v2-mst-aptd-gcms-lcz-sty'
-      - 'CC-integration'
+      - 'CodeClimate-integration'
 
 jobs:
   run-tests-coverage:

--- a/.github/workflows/update-codeclimate-coverage.yml
+++ b/.github/workflows/update-codeclimate-coverage.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - 'v2-mst-aptd-gcms-lcz-sty'
-      - 'CodeClimate-integration'
 
 jobs:
   run-tests-coverage:
@@ -21,7 +20,6 @@ jobs:
           node-version: '12.x'
       - run: npm install -g yarn
       - run: yarn install
-      - run: yarn build
       - uses: paambaati/codeclimate-action@v2.6.0
         env:
           CC_TEST_REPORTER_ID: 1977a1d86aebb0b8ad0fde9af8f081c5703d7320763258db0031142a0e196d76

--- a/.github/workflows/update-codeclimate-coverage.yml
+++ b/.github/workflows/update-codeclimate-coverage.yml
@@ -7,7 +7,7 @@ name: Update Code Climate Coverage
 on:
   push:
     branches:
-      - 'v2-mst-aptd-gcms-lcz-sty'
+      - 'v2-mst-aptd-gcms-lcz-sty' # Change this branch name by your "main" branch use
 
 jobs:
   run-tests-coverage:
@@ -23,5 +23,6 @@ jobs:
       - uses: paambaati/codeclimate-action@v2.6.0
         env:
           CC_TEST_REPORTER_ID: 1977a1d86aebb0b8ad0fde9af8f081c5703d7320763258db0031142a0e196d76
+          #CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }} # Fill this secret to make it works for you.
         with:
           coverageCommand: yarn test:coverage

--- a/.github/workflows/update-codeclimate-coverage.yml
+++ b/.github/workflows/update-codeclimate-coverage.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - 'v2-mst-aptd-gcms-lcz-sty' # Change this branch name by your "main" branch use
-      - 'CodeClimate-integration'
 
 jobs:
   setup-environment:

--- a/.github/workflows/update-codeclimate-coverage.yml
+++ b/.github/workflows/update-codeclimate-coverage.yml
@@ -1,0 +1,29 @@
+# Summary:
+# Run Unit and coverage tests, then upload it to Code Climate dashboard
+# Read ./README.md for extensive documentation
+
+name: Update Code Climate Coverage
+
+on:
+  push:
+    branches:
+      - 'v2-mst-aptd-gcms-lcz-sty'
+      - 'CC-integration'
+
+jobs:
+  run-tests-coverage:
+    name: Run tests coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: '12.x'
+      - run: npm install -g yarn
+      - run: yarn install
+      - run: yarn build
+      - uses: paambaati/codeclimate-action@v2.6.0
+        env:
+          CC_TEST_REPORTER_ID: 1977a1d86aebb0b8ad0fde9af8f081c5703d7320763258db0031142a0e196d76
+        with:
+          coverageCommand: yarn test:coverage


### PR DESCRIPTION
Goal: Add CC test coverage integration using Github Actions

Done in a separate GHA file so that it doesn't affect other actions. (and because the "default" CC branch may not be the "master" branch, so better keep them separated.

Also, this is really a nice-to-have, so we wouldn't want to it to crash a deployment (tests are already being executed by Vercel when deploying)
