### PR TITLE
Fix CI not being run on PR merge

### DIFF
--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -12,6 +12,11 @@ on:
   pull_request: # Triggers on each pushed commit associated with a pull request
     branches-ignore:
       - 'master'
+    types: # We must specify the "closed" event, because it's not applied by default - See https://github.community/t/pull-request-action-does-not-run-on-merge/16092/8?u=vadorequest
+      - opened
+      - reopened
+      - synchronize
+      - closed
 
 jobs:
   # Configures the deployment environment, install dependencies (like node, npm, etc.) that are requirements for the upcoming jobs


### PR DESCRIPTION
**Current behaviour**: 
CI runs when a commit is pushed to a PR. It doesn't run when a branch is merged into another

**Desired behaviour**:
Run CI when a PR is merged into another. (in the target PR, not the origin)