### PR TITLE
GDPR - Disable Google Click ID being used by default

### DIFF
--- a/src/utils/analytics/amplitude.ts
+++ b/src/utils/analytics/amplitude.ts
@@ -116,7 +116,7 @@ export const sendWebVitals = (report: NextWebVitalsMetricsReport): void => {
       // userId: null,
       userId: userData.id,
       logLevel: process.env.NEXT_PUBLIC_APP_STAGE === 'production' ? 'DISABLE' : 'WARN',
-      includeGclid: true,
+      includeGclid: false, // GDPR Enabling this is not GDPR compliant and must not be enabled without explicit user consent - See https://croud.com/blog/news/10-point-gdpr-checklist-digital-advertising/
       includeReferrer: true, // https://help.amplitude.com/hc/en-us/articles/215131888#track-referrers
       includeUtm: true,
       // @ts-ignore XXX onError should be allowed, see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/42005


### PR DESCRIPTION
As it doesn't respect GDPR and should be expressively consented to by the end-user

https://croud.com/blog/news/10-point-gdpr-checklist-digital-advertising/

>And if you use GA auto-tagging with a linked AdWords account, then potentially you are extending your record of the user’s personal data beyond your site, and so arguably you shouldn’t track the session’s landing page URL until the user has either allowed or denied consent. Once that’s clear, you can either include or strip out the AdWords ID in the URL, i.e. the “gclid parameter”.
