### PR TITLE
CI - Automatically run LightHouse (on PR commits)

### DIFF
--- a/.github/workflows/deploy-zeit-production.yml
+++ b/.github/workflows/deploy-zeit-production.yml
@@ -79,3 +79,56 @@ jobs:
         with:
           name: videos
           path: cypress/videos/
+
+  # Run Lighthouse reports in parallel of E2E tests
+  run-lighthouse-tests:
+    name: Run LightHouse checks (Ubuntu 18.04)
+    runs-on: ubuntu-18.04
+    needs: start-production-deployment
+    steps:
+      - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
+      - name: Resolving deployment url from Zeit
+        # The following workflow is:
+        #  - getting all deployments data (by using the scope in `now.json`)
+        #  - then we get the last url (in Node.js it corresponds as `response.deployments[0].url`
+        #  - and then we remove the `"` character to pre-format url
+        # We need to set env the url for next step, formatted as `https://${url provided by API}`
+        run: |
+          apt update -y >/dev/null && apt install -y jq >/dev/null
+          ZEIT_DEPLOYMENT=`curl -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'Authorization: Bearer ${{ secrets.ZEIT_TOKEN }}' https://api.zeit.co/v5/now/deployments?teamId=$(cat now.json | jq -r '.scope') | jq '.deployments [0].url' | tr -d \"`
+          echo "::set-env name=ZEIT_DEPLOYMENT_URL::https://$ZEIT_DEPLOYMENT"
+        env:
+          ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
+      # In order to store reports and then upload it, we need to create the folder before any tests
+      - name: Create temporary folder for artifacts storage
+        run: mkdir /tmp/lighthouse-artifacts
+
+      # It runs the lighthouse report for a provided url and create a HTML report in the specified directory
+      # Action documentation: https://github.com/marketplace/actions/lighthouse-check#usage-standard-example
+      - name: Run Lighthouse
+        uses: foo-software/lighthouse-check-action@v1.0.14
+        id: lighthouseCheck
+        with:
+          outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
+          urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
+
+      # Upload HTML report create by lighthouse, could be useful
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: Lighthouse reports
+          path: /tmp/lighthouse-artifacts
+
+      # Using a pre-build action to make the action fail if your score is too low. It can be really interesting to track a low score on a commit
+      # You can remove this action IF you don't want lighthouse to be a blocking point in your CI
+      # This default values so you need to change them by your own criteria
+      # Official documentation: https://github.com/foo-software/lighthouse-check-status-action
+      - name: Handle Lighthouse Check results
+        uses: foo-software/lighthouse-check-status-action@v1.0.1
+        with:
+          lighthouseCheckResults: ${{ steps.lighthouseCheck.outputs.lighthouseCheckResults }}
+          minAccessibilityScore: "50"
+          minBestPracticesScore: "50"
+          minPerformanceScore: "30"
+          minProgressiveWebAppScore: "50"
+          minSeoScore: "50"

--- a/.github/workflows/deploy-zeit-production.yml
+++ b/.github/workflows/deploy-zeit-production.yml
@@ -5,6 +5,10 @@
 name: Deploy to Zeit (production)
 
 on:
+  # There are several ways to trigger Github actions - See https://help.github.com/en/actions/reference/events-that-trigger-workflows#example-using-a-single-event for a comprehensive list:
+  # "push": Triggers each time a commit is pushed
+  # "pull_request": Triggers each time a commit is pushed within a pull request
+  # In production, we use the "push" trigger, because we want to deploy whether any pushed commit, whether it belongs to a PR.
   push:
     branches:
       - 'master'
@@ -31,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
       - name: Deploying on Zeit
+        # Workflow:
+        # Deploy the customer in production
         run: yarn deploy:$(cat now.json | jq -r '.build.env.NEXT_PUBLIC_CUSTOMER_REF'):production --token $ZEIT_TOKEN
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
@@ -108,7 +114,7 @@ jobs:
       - name: Run Lighthouse
         uses: foo-software/lighthouse-check-action@v1.0.14
         id: lighthouseCheck
-        with:
+        with: # See https://github.com/marketplace/actions/lighthouse-check#inputs for all options
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -210,8 +210,8 @@ jobs:
         id: lighthouseCheck
         with:
           accessToken: ${{ secrets.GITHUB_CI_PR_COMMENT }} # Providing a token to comment the PR.
-          prCommentEnabled: true # If we want for this action to comment or not (default: true).
-          prCommentSaveOld: false # Comment each time with another comment, instead of update the last one (default: false).
+          #prCommentEnabled: true # If we want for this action to comment or not (default: true).
+          #prCommentSaveOld: false # Comment each time with another comment, instead of update the last one (default: false).
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -209,11 +209,11 @@ jobs:
         uses: foo-software/lighthouse-check-action@v1.0.14
         id: lighthouseCheck
         with:
-          urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
-          outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           accessToken: ${{ secrets.GITHUB_CI_PR_COMMENT }} # Providing a token to comment the PR.
-          prCommentEnabled: true # If we want for this action to comment or not.
+          prCommentEnabled: true # If we want for this action to comment or not (default: true).
           prCommentSaveOld: false # Comment each time with another comment, instead of update the last one (default: false).
+          outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
+          urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
 
       # Upload HTML report create by lighthouse, could be useful
       - name: Upload artifacts

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -5,9 +5,6 @@
 name: Deploy to Zeit (staging)
 
 on:
-  push:
-    branches-ignore:
-      - 'master'
   pull_request:
     branches-ignore:
       - 'master'
@@ -213,8 +210,8 @@ jobs:
         id: lighthouseCheck
         with:
           accessToken: ${{ secrets.GITHUB_CI_PR_COMMENT }} # Providing a token to comment the PR.
-          #prCommentEnabled: true # If we want for this action to comment or not (default: true).
-          #prCommentSaveOld: false # Comment each time with another comment, instead of update the last one (default: false).
+          prCommentEnabled: true # If we want for this action to comment or not (default: true).
+          prCommentSaveOld: true # Comment each time with another comment, instead of update the last one (default: false).
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
 
@@ -232,8 +229,8 @@ jobs:
         uses: foo-software/lighthouse-check-status-action@v1.0.1
         with:
           lighthouseCheckResults: ${{ steps.lighthouseCheck.outputs.lighthouseCheckResults }}
-          minAccessibilityScore: "90"
-          minBestPracticesScore: "50"
-          minPerformanceScore: "50"
-          minProgressiveWebAppScore: "50"
-          minSeoScore: "50"
+          minAccessibilityScore: "30"
+          minBestPracticesScore: "30"
+          minPerformanceScore: "30"
+          minProgressiveWebAppScore: "30"
+          minSeoScore: "30"

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -4,6 +4,11 @@
 
 name: Deploy to Zeit (staging)
 
+# There are many ways to trigger actions:
+# "push": will be trigger each time a commit is made. It can useful for CI (unit tests).
+# "pull_request": will be trigger each time a commit is made IN a pull request. By this way, we are sure to deal with a PR.
+# We are using the pull_request trigger because we want to fully use the ChatOps communication, making reviews and tracking easier for maintainers.
+
 on:
   pull_request:
     branches-ignore:

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -66,26 +66,18 @@ jobs:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to worker
 
-      # We need to find the PR id. Will be used later to comment on that PR.
-      - name: Finding Pull Request ID
-        uses: jwalton/gh-find-current-pr@v1
-        id: pr_id_finder
-        if: always() # It forces the job to be always executed, even if a previous job fail.
-        with:
-          github-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
-
       # On deployment failure, add a comment to the PR
       - name: Comment PR (Deployment failure)
         uses: peter-evans/create-or-update-comment@v1
         if: failure()
         with:
           token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
-          issue-number: ${{ steps.pr_id_finder.outputs.number }}
+          issue-number: ${{ github.event.number }}
           body: |
             [GitHub Actions]
             Deployment **FAILED**
             Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }}
-            [click to see logs](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks)
+            [click to see logs](https://github.com/UnlyEd/next-right-now/pull/${{ github.event.number }}/checks)
 
       # On deployment success, add a comment to the PR
       - name: Comment PR (Deployment success)
@@ -93,7 +85,7 @@ jobs:
         if: success()
         with:
           token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
-          issue-number: ${{ steps.pr_id_finder.outputs.number }}
+          issue-number: ${{ github.event.number }}
           body: |
             [GitHub Actions]
             Deployment **SUCCESS**
@@ -147,25 +139,17 @@ jobs:
           name: videos
           path: cypress/videos/
 
-      # We need to find the PR id. Will be used later to comment on that PR.
-      - name: Finding Pull Request ID
-        uses: jwalton/gh-find-current-pr@v1
-        id: pr_id_finder
-        if: always() # It forces the job to be always executed, even if a previous job fail.
-        with:
-          github-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
-
       # On E2E failure, add a comment to the PR with additional information
       - name: Comment PR (E2E failure)
         uses: peter-evans/create-or-update-comment@v1
         if: failure()
         with:
           token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
-          issue-number: ${{ steps.pr_id_finder.outputs.number }}
+          issue-number: ${{ github.event.number }}
           body: |
             [GitHub Actions]
             E2E tests **FAILED**
-            Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks) section
+            Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ github.event.number }}/checks) section
 
       # On E2E success, add a comment to the PR
       - name: Comment PR (E2E success)
@@ -173,7 +157,7 @@ jobs:
         if: success()
         with:
           token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
-          issue-number: ${{ steps.pr_id_finder.outputs.number }}
+          issue-number: ${{ github.event.number }}
           body: |
             [GitHub Actions]
             E2E tests **SUCCESS**

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -184,7 +184,7 @@ jobs:
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
       # In order to store reports and then upload it, we need to create the folder before any tests
-      - name: Create temporary fodler for artifacts storage
+      - name: Create temporary folder for artifacts storage
         run: mkdir /tmp/lighthouse-artifacts
 
       # It runs the lighthouse report for a provided url and create a HTML report in the specified directory
@@ -214,8 +214,8 @@ jobs:
         uses: foo-software/lighthouse-check-status-action@v1.0.1
         with:
           lighthouseCheckResults: ${{ steps.lighthouseCheck.outputs.lighthouseCheckResults }}
-          minAccessibilityScore: "30"
-          minBestPracticesScore: "30"
+          minAccessibilityScore: "50"
+          minBestPracticesScore: "50"
           minPerformanceScore: "30"
-          minProgressiveWebAppScore: "30"
-          minSeoScore: "30"
+          minProgressiveWebAppScore: "50"
+          minSeoScore: "50"

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -179,3 +179,33 @@ jobs:
             E2E tests **SUCCESS**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+
+  run-lighthouse-tests:
+    name: Run LightHouse checks (Ubuntu 18.04)
+    runs-on: ubuntu-18.04
+    needs: start-staging-deployment
+    steps:
+      - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
+      - name: Resolving deployment url from Zeit
+        # The following workflow is:
+        #  - getting all deployments data (by using the scope in `now.json`)
+        #  - then we get the last url (in Node.js it corresponds as `response.deployments[0].url`
+        #  - and then we remove the `"` character to pre-format url
+        # We need to set env the url for next step, formatted as `https://${url provided by API}`
+        run: |
+          apt update -y >/dev/null && apt install -y jq >/dev/null
+          ZEIT_DEPLOYMENT=`curl -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'Authorization: Bearer ${{ secrets.ZEIT_TOKEN }}' https://api.zeit.co/v5/now/deployments?teamId=$(cat now.json | jq -r '.scope') | jq '.deployments [0].url' | tr -d \"`
+          echo "::set-env name=ZEIT_DEPLOYMENT_URL::https://$ZEIT_DEPLOYMENT"
+        env:
+          ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
+      - name: Create temporary fodler for artifacts storage
+        run: mkdir /tmp/lighthouse-artifacts
+      - name: Run Lighthouse
+        uses: foo-software/lighthouse-check-action@master
+        with:
+          urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: Lighthouse reports
+          path: /tmp/lighthouse-artifacts

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -180,6 +180,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_CI_PR_COMMENT }}
 
+  # Run Lighthouse reports in parallel of E2E tests
   run-lighthouse-tests:
     name: Run LightHouse checks (Ubuntu 18.04)
     runs-on: ubuntu-18.04
@@ -198,18 +199,32 @@ jobs:
           echo "::set-env name=ZEIT_DEPLOYMENT_URL::https://$ZEIT_DEPLOYMENT"
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
+      # In order to store reports and then upload it, we need to create the folder before any tests
       - name: Create temporary fodler for artifacts storage
         run: mkdir /tmp/lighthouse-artifacts
+
+      # It runs the lighthouse report for a provided url and create a HTML report in the specified directory
+      # Action documentation: https://github.com/marketplace/actions/lighthouse-check#usage-standard-example
       - name: Run Lighthouse
         uses: foo-software/lighthouse-check-action@v1.0.14
         id: lighthouseCheck
         with:
           urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
+          outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
+          accessToken: ${{ secrets.GITHUB_CI_PR_COMMENT }} # Providing a token to comment the PR.
+          prCommentEnabled: true # If we want for this action to comment or not.
+          prCommentSaveOld: false # Comment each time with another comment, instead of update the last one (default: false).
+
+      # Upload HTML report create by lighthouse, could be useful
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
           name: Lighthouse reports
           path: /tmp/lighthouse-artifacts
+
+      # Using a pre-build action to make the action fail if your score is too low. It can be really interesting to track a low score on a commit
+      # You can remove this action IF you don't want lighthouse to be a blocking point in your CI
+      # This default values so you need to change them by your own criteria
       - name: Handle Lighthouse Check results
         uses: foo-software/lighthouse-check-status-action@v1.0.1
         with:

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -8,7 +8,9 @@ on:
   push:
     branches-ignore:
       - 'master'
-  pull_request
+  pull_request:
+    branches-ignore:
+      - 'master'
 
 jobs:
   # Configures the deployment environment, install dependencies (like node, npm, etc.) that are requirements for the upcoming jobs

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -209,6 +209,7 @@ jobs:
       # Using a pre-build action to make the action fail if your score is too low. It can be really interesting to track a low score on a commit
       # You can remove this action IF you don't want lighthouse to be a blocking point in your CI
       # This default values so you need to change them by your own criteria
+      # Official documentation: https://github.com/foo-software/lighthouse-check-status-action
       - name: Handle Lighthouse Check results
         uses: foo-software/lighthouse-check-status-action@v1.0.1
         with:

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches-ignore:
       - 'master'
+  pull_request
 
 jobs:
   # Configures the deployment environment, install dependencies (like node, npm, etc.) that are requirements for the upcoming jobs

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -117,8 +117,6 @@ jobs:
           apt update -y >/dev/null && apt install -y jq >/dev/null
           ZEIT_DEPLOYMENT=`curl -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'Authorization: Bearer ${{ secrets.ZEIT_TOKEN }}' https://api.zeit.co/v5/now/deployments?teamId=$(cat now.json | jq -r '.scope') | jq '.deployments [0].url' | tr -d \"`
           echo "::set-env name=ZEIT_DEPLOYMENT_URL::https://$ZEIT_DEPLOYMENT"
-        env:
-          ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
 
       # Run the E2E tests against the new Zeit deployment
       - name: Run E2E tests (Cypress)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -4,13 +4,12 @@
 
 name: Deploy to Zeit (staging)
 
-# There are many ways to trigger actions:
-# "push": will be trigger each time a commit is made. It can useful for CI (unit tests).
-# "pull_request": will be trigger each time a commit is made IN a pull request. By this way, we are sure to deal with a PR.
-# We are using the pull_request trigger because we want to fully use the ChatOps communication, making reviews and tracking easier for maintainers.
-
 on:
-  pull_request:
+  # There are several ways to trigger Github actions - See https://help.github.com/en/actions/reference/events-that-trigger-workflows#example-using-a-single-event for a comprehensive list:
+  # "push": Triggers each time a commit is pushed
+  # "pull_request": Triggers each time a commit is pushed within a pull request
+  # In staging, we use the "pull_request" trigger, because it makes it much easier to write comments within the PR.
+  pull_request: # Triggers on each pushed commit associated with a pull request
     branches-ignore:
       - 'master'
 
@@ -37,9 +36,9 @@ jobs:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
       - name: Deploying on Zeit
         # Workflow:
-        #   - Get stdout from deploy command (stderr shows build steps and stdout shows final url, what we are looking for)
-        #   - Set deployment url to show on PR message
-        #   - Create alias and link it
+        #   - Get stdout from deploy command (stderr shows build steps and stdout shows final url, which is what we are really looking for)
+        #   - Set the deployment url that will be included in the eventual PR comment
+        #   - Create a branch alias and link it to the deployment (so that each branch has its own domain automatically aliased to the lastest commit)
         run: |
           ZEIT_DEPLOYMENT_OUTPUT=`yarn deploy:$(cat now.json | jq -r '.build.env.NEXT_PUBLIC_CUSTOMER_REF') --token $ZEIT_TOKEN`
 
@@ -69,7 +68,7 @@ jobs:
           npx now alias $ZEIT_DEPLOYMENT_URL https://$ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
-          CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to worker
+          CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to the worker
 
       # On deployment failure, add a comment to the PR
       - name: Comment PR (Deployment failure)
@@ -195,10 +194,10 @@ jobs:
       - name: Run Lighthouse
         uses: foo-software/lighthouse-check-action@v1.0.14
         id: lighthouseCheck
-        with:
+        with: # See https://github.com/marketplace/actions/lighthouse-check#inputs for all options
           accessToken: ${{ secrets.GITHUB_CI_PR_COMMENT }} # Providing a token to comment the PR.
-          prCommentEnabled: true # If we want for this action to comment or not (default: true).
-          prCommentSaveOld: true # Comment each time with another comment, instead of update the last one (default: false).
+          prCommentEnabled: true # Whether to comment on the PR (default: true).
+          prCommentSaveOld: true # If true, then add a new comment for each commit. Otherwise, update the latest comment (default: false).
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           accessToken: ${{ secrets.GITHUB_CI_PR_COMMENT }} # Providing a token to comment the PR.
           prCommentEnabled: true # If we want for this action to comment or not (default: true).
-          prCommentSaveOld: true # Comment each time with another comment, instead of update the last one (default: false).
+          prCommentSaveOld: false # Comment each time with another comment, instead of update the last one (default: false).
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           accessToken: ${{ secrets.GITHUB_CI_PR_COMMENT }} # Providing a token to comment the PR.
           prCommentEnabled: true # If we want for this action to comment or not (default: true).
-          prCommentSaveOld: false # Comment each time with another comment, instead of update the last one (default: false).
+          prCommentSaveOld: true # Comment each time with another comment, instead of update the last one (default: false).
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -201,11 +201,21 @@ jobs:
       - name: Create temporary fodler for artifacts storage
         run: mkdir /tmp/lighthouse-artifacts
       - name: Run Lighthouse
-        uses: foo-software/lighthouse-check-action@master
+        uses: foo-software/lighthouse-check-action@v1.0.14
+        id: lighthouseCheck
         with:
           urls: ${{ env.ZEIT_DEPLOYMENT_URL }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: Lighthouse reports
           path: /tmp/lighthouse-artifacts
+      - name: Handle Lighthouse Check results
+        uses: foo-software/lighthouse-check-status-action@v1.0.1
+        with:
+          lighthouseCheckResults: ${{ steps.lighthouseCheck.outputs.lighthouseCheckResults }}
+          minAccessibilityScore: "90"
+          minBestPracticesScore: "50"
+          minPerformanceScore: "50"
+          minProgressiveWebAppScore: "50"
+          minSeoScore: "50"


### PR DESCRIPTION
We want to create Lighthouse reports for each commit.
It should:

- Run in parallel with E2E tests
- Display a report
- Upload artifacts
- Make the workflow fail if the score is too low (@Vadorequest I'll need a minimal "critical" score to set :D )

I don't think we should have another PR comment about the Lighthouse reports, another spam. It should be enough to have a job which fail.