### PR TITLE
Allow custom i18n translations per customer

### DIFF
--- a/src/components/pageLayouts/Nav.tsx
+++ b/src/components/pageLayouts/Nav.tsx
@@ -110,8 +110,17 @@ const Nav: React.FunctionComponent<Props> = () => {
                 }
               }
 
+              .dropdown-menu {
+                z-index: 10000;
+              }
+
               .dropdown-item {
                 max-height: 30px;
+                padding-top: 0;
+
+                .nav-link {
+                  padding: 4px;
+                }
               }
             }
 

--- a/src/pages/[locale]/examples/built-in-features/static-i18n.tsx
+++ b/src/pages/[locale]/examples/built-in-features/static-i18n.tsx
@@ -13,9 +13,11 @@ import DefaultLayout from '../../../../components/pageLayouts/DefaultLayout';
 import DisplayOnBrowserMount from '../../../../components/rehydration/DisplayOnBrowserMount';
 import Code from '../../../../components/utils/Code';
 import ExternalLink from '../../../../components/utils/ExternalLink';
+import useI18n, { I18n } from '../../../../hooks/useI18n';
 import { CommonServerSideParams } from '../../../../types/nextjs/CommonServerSideParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
+import { resolveCustomerVariationLang } from '../../../../utils/i18n/i18n';
 import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
 
 const fileLabel = 'pages/[locale]/examples/built-in-features/static-i18n';
@@ -51,6 +53,7 @@ type Props = {} & SSGPageProps<Partial<OnlyBrowserPageProps>>;
 
 const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
   const { t } = useTranslation();
+  const { lang }: I18n = useI18n();
 
   return (
     <DefaultLayout
@@ -220,6 +223,42 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
                 </Trans>
               `}
             />
+          </div>
+          <hr />
+
+          <div>
+            <Trans
+              i18nKey={'examples.i18n.translationUsingCustomerVariation'}
+            >
+              Cette traduction est spécifique au customer "{{ customerRef: process.env.NEXT_PUBLIC_CUSTOMER_REF }}". <br />
+              Chaque customer peut surcharger ses propres traductions, en créant une clé Locize dans son <code>"{{ customerVariationLang: resolveCustomerVariationLang(lang) }}"</code> langage.<br />
+              Cette traduction va surcharger/remplacer la traduction de base, pour ce customer.<br />
+              <br />
+              Exemple:
+            </Trans>
+            <br />
+            <Code
+              text={`
+                <Trans
+                  i18nKey={'examples.i18n.translationUsingCustomerVariation'}
+                >
+                  Cette traduction est spécifique au customer "{{ customerRef: process.env.NEXT_PUBLIC_CUSTOMER_REF }}". <br />
+                  Chaque customer peut surcharger ses propres traductions, en créant une clé Locize dans son <code>"{{ customerVariationLang: resolveCustomerVariationLang(lang)}}"</code> langage.<br />
+                  Cette traduction va surcharger/remplacer la traduction de base, pour ce customer.<br />
+                  <br />
+                  Exemple:
+                </Trans>
+              `}
+            />
+            <Alert color={'warning'}>
+              This requires you create a new <code>Language</code> in Locize first, for instance: <code>fr-x-customer1</code> and <code>en-x-customer1</code><br />
+              <br />
+              The <code>-x-</code> stands for "variation", it's the official way to create custom language variations that are specific to your business needs, when using i18next.
+            </Alert>
+            <Alert color={'info'}>
+              You will need to check how this page displays on other customers to see this particular behaviour. <br />
+              <ExternalLink href={'https://github.com/UnlyEd/next-right-now#overview-of-available-presets'}>Check out the README to see all other demos.</ExternalLink> (e.g: customer 1/2)
+            </Alert>
           </div>
         </Container>
       </DocPage>

--- a/src/pages/[locale]/examples/built-in-features/static-i18n.tsx
+++ b/src/pages/[locale]/examples/built-in-features/static-i18n.tsx
@@ -11,6 +11,7 @@ import BuiltInFeaturesSidebar from '../../../../components/doc/BuiltInFeaturesSi
 import DocPage from '../../../../components/doc/DocPage';
 import DefaultLayout from '../../../../components/pageLayouts/DefaultLayout';
 import DisplayOnBrowserMount from '../../../../components/rehydration/DisplayOnBrowserMount';
+import Code from '../../../../components/utils/Code';
 import ExternalLink from '../../../../components/utils/ExternalLink';
 import { CommonServerSideParams } from '../../../../types/nextjs/CommonServerSideParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
@@ -104,17 +105,29 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
         <Container>
           <div>
             {t('examples.i18n.simpleTranslation', 'Traduction simple')}<br />
-            <code>{'{t(\'examples.i18n.simpleTranslation\', \'Traduction simple\')}'}</code>
+            <Code
+              text={`
+                {t('examples.i18n.simpleTranslation', 'Traduction simple')}
+              `}
+            />
           </div>
           <hr />
 
           <div>
             {t('examples.i18n.pluralTranslation', 'Traduction avec gestion du pluriel', { count: 1 })}<br />
-            <code>{'{t(\'examples.i18n.pluralTranslation\', \'Traduction avec gestion du pluriel\', { count: 1 })}'}</code>
+            <Code
+              text={`
+                {t('examples.i18n.pluralTranslation', 'Traduction avec gestion du pluriel', { count: 1 })}
+              `}
+            />
           </div>
           <div>
             {t('examples.i18n.pluralTranslation', 'Traduction avec gestion du pluriel', { count: 2 })}<br />
-            <code>{'{t(\'examples.i18n.pluralTranslation\', \'Traduction avec gestion du pluriel\', { count: 2 })}'}</code>
+            <Code
+              text={`
+                {t('examples.i18n.pluralTranslation', 'Traduction avec gestion du pluriel', { count: 2 })}
+              `}
+            />
           </div>
           <hr />
 
@@ -126,13 +139,15 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
                 Contenu dynamique : <b>{{ uuid: uuid() }}</b>
               </Trans>
               <br />
-              <code>
-                {'<Trans\n' +
-                '  i18nKey="{\'examples.i18n.dynamicTranslation\'}"\n' +
-                '>\n' +
-                '  Contenu dynamique : <b>{{ uuid: uuid() }}</b>\n' +
-                '</Trans>'}
-              </code>
+              <Code
+                text={`
+                  <Trans
+                    i18nKey={'examples.i18n.dynamicTranslation'}
+                  >
+                    Contenu dynamique : <b>{{ uuid: uuid() }}</b>
+                  </Trans>
+                `}
+              />
             </DisplayOnBrowserMount>
           </div>
           <hr />
@@ -145,14 +160,16 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
               Nous avons trouvé {{ count: 1 }} solution pour vous.
             </Trans>
             <br />
-            <code>
-              {'<Trans\n' +
-              '  i18nKey="{\'examples.i18n.dynamicPluralTranslation\'}"\n' +
-              '  count="{1}"\n' +
-              '>\n' +
-              '  Nous avons trouvé {{ count: 1 }} solution pour vous.\n' +
-              '</Trans>'}
-            </code>
+            <Code
+              text={`
+                <Trans
+                  i18nKey={'examples.i18n.dynamicPluralTranslation'}
+                  count={1}
+                >
+                  Nous avons trouvé {{ count: 1 }} solution pour vous.
+                </Trans>
+              `}
+            />
           </div>
           <hr />
 
@@ -164,14 +181,45 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
               Nous avons trouvé {{ count: 2 }} solution pour vous.
             </Trans>
             <br />
-            <code>
-              {'<Trans\n' +
-              '  i18nKey="{\'examples.i18n.dynamicPluralTranslation\'}"\n' +
-              '  count="{2}"\n' +
-              '>\n' +
-              '  Nous avons trouvé {{ count: 2 }} solution pour vous.\n' +
-              '</Trans>'}
-            </code>
+            <Code
+              text={`
+                <Trans
+                  i18nKey={'examples.i18n.dynamicPluralTranslation'}
+                  count={2}
+                >
+                  Nous avons trouvé {{ count: 2 }} solution pour vous.
+                </Trans>
+              `}
+            />
+          </div>
+          <hr />
+
+          <div>
+            <Trans
+              i18nKey={'examples.i18n.missingTranslationWithFallback'}
+            >
+              Cette phrase n'est pas traduite en anglais, et sera affichée en Français même quand la langue anglaise est utilisée<br />
+              (This sentence is not translated in English, and will be displayed in French even when English language is being used)<br />
+              <i>
+                Note that I actually translated it (within the same sentence), so that non-French speakers may understand the explanation/feature.<br />
+                Basically, if a static translation is not found in any non-primary language, then NRN automatically fall backs to another language, so that something gets displayed in any way.
+              </i>
+            </Trans>
+            <br />
+            <Code
+              text={`
+                <Trans
+                  i18nKey={'examples.i18n.missingTranslationWithFallback'}
+                >
+                  Cette phrase n'est pas traduite en anglais, et sera affichée en Français même quand la langue anglaise est utilisée<br />
+                  (This sentence is not translated in English, and will be displayed in French even when English language is being used)<br />
+                  <i>
+                    Note that I actually translated it (within the same sentence), so that non-French speakers may understand the explanation/feature.<br />
+                    Basically, if a static translation is not found in any non-primary language, then NRN automatically fall backs to another language, so that something gets displayed in any way.
+                  </i>
+                </Trans>
+              `}
+            />
           </div>
         </Container>
       </DocPage>

--- a/src/pages/[locale]/examples/built-in-features/static-i18n.tsx
+++ b/src/pages/[locale]/examples/built-in-features/static-i18n.tsx
@@ -106,6 +106,8 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
         </Alert>
 
         <Container>
+          <h2>Translation using <code>t</code> function</h2>
+
           <div>
             {t('examples.i18n.simpleTranslation', 'Traduction simple')}<br />
             <Code
@@ -116,6 +118,14 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
           </div>
           <hr />
 
+          <h2>Translation with plurals</h2>
+
+          <Alert color={'info'}>
+            Plurals work with the <code>count</code> property, which is the amount of items.<br />
+            It's a very particular variable, only meant for that purpose.<br />
+            <ExternalLink href={'https://www.i18next.com/translation-function/plurals'}>Read the doc</ExternalLink>
+          </Alert>
+
           <div>
             {t('examples.i18n.pluralTranslation', 'Traduction avec gestion du pluriel', { count: 1 })}<br />
             <Code
@@ -124,6 +134,7 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
               `}
             />
           </div>
+          <br />
           <div>
             {t('examples.i18n.pluralTranslation', 'Traduction avec gestion du pluriel', { count: 2 })}<br />
             <Code
@@ -132,7 +143,51 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
               `}
             />
           </div>
+          <br />
+
+          <div>
+            <Trans
+              i18nKey={'examples.i18n.dynamicPluralTranslation'}
+              count={1}
+            >
+              Nous avons trouvé {{ count: 1 }} solution pour vous.
+            </Trans>
+            <br />
+            <Code
+              text={`
+                <Trans
+                  i18nKey={'examples.i18n.dynamicPluralTranslation'}
+                  count={1}
+                >
+                  Nous avons trouvé {{ count: 1 }} solution pour vous.
+                </Trans>
+              `}
+            />
+          </div>
+          <br />
+
+          <div>
+            <Trans
+              i18nKey={'examples.i18n.dynamicPluralTranslation'}
+              count={2}
+            >
+              Nous avons trouvé {{ count: 2 }} solution pour vous.
+            </Trans>
+            <br />
+            <Code
+              text={`
+                <Trans
+                  i18nKey={'examples.i18n.dynamicPluralTranslation'}
+                  count={2}
+                >
+                  Nous avons trouvé {{ count: 2 }} solution pour vous.
+                </Trans>
+              `}
+            />
+          </div>
           <hr />
+
+          <h2>Translation using variables</h2>
 
           <div>
             <DisplayOnBrowserMount>
@@ -155,47 +210,12 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
           </div>
           <hr />
 
-          <div>
-            <Trans
-              i18nKey={'examples.i18n.dynamicPluralTranslation'}
-              count={1}
-            >
-              Nous avons trouvé {{ count: 1 }} solution pour vous.
-            </Trans>
-            <br />
-            <Code
-              text={`
-                <Trans
-                  i18nKey={'examples.i18n.dynamicPluralTranslation'}
-                  count={1}
-                >
-                  Nous avons trouvé {{ count: 1 }} solution pour vous.
-                </Trans>
-              `}
-            />
-          </div>
-          <hr />
+          <h2>Automated fallback - Handling missing translations</h2>
 
-          <div>
-            <Trans
-              i18nKey={'examples.i18n.dynamicPluralTranslation'}
-              count={2}
-            >
-              Nous avons trouvé {{ count: 2 }} solution pour vous.
-            </Trans>
-            <br />
-            <Code
-              text={`
-                <Trans
-                  i18nKey={'examples.i18n.dynamicPluralTranslation'}
-                  count={2}
-                >
-                  Nous avons trouvé {{ count: 2 }} solution pour vous.
-                </Trans>
-              `}
-            />
-          </div>
-          <hr />
+          <Alert color={'info'}>
+            It will happen that some translations are missing, in such case NRN has been configured to fallback to another language (AKA "fallback" language).<br />
+            French has been defined as the default language in NRN (Locize configuration), meaning all translations must always exist for the French language.<br />
+          </Alert>
 
           <div>
             <Trans
@@ -225,6 +245,13 @@ const ExampleStaticI18nPage: NextPage<Props> = (props): JSX.Element => {
             />
           </div>
           <hr />
+
+          <h2>Customising translations, per customer</h2>
+
+          <Alert color={'info'}>
+            You may need to allow some translations to be overridden by a particular customer.<br />
+            NRN comes with built-in support for this advanced need, and uses additional Locize "Languages" to store "variations" of the translations.
+          </Alert>
 
           <div>
             <Trans

--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -35,6 +35,20 @@ export const resolveFallbackLanguage = (primaryLanguage: string): string => {
 };
 
 /**
+ * Each customer may own its own variation of the translations.
+ * Resolves the lang of the customer variation, based on the lang and the customer.
+ *
+ * XXX To define a customer variation language, you must create it on Locize manually
+ *  @example fr-x-customer1
+ *  @example en-x-customer1
+ *
+ * @param lang
+ */
+export const resolveCustomerVariationLang = (lang: string): string => {
+  return `${lang}-x-${process.env.NEXT_PUBLIC_CUSTOMER_REF}`;
+};
+
+/**
  * Detects the browser locale (from "accept-language" header) and returns an array of locales by order of importance
  *
  * TODO Should be re-implemented using https://github.com/UnlyEd/universal-language-detector

--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -18,6 +18,14 @@ export const SUPPORTED_LANGUAGES: string[] = supportedLanguages;
  */
 export const DEFAULT_LOCALE: string = defaultLocale;
 
+/**
+ * The fallback language is used when a translation is not found in the primary language
+ *
+ * Simple fallback language implementation.
+ * Only considers EN and FR languages.
+ *
+ * @param primaryLanguage
+ */
 export const resolveFallbackLanguage = (primaryLanguage: string): string => {
   if (primaryLanguage === LANG_FR) {
     return LANG_EN;

--- a/src/utils/i18n/i18nextLocize.ts
+++ b/src/utils/i18n/i18nextLocize.ts
@@ -7,7 +7,6 @@ import get from 'lodash.get';
 import map from 'lodash.map';
 import { initReactI18next } from 'react-i18next';
 import { LANG_EN, LANG_FR } from './i18n';
-import cloneDeep from 'lodash.clonedeep';
 
 const logger = createLogger({
   label: 'utils/i18n/i18nextLocize',
@@ -345,15 +344,6 @@ export const fetchTranslations = async (lang: string): Promise<I18nextResources>
  * @param i18nTranslations
  */
 const createI18nextLocizeInstance = (lang: string, i18nTranslations: I18nextResources): i18n => {
-  const langCustomerVariation = `${lang}-x-${process.env.NEXT_PUBLIC_CUSTOMER_REF}`;
-  const fallbackLang = lang === LANG_FR ? LANG_EN : LANG_FR;
-  i18nTranslations[langCustomerVariation] = cloneDeep(i18nTranslations[lang] || {});
-  // @ts-ignore
-  i18nTranslations[langCustomerVariation].common.examples.i18n.simpleTranslation = 'Overridden';
-  // @ts-ignore
-  i18nTranslations[langCustomerVariation].common.examples.i18n.dynamicPluralTranslation = 'Overridden';
-  console.log('customerLangCustomVariation', langCustomerVariation);
-  console.log('i18nTranslations', i18nTranslations);
   // If NEXT_PUBLIC_LOCIZE_PROJECT_ID is not defined then we mustn't init i18next or it'll crash the whole app when running in non-production stage
   // In that case, better crash early with an explicit message
   if (!process.env.NEXT_PUBLIC_LOCIZE_PROJECT_ID) {
@@ -401,10 +391,8 @@ const createI18nextLocizeInstance = (lang: string, i18nTranslations: I18nextReso
     debug: process.env.NEXT_PUBLIC_APP_STAGE !== 'production' && isBrowser(), // Only enable on non-production stages and only on browser (too much noise on server) XXX Note that missing keys will be created on the server first, so you should enable server logs if you need to debug "saveMissing" feature
     saveMissing: process.env.NEXT_PUBLIC_APP_STAGE === 'development', // Only save missing translations on development environment, to avoid outdated keys to be created from older staging deployments
     saveMissingTo: defaultNamespace,
-    lng: langCustomerVariation, // XXX We don't use the built-in i18next-browser-languageDetector because we have our own way of detecting language
-    // fallbackLng: [lang, fallbackLang],
-    // whitelist: [langCustomerVariation, lang, fallbackLang, 'dev'],
-    // nonExplicitWhitelist: true,
+    lng: lang, // XXX We don't use the built-in i18next-browser-languageDetector because we have our own way of detecting language
+    fallbackLng: lang === LANG_FR ? LANG_EN : LANG_FR,
     ns: [defaultNamespace], // string or array of namespaces to load
     defaultNS: defaultNamespace, // default namespace used if not passed to translation function
     interpolation: {

--- a/src/utils/i18n/i18nextLocize.ts
+++ b/src/utils/i18n/i18nextLocize.ts
@@ -6,7 +6,7 @@ import i18nextLocizeBackend from 'i18next-locize-backend/cjs'; // https://github
 import get from 'lodash.get';
 import map from 'lodash.map';
 import { initReactI18next } from 'react-i18next';
-import { LANG_EN, LANG_FR } from './i18n';
+import { resolveFallbackLanguage } from './i18n';
 
 const logger = createLogger({
   label: 'utils/i18n/i18nextLocize',
@@ -392,7 +392,7 @@ const createI18nextLocizeInstance = (lang: string, i18nTranslations: I18nextReso
     saveMissing: process.env.NEXT_PUBLIC_APP_STAGE === 'development', // Only save missing translations on development environment, to avoid outdated keys to be created from older staging deployments
     saveMissingTo: defaultNamespace,
     lng: lang, // XXX We don't use the built-in i18next-browser-languageDetector because we have our own way of detecting language
-    fallbackLng: lang === LANG_FR ? LANG_EN : LANG_FR,
+    fallbackLng: resolveFallbackLanguage(lang),
     ns: [defaultNamespace], // string or array of namespaces to load
     defaultNS: defaultNamespace, // default namespace used if not passed to translation function
     interpolation: {

--- a/src/utils/i18n/i18nextLocize.ts
+++ b/src/utils/i18n/i18nextLocize.ts
@@ -1,12 +1,13 @@
 import * as Sentry from '@sentry/node';
 import { isBrowser } from '@unly/utils';
 import { createLogger } from '@unly/utils-simple-logger';
+import deepmerge from 'deepmerge';
 import i18next, { i18n } from 'i18next';
 import i18nextLocizeBackend from 'i18next-locize-backend/cjs'; // https://github.com/locize/i18next-locize-backend/issues/323#issuecomment-619625571
 import get from 'lodash.get';
 import map from 'lodash.map';
 import { initReactI18next } from 'react-i18next';
-import { resolveFallbackLanguage } from './i18n';
+import { resolveCustomerVariationLang, resolveFallbackLanguage } from './i18n';
 
 const logger = createLogger({
   label: 'utils/i18n/i18nextLocize',
@@ -191,7 +192,83 @@ export const locizeBackendOptions = {
 };
 
 /**
- * Fetch translations from Locize API
+ * Builds Locize API endpoint based on the desired lang and namespace
+ *
+ * @param lang
+ * @param namespace
+ */
+export const buildLocizeAPIEndpoint = (lang: string, namespace: string = defaultNamespace): string => {
+  return locizeBackendOptions
+    .loadPath
+    .replace('{{projectId}}', locizeBackendOptions.projectId)
+    .replace('{{version}}', locizeBackendOptions.version)
+    .replace('{{lng}}', lang)
+    .replace('{{ns}}', namespace);
+};
+
+/**
+ * Fetches the translations that are shared amongst all customers.
+ *
+ * Used as base translations, which can be overridden using translations variation.
+ *
+ * @param lang
+ */
+export const fetchBaseTranslations = async (lang: string): Promise<I18nextResources> => {
+  const locizeAPIEndpoint: string = buildLocizeAPIEndpoint(lang);
+  let i18nTranslations: I18nextResources = {};
+
+  try {
+    // Manually fetching locales from Locize API, for the "common" namespace of the current language
+    // XXX We fetch manually from Locize, because if we use the i18next "preload" feature, it'll crash with Next (no serverless support)
+    logger.info(`Pre-fetching translations from ${locizeAPIEndpoint}`);
+    const defaultI18nTranslationsResponse: Response = await fetch(locizeAPIEndpoint);
+
+    try {
+      i18nTranslations = await defaultI18nTranslationsResponse.json();
+    } catch (e) {
+      logger.error(e.message, `Failed to extract JSON data from locize API response for "${lang}"`);
+      Sentry.captureException(e);
+    }
+  } catch (e) {
+    logger.error(e.message, `Failed to fetch data from locize API for "${lang}"`);
+    Sentry.captureException(e);
+  }
+
+  return i18nTranslations;
+};
+
+/**
+ * Fetches the translations that are specific to the customer (its own translations variation)
+ *
+ * @param lang
+ */
+export const fetchCustomerVariationTranslations = async (lang: string): Promise<I18nextResources> => {
+  const customerVariationLang = resolveCustomerVariationLang(lang);
+  const customerVariationLocizeAPIEndpoint: string = buildLocizeAPIEndpoint(customerVariationLang);
+  let customerVariationI18nTranslations: I18nextResources = {};
+
+  try {
+    // Manually fetching locales from Locize API, for the "common" namespace of the customer language variation
+    // XXX We fetch manually from Locize, because if we use the i18next "preload" feature, it'll crash with Next (no serverless support)
+    logger.info(`Pre-fetching "${customerVariationLang}" translations variation from ${customerVariationLocizeAPIEndpoint}`);
+    const customerVariationI18nTranslationsResponse: Response = await fetch(customerVariationLocizeAPIEndpoint);
+
+    try {
+      customerVariationI18nTranslations = await customerVariationI18nTranslationsResponse.json();
+    } catch (e) {
+      logger.error(e.message, `Failed to extract JSON data from locize API response for "${customerVariationLang}"`);
+      Sentry.captureException(e);
+    }
+  } catch (e) {
+    logger.error(e.message, `Failed to fetch data from locize API for "${customerVariationLang}"`);
+    Sentry.captureException(e);
+  }
+
+  return customerVariationI18nTranslations;
+};
+
+/**
+ * Fetch translations from Locize API (both base translations + translations that are specific to the customer)
  *
  * We use a "common" namespace that contains all our translations
  * It's easier to manage, as we don't need to split translations under multiple files (we don't have so many translations)
@@ -263,13 +340,8 @@ export const locizeBackendOptions = {
  * @return {Promise<string>}
  */
 export const fetchTranslations = async (lang: string): Promise<I18nextResources> => {
-  const locizeAPIEndpoint: string = locizeBackendOptions
-    .loadPath
-    .replace('{{projectId}}', locizeBackendOptions.projectId)
-    .replace('{{version}}', locizeBackendOptions.version)
-    .replace('{{lng}}', lang)
-    .replace('{{ns}}', defaultNamespace);
-  const memoizedI18nextResources: MemoizedI18nextResources = get(_memoizedI18nextResources, locizeAPIEndpoint, null);
+  const cacheIndexKey: string = buildLocizeAPIEndpoint(lang); // Also used as cache index key (memoization)
+  const memoizedI18nextResources: MemoizedI18nextResources = get(_memoizedI18nextResources, cacheIndexKey, null);
 
   if (memoizedI18nextResources) {
     const date = new Date();
@@ -284,28 +356,9 @@ export const fetchTranslations = async (lang: string): Promise<I18nextResources>
       logger.info(`Translations from in-memory cache are too old (> ${memoizedCacheMaxAge} seconds) and thus have been invalidated`);
     }
   }
-  let i18nTranslations: I18nextResources = {};
-
-  try {
-    // Fetching locales for i18next, for the "common" namespace
-    // XXX We do that because if we don't, then the SSR fails at fetching those locales using the i18next "backend" and renders too early
-    //  This hack helps fix the SSR issue
-    //  On the other hand, it seems that once the i18next "resources" are set, they don't change,
-    //  so this workaround could cause sync issue if we were using multiple namespaces, but we aren't and probably won't
-    logger.info(`Pre-fetching translations from ${locizeAPIEndpoint}`);
-    const defaultI18nTranslationsResponse: Response = await fetch(locizeAPIEndpoint);
-
-    try {
-      i18nTranslations = await defaultI18nTranslationsResponse.json();
-    } catch (e) {
-      // TODO Load the locales from local JSON files if ever the API fails, to still display i18n translation even if it's not the most up-to-date?
-      logger.error(e.message, 'Failed to extract JSON data from locize API response');
-      Sentry.captureException(e);
-    }
-  } catch (e) {
-    logger.error(e.message, 'Failed to fetch data from locize API');
-    Sentry.captureException(e);
-  }
+  const i18nBaseTranslations: I18nextResources = await fetchBaseTranslations(lang);
+  const customerVariationI18nTranslations: I18nextResources = await fetchCustomerVariationTranslations(lang);
+  const i18nTranslations: I18nextResources = deepmerge(i18nBaseTranslations, customerVariationI18nTranslations);
 
   const i18nextResources: I18nextResources = {
     [lang]: {
@@ -314,7 +367,7 @@ export const fetchTranslations = async (lang: string): Promise<I18nextResources>
   };
   logger.info('Translations were resolved from Locize API and are now being memoized for subsequent calls');
 
-  _memoizedI18nextResources[locizeAPIEndpoint] = {
+  _memoizedI18nextResources[cacheIndexKey] = {
     resources: i18nextResources,
     ts: ((): number => {
       const date = new Date();


### PR DESCRIPTION
**Goal**: Allow to use custom translation defined per-customer, that overrides the translation defined for the language by default

**Current workflow (to resolve the language) is:**

1. End user locale (fr or en) - based on browser headers
2. Fallback to fr/en when a sentence is not found

**New workflow**:
1. Custom (per-customer) translations based on the end user locale (takes precedence over the end-user locale)
2. End user locale (fr or en)
3. Fallback to fr/en when sentence is not found

**Example using key "common.a" and "en"/"en-x-customer1" langs**:

- If "common.a" is defined in "en-x-customer1" then it is used ("common.a" in "en" language is ignored)
- If "common.a" is not defined in "en-x-customer1" then it fall backs to "common.a" in "en" lang
- If "common.a" is not defined in "en-x-customer1" and "common.a" is not defined "en" lang then it fall backs to "fr"

That's the default behaviour I'm trying to achieve, by using t('a').