### PR TITLE
Remove unnecessary `GITHUB_CI_PR_COMMENT` and use default `GITHUB_TOKEN` instead (comment as `github-actions`)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,1 @@
+Learn more about [our CI/CD configuration](https://unlyed.github.io/next-right-now/guides/ci-cd/)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -187,13 +187,13 @@ jobs:
         uses: peter-evans/create-or-update-comment@v1
         if: success()
         with:
-          token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             [GitHub Actions]
             E2E tests **SUCCESS**
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Run Lighthouse reports in parallel of E2E tests
   run-lighthouse-tests:
@@ -224,7 +224,7 @@ jobs:
         uses: foo-software/lighthouse-check-action@v1.0.14
         id: lighthouseCheck
         with: # See https://github.com/marketplace/actions/lighthouse-check#inputs for all options
-          #accessToken: ${{ secrets.GITHUB_CI_PR_COMMENT }} # Providing a token to comment the PR if you are using a "pull_request" as trigger.
+          #accessToken: ${{ secrets.GITHUB_TOKEN }} # Providing a token to comment the PR if you are using a "pull_request" as trigger.
           prCommentEnabled: false # Whether to comment on the PR (default: true). Disabled because we use our own "Comment PR (LightHouse report)" action
           prCommentSaveOld: true # If true, then add a new comment for each commit. Otherwise, update the latest comment (default: false).
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
@@ -256,13 +256,13 @@ jobs:
         id: pr_id_finder
         if: always() # It forces the job to be always executed, even if a previous job fail.
         with:
-          github-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Add a comment to the PR with lighthouse report
       - name: Comment PR (LightHouse report)
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           # Report provided by steps.lighthouseCheck.outputs.lighthouseCheckResults is a string and need to be transform into an object.
           # Then, using badges with results provided by `data[0].scores.<category>`

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -89,14 +89,14 @@ jobs:
         id: pr_id_finder
         if: always() # It forces the job to be always executed, even if a previous job fail.
         with:
-          github-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # On deployment failure, add a comment to the PR
       - name: Comment PR (Deployment failure)
         uses: peter-evans/create-or-update-comment@v1
         if: failure()
         with:
-          token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             [GitHub Actions]
@@ -109,7 +109,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v1
         if: success()
         with:
-          token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             [GitHub Actions]
@@ -168,14 +168,14 @@ jobs:
         id: pr_id_finder
         if: always() # It forces the job to be always executed, even if a previous job fail.
         with:
-          github-token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # On E2E failure, add a comment to the PR with additional information
       - name: Comment PR (E2E failure)
         uses: peter-evans/create-or-update-comment@v1
         if: failure()
         with:
-          token: ${{ secrets.GITHUB_CI_PR_COMMENT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             [GitHub Actions]

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -99,7 +99,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
-            :x: Deployment **FAILED**
+            :x:&nbsp; Deployment **FAILED**
             Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }}
             [click to see logs](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks)
 
@@ -111,7 +111,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
-            :white_check_mark: Deployment **SUCCESS**
+            :white_check_mark:&nbsp; Deployment **SUCCESS**
             Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}
             Deployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}
 
@@ -176,7 +176,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
-            :x: E2E tests **FAILED**
+            :x:&nbsp; E2E tests **FAILED**
             Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks) section
 
       # On E2E success, add a comment to the PR
@@ -187,7 +187,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
-            :white_check_mark: E2E tests **SUCCESS**
+            :white_check_mark:&nbsp; E2E tests **SUCCESS**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -265,5 +265,5 @@ jobs:
           # data is an array containing results of every urls tested. Thankfully, we only test one url so we don't care about the index.
           # See "fromJson" documentation: https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#fromjson
           body: |
-            :white_check_mark: **Lighthouse report** for ${{ env.ZEIT_DEPLOYMENT_URL }}
+            :white_check_mark:&nbsp; **Lighthouse report** for ${{ env.ZEIT_DEPLOYMENT_URL }}
             ![](https://img.shields.io/badge/Accessibility-${{ fromJson(steps.lighthouseCheck.outputs.lighthouseCheckResults).data[0].scores.accessibility }}-green?style=flat-square) ![](https://img.shields.io/badge/Best%20Practices-${{ fromJson(steps.lighthouseCheck.outputs.lighthouseCheckResults).data[0].scores.bestPractices }}-green?style=flat-square) ![](https://img.shields.io/badge/Performance-${{ fromJson(steps.lighthouseCheck.outputs.lighthouseCheckResults).data[0].scores.performance }}-orange?style=flat-square) ![](https://img.shields.io/badge/Progressive%20Web%20App-${{ fromJson(steps.lighthouseCheck.outputs.lighthouseCheckResults).data[0].scores.progressiveWebApp }}-orange?style=flat-square) ![](https://img.shields.io/badge/SEO-${{ fromJson(steps.lighthouseCheck.outputs.lighthouseCheckResults).data[0].scores.seo }}-green?style=flat-square)

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -99,8 +99,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
-            [GitHub Actions]
-            Deployment **FAILED**
+            :x: Deployment **FAILED**
             Commit ${{ github.sha }} failed to deploy to ${{ env.ZEIT_DEPLOYMENT_URL }}
             [click to see logs](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks)
 
@@ -112,8 +111,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
-            [GitHub Actions]
-            Deployment **SUCCESS**
+            :white_check_mark: Deployment **SUCCESS**
             Commit ${{ github.sha }} successfully deployed to ${{ env.ZEIT_DEPLOYMENT_URL }}
             Deployment aliased as ${{ env.ZEIT_DEPLOYMENT_ALIAS }}
 
@@ -178,8 +176,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
-            [GitHub Actions]
-            E2E tests **FAILED**
+            :x: E2E tests **FAILED**
             Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks) section
 
       # On E2E success, add a comment to the PR
@@ -190,8 +187,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
-            [GitHub Actions]
-            E2E tests **SUCCESS**
+            :white_check_mark: E2E tests **SUCCESS**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -269,5 +265,5 @@ jobs:
           # data is an array containing results of every urls tested. Thankfully, we only test one url so we don't care about the index.
           # See "fromJson" documentation: https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#fromjson
           body: |
-            [GitHub Actions] - **Lighthouse report** for ${{ env.ZEIT_DEPLOYMENT_URL }}
+            :white_check_mark: **Lighthouse report** for ${{ env.ZEIT_DEPLOYMENT_URL }}
             ![](https://img.shields.io/badge/Accessibility-${{ fromJson(steps.lighthouseCheck.outputs.lighthouseCheckResults).data[0].scores.accessibility }}-green?style=flat-square) ![](https://img.shields.io/badge/Best%20Practices-${{ fromJson(steps.lighthouseCheck.outputs.lighthouseCheckResults).data[0].scores.bestPractices }}-green?style=flat-square) ![](https://img.shields.io/badge/Performance-${{ fromJson(steps.lighthouseCheck.outputs.lighthouseCheckResults).data[0].scores.performance }}-orange?style=flat-square) ![](https://img.shields.io/badge/Progressive%20Web%20App-${{ fromJson(steps.lighthouseCheck.outputs.lighthouseCheckResults).data[0].scores.progressiveWebApp }}-orange?style=flat-square) ![](https://img.shields.io/badge/SEO-${{ fromJson(steps.lighthouseCheck.outputs.lighthouseCheckResults).data[0].scores.seo }}-green?style=flat-square)


### PR DESCRIPTION
@Vadorequest A small PR about changing the way we get the token. In fact, I can only see now that we can do it.