### PR TITLE
GDPR - Add cookie consent UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "animate.css": "4.1.0",
     "bootstrap": "4.5.0",
     "classnames": "2.2.6",
+    "cookieconsent": "3.1.1",
     "cookies": "0.8.0",
     "css-to-react-native": "3.0.0",
     "deepmerge": "4.2.2",

--- a/src/components/appBootstrap/BrowserPageBootstrap.tsx
+++ b/src/components/appBootstrap/BrowserPageBootstrap.tsx
@@ -81,7 +81,7 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
   });
 
   // Init the Cookie Consent popup, which will open on the browser
-  initCookieConsent(amplitudeInstance, theme, t, locale);
+  initCookieConsent(userConsent, amplitudeInstance, theme, t, locale);
 
   // In non-production stages, bind some utilities to the browser's DOM, for ease of quick testing
   if (process.env.NEXT_PUBLIC_APP_STAGE !== 'production') {

--- a/src/components/appBootstrap/BrowserPageBootstrap.tsx
+++ b/src/components/appBootstrap/BrowserPageBootstrap.tsx
@@ -3,19 +3,22 @@ import { Amplitude, AmplitudeProvider } from '@amplitude/react-amplitude';
 import { jsx } from '@emotion/core';
 import * as Sentry from '@sentry/node';
 import { createLogger } from '@unly/utils-simple-logger';
+import { AmplitudeClient } from 'amplitude-js';
 import { useTheme } from 'emotion-theming';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import userConsentContext from '../../stores/userConsentContext';
 import { userSessionContext } from '../../stores/userSessionContext';
 import { CustomerTheme } from '../../types/data/CustomerTheme';
 import { MultiversalAppBootstrapPageProps } from '../../types/nextjs/MultiversalAppBootstrapPageProps';
 import { MultiversalAppBootstrapProps } from '../../types/nextjs/MultiversalAppBootstrapProps';
 import { MultiversalPageProps } from '../../types/pageProps/MultiversalPageProps';
 import { OnlyBrowserPageProps } from '../../types/pageProps/OnlyBrowserPageProps';
+import { UserConsent } from '../../types/UserConsent';
 import { UserSemiPersistentSession } from '../../types/UserSemiPersistentSession';
 import { getAmplitudeInstance } from '../../utils/analytics/amplitude';
 
-import cookieConsentInit from '../../utils/cookies/cookieConsent';
+import initCookieConsent, { getUserConsent } from '../../utils/cookies/cookieConsent';
 import UniversalCookiesManager from '../../utils/cookies/UniversalCookiesManager';
 import { getIframeReferrer, isRunningInIframe } from '../../utils/iframe';
 
@@ -65,17 +68,20 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
     level: Sentry.Severity.Debug,
   });
 
-  // Init the Cookie Consent popup, which will open on the browser
-  cookieConsentInit(theme, t);
-
-  const amplitudeInstance = getAmplitudeInstance({
+  const userConsent: UserConsent = getUserConsent();
+  const { isUserOptedOutOfAnalytics, hasUserGivenAnyCookieConsent } = userConsent;
+  const amplitudeInstance: AmplitudeClient = getAmplitudeInstance({
     customerRef,
     iframeReferrer,
     isInIframe,
     lang,
     locale,
     userId,
+    userConsent,
   });
+
+  // Init the Cookie Consent popup, which will open on the browser
+  initCookieConsent(amplitudeInstance, theme, t, locale);
 
   // In non-production stages, bind some utilities to the browser's DOM, for ease of quick testing
   if (process.env.NEXT_PUBLIC_APP_STAGE !== 'production') {
@@ -121,6 +127,8 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
           locale: locale,
           iframe: isInIframe,
           iframeReferrer: iframeReferrer,
+          isUserOptedOutOfAnalytics: isUserOptedOutOfAnalytics,
+          hasUserGivenAnyCookieConsent: hasUserGivenAnyCookieConsent,
         }}
         // XXX Do not use "userProperties" here, add default user-related properties in getAmplitudeInstance instead
         //  Because "event" had priority over "user event" and will be executed before
@@ -128,11 +136,13 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
         // userProperties={{}}
       >
         <userSessionContext.Provider value={{ ...userSession }}>
-          <Component
-            {...injectedPageProps}
-            // @ts-ignore
-            error={err}
-          />
+          <userConsentContext.Provider value={{ ...userConsent }}>
+            <Component
+              {...injectedPageProps}
+              // @ts-ignore
+              error={err}
+            />
+          </userConsentContext.Provider>
         </userSessionContext.Provider>
       </Amplitude>
     </AmplitudeProvider>

--- a/src/components/appBootstrap/BrowserPageBootstrap.tsx
+++ b/src/components/appBootstrap/BrowserPageBootstrap.tsx
@@ -84,7 +84,7 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
   initCookieConsent({
     allowedPages: [ // We only allow it on those 2 pages to avoid display that boring popup on every page
       `${window.location.origin}/${locale}/terms`,
-      `${window.location.origin}/${locale}/examples/built-in-features/css-in-js`,
+      `${window.location.origin}/${locale}/examples/built-in-features/cookies-consent`,
     ],
     amplitudeInstance,
     locale,

--- a/src/components/appBootstrap/BrowserPageBootstrap.tsx
+++ b/src/components/appBootstrap/BrowserPageBootstrap.tsx
@@ -3,16 +3,19 @@ import { Amplitude, AmplitudeProvider } from '@amplitude/react-amplitude';
 import { jsx } from '@emotion/core';
 import * as Sentry from '@sentry/node';
 import { createLogger } from '@unly/utils-simple-logger';
+import { useTheme } from 'emotion-theming';
 import React from 'react';
-
 import { useTranslation } from 'react-i18next';
 import { userSessionContext } from '../../stores/userSessionContext';
+import { CustomerTheme } from '../../types/data/CustomerTheme';
 import { MultiversalAppBootstrapPageProps } from '../../types/nextjs/MultiversalAppBootstrapPageProps';
 import { MultiversalAppBootstrapProps } from '../../types/nextjs/MultiversalAppBootstrapProps';
 import { MultiversalPageProps } from '../../types/pageProps/MultiversalPageProps';
 import { OnlyBrowserPageProps } from '../../types/pageProps/OnlyBrowserPageProps';
 import { UserSemiPersistentSession } from '../../types/UserSemiPersistentSession';
 import { getAmplitudeInstance } from '../../utils/analytics/amplitude';
+
+import cookieConsentInit from '../../utils/cookies/cookieConsent';
 import UniversalCookiesManager from '../../utils/cookies/UniversalCookiesManager';
 import { getIframeReferrer, isRunningInIframe } from '../../utils/iframe';
 
@@ -32,7 +35,7 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
   const {
     Component,
     err,
-    router
+    router,
   } = props;
   // When the page is served by the browser, some browser-only properties are available
   const pageProps = props.pageProps as unknown as MultiversalPageProps<OnlyBrowserPageProps>;
@@ -54,12 +57,16 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
     cookiesManager,
     userSession,
   };
+  const theme = useTheme<CustomerTheme>();
 
   Sentry.addBreadcrumb({ // See https://docs.sentry.io/enriching-error-data/breadcrumbs
     category: fileLabel,
     message: `Rendering ${fileLabel}`,
     level: Sentry.Severity.Debug,
   });
+
+  // Init the Cookie Consent popup, which will open on the browser
+  cookieConsentInit(theme, t);
 
   const amplitudeInstance = getAmplitudeInstance({
     customerRef,

--- a/src/components/appBootstrap/BrowserPageBootstrap.tsx
+++ b/src/components/appBootstrap/BrowserPageBootstrap.tsx
@@ -81,7 +81,17 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
   });
 
   // Init the Cookie Consent popup, which will open on the browser
-  initCookieConsent(userConsent, amplitudeInstance, theme, t, locale);
+  initCookieConsent({
+    allowedPages: [ // We only allow it on those 2 pages to avoid display that boring popup on every page
+      `${window.location.origin}/${locale}/terms`,
+      `${window.location.origin}/${locale}/examples/built-in-features/css-in-js`,
+    ],
+    amplitudeInstance,
+    locale,
+    t,
+    theme,
+    userConsent,
+  });
 
   // In non-production stages, bind some utilities to the browser's DOM, for ease of quick testing
   if (process.env.NEXT_PUBLIC_APP_STAGE !== 'production') {

--- a/src/components/appBootstrap/UniversalGlobalStyles.tsx
+++ b/src/components/appBootstrap/UniversalGlobalStyles.tsx
@@ -278,6 +278,11 @@ const UniversalGlobalStyles: React.FunctionComponent<Props> = (props): JSX.Eleme
             opacity: 1 !important; // Overrides default bootstrap behaviour to avoid make-believe SSR doesn't work on the demo, when JS is disabled - See https://github.com/UnlyEd/next-right-now/issues/9
           }
         }
+
+        // Overrides of CookieConsent
+        .cc-revoke {
+          border: 1px solid lightgrey
+        }
       `}
     />
   );

--- a/src/components/appBootstrap/UniversalGlobalStyles.tsx
+++ b/src/components/appBootstrap/UniversalGlobalStyles.tsx
@@ -281,7 +281,20 @@ const UniversalGlobalStyles: React.FunctionComponent<Props> = (props): JSX.Eleme
 
         // Overrides of CookieConsent
         .cc-revoke {
-          border: 1px solid lightgrey
+          border: 1px solid lightgrey;
+        }
+
+        .cc-btn.cc-allow {
+          background-color: ${primaryColor} !important;
+          color: white !important;
+
+          &:hover {
+            opacity: 0.8;
+          }
+        }
+
+        .cc-btn.cc-deny {
+          color: darkgrey !important;
         }
       `}
     />

--- a/src/components/doc/BuiltInFeaturesSection.tsx
+++ b/src/components/doc/BuiltInFeaturesSection.tsx
@@ -170,6 +170,23 @@ const BuiltInFeaturesSection: React.FunctionComponent<Props> = (props): JSX.Elem
 
         <Card>
           <CardBody>
+            <CardTitle><h3>Cookies consent</h3></CardTitle>
+            <CardSubtitle>&ldquo;Cookies consent using <code>CookieConsent</code> OSS library&rdquo;</CardSubtitle>
+            <CardText tag={'div'}>
+              <div className={'buttons'}>
+                <ExternalLink href={'https://github.com/osano/cookieconsent'}>
+                  <Button color={'link'}>Learn more about the "Cookie consent" library</Button>
+                </ExternalLink>
+                <I18nLink href={'/examples/built-in-features/cookies-consent'}>
+                  <Button color={'link'}>See usage examples</Button>
+                </I18nLink>
+              </div>
+            </CardText>
+          </CardBody>
+        </Card>
+
+        <Card>
+          <CardBody>
             <CardTitle><h3>Analytics</h3></CardTitle>
             <CardSubtitle>&ldquo;Analytics using Amplitude vendor&rdquo;</CardSubtitle>
             <CardText tag={'div'}>

--- a/src/components/doc/BuiltInFeaturesSection.tsx
+++ b/src/components/doc/BuiltInFeaturesSection.tsx
@@ -178,7 +178,7 @@ const BuiltInFeaturesSection: React.FunctionComponent<Props> = (props): JSX.Elem
                   <Button color={'link'}>Learn more about the "Cookie consent" library</Button>
                 </ExternalLink>
                 <I18nLink href={'/examples/built-in-features/cookies-consent'}>
-                  <Button color={'link'}>See usage examples</Button>
+                  <Button color={'link'}>Learn more about user consent and its impact on analytics</Button>
                 </I18nLink>
               </div>
             </CardText>

--- a/src/components/doc/BuiltInFeaturesSidebar.tsx
+++ b/src/components/doc/BuiltInFeaturesSidebar.tsx
@@ -41,6 +41,10 @@ export const BUILT_IN_FEATURES_SIDEBAR_LINKS: SidebarLink[] = [
     label: 'CSS-in-JS',
   },
   {
+    href: '/examples/built-in-features/cookies-consent',
+    label: 'Cookies consent',
+  },
+  {
     href: '/examples/built-in-features/analytics',
     label: 'Analytics',
   },

--- a/src/hooks/useUserConsent.tsx
+++ b/src/hooks/useUserConsent.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import userConsentContext from '../stores/userConsentContext';
+import { UserConsent } from '../types/UserConsent';
+
+/**
+ * Hook to access the user consent data
+ *
+ * Uses userConsentContext internally (provides an identical API)
+ *
+ * This hook should be used by components in favor of userSessionContext directly,
+ * because it grants higher flexibility if you ever need to change the implementation (e.g: use something else than React.Context, like Redux/MobX/Recoil)
+ *
+ * @see https://slides.com/djanoskova/react-context-api-create-a-reusable-snackbar#/11
+ */
+const useUserConsent = (): UserConsent => {
+  return React.useContext(userConsentContext);
+};
+
+export default useUserConsent;

--- a/src/pages/[locale]/examples/built-in-features/analytics.tsx
+++ b/src/pages/[locale]/examples/built-in-features/analytics.tsx
@@ -210,7 +210,9 @@ const ExampleAnalyticsPage: NextPage<Props> = (props): JSX.Element => {
                 {
                   !hasUserGivenAnyCookieConsent ? `You haven't made any choice regarding your consent yet, and thus an event will be sent (because you're opt-in by default)` : (isUserOptedOutOfAnalytics ? `You've chosen to opt-out from analytics tracking, and thus no event will be sent` : `You've chosen to opt-in to analytics tracking, and thus an event will be sent`)
                 }
-              </b>
+              </b><br />
+              <br />
+              You can check the event details using <ExternalLink href={'https://chrome.google.com/webstore/detail/amplitude-instrumentation/acehfjhnmhbmgkedjmjlobpgdicnhkbp'}>Amplitude Instrumentation Explorer</ExternalLink> Chrome extension.
             </p>
 
             <Button

--- a/src/pages/[locale]/examples/built-in-features/analytics.tsx
+++ b/src/pages/[locale]/examples/built-in-features/analytics.tsx
@@ -9,6 +9,7 @@ import { Alert, Button } from 'reactstrap';
 import BuiltInFeaturesSidebar from '../../../../components/doc/BuiltInFeaturesSidebar';
 import DocPage from '../../../../components/doc/DocPage';
 import DefaultLayout from '../../../../components/pageLayouts/DefaultLayout';
+import DisplayOnBrowserMount from '../../../../components/rehydration/DisplayOnBrowserMount';
 import Code from '../../../../components/utils/Code';
 import ExternalLink from '../../../../components/utils/ExternalLink';
 import useUserConsent from '../../../../hooks/useUserConsent';
@@ -206,19 +207,21 @@ const ExampleAnalyticsPage: NextPage<Props> = (props): JSX.Element => {
               Below is how we log events upon user interaction. (i.e: click)<br />
               When you click on the below button an event <code>analytics-button-test-event</code> is sent to Amplitude.<br />
               No data will be sent if you've opted-out of analytics tracking:
-              <b>
-                {
-                  !hasUserGivenAnyCookieConsent ? `You haven't made any choice regarding your consent yet, and thus an event will be sent (because you're opt-in by default)` : (isUserOptedOutOfAnalytics ? `You've chosen to opt-out from analytics tracking, and thus no event will be sent` : `You've chosen to opt-in to analytics tracking, and thus an event will be sent`)
-                }
-              </b><br />
+              <DisplayOnBrowserMount>
+                <br />
+                <b>
+                  {
+                    !hasUserGivenAnyCookieConsent ? `You haven't made any choice regarding your consent yet, and thus an event will be sent (because you're opt-in by default).` : (isUserOptedOutOfAnalytics ? `You've chosen to opt-out from analytics tracking, and thus no event will be sent.` : `You've chosen to opt-in to analytics tracking, and thus an event will be sent.`)
+                  }
+                </b>
+              </DisplayOnBrowserMount>
+              <br />
               <br />
               You can check the event details using <ExternalLink href={'https://chrome.google.com/webstore/detail/amplitude-instrumentation/acehfjhnmhbmgkedjmjlobpgdicnhkbp'}>Amplitude Instrumentation Explorer</ExternalLink> Chrome extension.
             </p>
 
             <Button
-              onClick={(): void => logEvent('analytics-button-test-event', {
-                file: fileLabel,
-              })}
+              onClick={(): void => logEvent('analytics-button-test-event')}
             >
               Click me
             </Button>
@@ -230,9 +233,7 @@ const ExampleAnalyticsPage: NextPage<Props> = (props): JSX.Element => {
                 <Amplitude>
                   {({ logEvent }): JSX.Element => (
                     <Button
-                      onClick={(): void => logEvent('analytics-button-test-event', {
-                        file: fileLabel,
-                      })}
+                      onClick={(): void => logEvent('analytics-button-test-event')}
                     >
                       Click me
                     </Button>

--- a/src/pages/[locale]/examples/built-in-features/analytics.tsx
+++ b/src/pages/[locale]/examples/built-in-features/analytics.tsx
@@ -221,7 +221,10 @@ const ExampleAnalyticsPage: NextPage<Props> = (props): JSX.Element => {
             </p>
 
             <Button
-              onClick={(): void => logEvent('analytics-button-test-event')}
+              onClick={(): void => {
+                console.log('Button click');
+                logEvent('analytics-button-test-event');
+              }}
             >
               Click me
             </Button>
@@ -233,7 +236,10 @@ const ExampleAnalyticsPage: NextPage<Props> = (props): JSX.Element => {
                 <Amplitude>
                   {({ logEvent }): JSX.Element => (
                     <Button
-                      onClick={(): void => logEvent('analytics-button-test-event')}
+                      onClick={(): void => {
+                        console.log('Button click');
+                        logEvent('analytics-button-test-event');
+                      }}
                     >
                       Click me
                     </Button>

--- a/src/pages/[locale]/examples/built-in-features/analytics.tsx
+++ b/src/pages/[locale]/examples/built-in-features/analytics.tsx
@@ -1,15 +1,17 @@
 /** @jsx jsx */
+import { Amplitude } from '@amplitude/react-amplitude';
 import { jsx } from '@emotion/core';
 import { createLogger } from '@unly/utils-simple-logger';
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars
 import React from 'react';
-import { Alert } from 'reactstrap';
+import { Alert, Button } from 'reactstrap';
 import BuiltInFeaturesSidebar from '../../../../components/doc/BuiltInFeaturesSidebar';
 import DocPage from '../../../../components/doc/DocPage';
 import DefaultLayout from '../../../../components/pageLayouts/DefaultLayout';
 import Code from '../../../../components/utils/Code';
 import ExternalLink from '../../../../components/utils/ExternalLink';
+import useUserConsent from '../../../../hooks/useUserConsent';
 import { CommonServerSideParams } from '../../../../types/nextjs/CommonServerSideParams';
 import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
 import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
@@ -47,6 +49,8 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
 type Props = {} & SSGPageProps<Partial<OnlyBrowserPageProps>>;
 
 const ExampleAnalyticsPage: NextPage<Props> = (props): JSX.Element => {
+  const { isUserOptedOutOfAnalytics, hasUserGivenAnyCookieConsent } = useUserConsent();
+
   return (
     <DefaultLayout
       {...props}
@@ -56,170 +60,188 @@ const ExampleAnalyticsPage: NextPage<Props> = (props): JSX.Element => {
       }}
       Sidebar={BuiltInFeaturesSidebar}
     >
-      <DocPage>
-        <h1 className={'pcolor'}>Analytics examples, using Amplitude vendor</h1>
+      <Amplitude>
+        {({ logEvent }): JSX.Element => (
+          <DocPage>
+            <h1 className={'pcolor'}>Analytics examples, using Amplitude vendor</h1>
 
-        <Alert color={'danger'}>
-          Before investing time in Amplitude, make sure to check
-          <ExternalLink
-            href={'https://unlyed.github.io/next-right-now/guides/analytics/use-amplitude.html#a-note-about-amplitudes-pricing'}
-            suffix={null}
-          >
-            their pricing and usage limits
-          </ExternalLink>
-          .<br />
-          Amplitude is great for getting started but if you need more than what the free plan offers, then you better make sure you can afford it.
-        </Alert>
+            <Alert color={'danger'}>
+              Before investing time in Amplitude, make sure to check
+              <ExternalLink
+                href={'https://unlyed.github.io/next-right-now/guides/analytics/use-amplitude.html#a-note-about-amplitudes-pricing'}
+                suffix={null}
+              >
+                their pricing and usage limits
+              </ExternalLink>
+              .<br />
+              Amplitude is great for getting started but if you need more than what the free plan offers, then you better make sure you can afford it.
+            </Alert>
 
-        <Alert color={'info'}>
-          Amplitude provides a <ExternalLink href={'https://github.com/amplitude/react-amplitude'}>React component</ExternalLink>
-          that makes it a breeze to work with, and we really love it.<br />
-          It's much more comfortable from a developer standpoint that everything we've worked with by the past.<br />
-          <br />
-          We only use Amplitude from the client, mostly because Amplitude didn't provide a nodejs compatible library until very recently.<br />
-          Also, we prefer to perform all reporting on the client side, as it avoids issues with multiple events sent by mistake.
-        </Alert>
+            <Alert color={'info'}>
+              Amplitude provides a <ExternalLink href={'https://github.com/amplitude/react-amplitude'}>React component</ExternalLink>
+              that makes it a breeze to work with, and we really love it.<br />
+              It's much more comfortable from a developer standpoint that everything we've worked with by the past.<br />
+              <br />
+              We only use Amplitude from the client, mostly because Amplitude didn't provide a nodejs compatible library until very recently.<br />
+              Also, we prefer to perform all reporting on the client side, as it avoids issues with multiple events sent by mistake.
+            </Alert>
 
-        <p>
-          The app is configured in a way that all usual web-related analytics options are handled out the box.<br />
-          It also comes with a shared configuration for all pages (see below) and user-session tracking.<br />
-          Regarding <b>GDPR concerns</b>, the IP address is tracked, and a cookie is created on the device by default.
-        </p>
+            <p>
+              The app is configured in a way that all usual web-related analytics options are handled out the box.<br />
+              It also comes with a shared configuration for all pages (see below) and user-session tracking.<br />
+              Regarding <b>GDPR concerns</b>, the IP address is not processed/stored by any vendor (analytics data are anonymous). Several cookies are created on the device if the user hasn't opted out of tracking (through the Cookie Consent popup).
+            </p>
 
-        <hr />
+            <hr />
 
-        <p>
-          The below code is the shared configuration between all pages.<br />
-          It initializes the whole thing, and automatically track app-wide data so that all event will contain those properties automatically.
-        </p>
+            <h2>Shared analytics configuration</h2>
+            <p>
+              The below code is the shared configuration between all pages.<br />
+              It initializes the whole thing, and automatically track app-wide data so that all event will contain those properties automatically.
+            </p>
 
-        <Code
-          text={`
-            <AmplitudeProvider
-              amplitudeInstance={amplitudeInstance}
-              apiKey={process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY}
-              userId={userId}
-            >
-              <Amplitude
-                eventProperties={{
-                  app: {
-                    name: process.env.NEXT_PUBLIC_APP_NAME,
-                    version: process.env.NEXT_PUBLIC_APP_VERSION,
-                    stage: process.env.NEXT_PUBLIC_APP_STAGE,
-                    preset: process.env.NEXT_PUBLIC_NRN_PRESET,
+            <Code
+              text={`
+                <AmplitudeProvider
+                  amplitudeInstance={amplitudeInstance}
+                  apiKey={process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY}
+                  userId={userId}
+                >
+                  <Amplitude
+                    eventProperties={{
+                      app: {
+                        name: process.env.NEXT_PUBLIC_APP_NAME,
+                        version: process.env.NEXT_PUBLIC_APP_VERSION,
+                        stage: process.env.NEXT_PUBLIC_APP_STAGE,
+                        preset: process.env.NEXT_PUBLIC_NRN_PRESET,
+                      },
+                      page: {
+                        url: location.href,
+                        path: location.pathname,
+                        origin: location.origin,
+                        name: null, // XXX Will be set by the page (usually through its layout)
+                      },
+                      customer: {
+                        ref: customerRef,
+                      },
+                      lang: lang,
+                      locale: locale,
+                      iframe: isInIframe,
+                      iframeReferrer: iframeReferrer,
+                    }}
+                  />
+                </AmplitudeProvider>
+
+                // ... elsewhere
+
+                // See https://help.amplitude.com/hc/en-us/articles/115001361248#settings-configuration-options
+                amplitudeInstance.init(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY, null, {
+                  userId,
+                  logLevel: process.env.NEXT_PUBLIC_APP_STAGE === 'production' ? 'DISABLE' : 'WARN',
+                  includeGclid: true,
+                  includeReferrer: true, // See https://help.amplitude.com/hc/en-us/articles/215131888#track-referrers
+                  includeUtm: true,
+                  // @ts-ignore XXX onError should be allowed, see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/42005
+                  onError: (error): void => {
+                    Sentry.captureException(error);
+                    console.error(error); // eslint-disable-line no-console
                   },
-                  page: {
-                    url: location.href,
-                    path: location.pathname,
-                    origin: location.origin,
-                    name: null, // XXX Will be set by the page (usually through its layout)
-                  },
-                  customer: {
-                    ref: customerRef,
-                  },
-                  lang: lang,
-                  locale: locale,
-                  iframe: isInIframe,
-                  iframeReferrer: iframeReferrer,
-                }}
-              />
-            </AmplitudeProvider>
+                });
 
-            // ... elsewhere
+                amplitudeInstance.setVersionName(process.env.NEXT_PUBLIC_APP_VERSION); // e.g: 1.0.0
 
-            // See https://help.amplitude.com/hc/en-us/articles/115001361248#settings-configuration-options
-            amplitudeInstance.init(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY, null, {
-              userId,
-              logLevel: process.env.NEXT_PUBLIC_APP_STAGE === 'production' ? 'DISABLE' : 'WARN',
-              includeGclid: true,
-              includeReferrer: true, // See https://help.amplitude.com/hc/en-us/articles/215131888#track-referrers
-              includeUtm: true,
-              // @ts-ignore XXX onError should be allowed, see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/42005
-              onError: (error): void => {
-                Sentry.captureException(error);
-                console.error(error); // eslint-disable-line no-console
-              },
-            });
+                // We're only doing this when detecting a new session, as it won't be executed multiple times for the same session anyway, and it avoids noise
+                if (amplitudeInstance.isNewSession()) {
+                    // Store whether the visitor originally came from an iframe (and from where)
+                    const visitor: Identify = new amplitudeInstance.Identify();
+                    // XXX Learn more about "setOnce" at https://github.com/amplitude/Amplitude-JavaScript/issues/223
+                    visitor.setOnce('initial_lang', lang); // DA Helps figuring out if the initial language (auto-detected) is changed afterwards
+                    visitor.setOnce('initial_locale', locale);
+                    // DA This will help track down the users who discovered our platform because of an iframe
+                    visitor.setOnce('initial_iframe', isInIframe);
+                    visitor.setOnce('initial_iframeReferrer', iframeReferrer);
 
-            amplitudeInstance.setVersionName(process.env.NEXT_PUBLIC_APP_VERSION); // e.g: 1.0.0
+                    // XXX We set all "must-have" properties here (instead of doing it in the "AmplitudeProvider", as userProperties), because react-amplitude will send the next "page-displayed" event BEFORE sending the $identify event
+                    visitor.setOnce('customer.ref', customerRef);
+                    visitor.setOnce('lang', lang);
+                    visitor.setOnce('locale', locale);
+                    visitor.setOnce('iframe', isInIframe);
+                    visitor.setOnce('iframeReferrer', iframeReferrer);
 
-            // We're only doing this when detecting a new session, as it won't be executed multiple times for the same session anyway, and it avoids noise
-            if (amplitudeInstance.isNewSession()) {
-              // Store whether the visitor originally came from an iframe (and from where)
-              const visitor: Identify = new amplitudeInstance.Identify();
-              // XXX Learn more about "setOnce" at https://github.com/amplitude/Amplitude-JavaScript/issues/223
-              visitor.setOnce('initial_lang', lang); // DA Helps figuring out if the initial language (auto-detected) is changed afterwards
-              visitor.setOnce('initial_locale', locale);
-              // DA This will help track down the users who discovered our platform because of an iframe
-              visitor.setOnce('initial_iframe', isInIframe);
-              visitor.setOnce('initial_iframeReferrer', iframeReferrer);
+                    amplitudeInstance.identify(visitor); // Send the new identify event to amplitude (updates user's identity)
+                  }
+              `}
+            />
 
-              // XXX We set all "must-have" properties here (instead of doing it in the "AmplitudeProvider", as userProperties), because react-amplitude will send the next "page-displayed" event BEFORE sending the $identify event
-              visitor.setOnce('customer.ref', customerRef);
-              visitor.setOnce('lang', lang);
-              visitor.setOnce('locale', locale);
-              visitor.setOnce('iframe', isInIframe);
-              visitor.setOnce('iframeReferrer', iframeReferrer);
+            <hr />
 
-              amplitudeInstance.identify(visitor); // Send the new identify event to amplitude (updates user's identity)
-            }
-           `}
-        />
+            <h2>Events - Automated page views</h2>
+            <p>
+              Below is how we automatically track all page views (through the <code>DefaultLayout</code> component):
+            </p>
 
-        <hr />
+            <Code
+              text={`
+                <Amplitude
+                  eventProperties={(inheritedProps): object => ({
+                    // All app-wide properties are inherited and overloaded to track additional properties
+                    ...inheritedProps,
+                    page: {
+                      ...inheritedProps.page,
+                      name: pageName,
+                    },
+                  })}
+                >
+                  {/* The event is automatically sent upon component mount */}
+                  <LogOnMount eventType="page-displayed" />
+                </Amplitude>
+              `}
+            />
 
-        <p>
-          Below is how we automatically track all page views (through the <code>DefaultLayout</code> component):
-        </p>
+            <hr />
 
-        <Code
-          text={`
-            <Amplitude
-              eventProperties={(inheritedProps): object => ({
-                // All app-wide properties are inherited and overloaded to track additional properties
-                ...inheritedProps,
-                page: {
-                  ...inheritedProps.page,
-                  name: pageName,
-                },
+            <h2>Events - User interactions</h2>
+
+            <p>
+              Below is how we log events upon user interaction. (i.e: click)<br />
+              When you click on the below button an event <code>analytics-button-test-event</code> is sent to Amplitude.<br />
+              No data will be sent if you've opted-out of analytics tracking:
+              <b>
+                {
+                  !hasUserGivenAnyCookieConsent ? `You haven't made any choice regarding your consent yet, and thus an event will be sent (because you're opt-in by default)` : (isUserOptedOutOfAnalytics ? `You've chosen to opt-out from analytics tracking, and thus no event will be sent` : `You've chosen to opt-in to analytics tracking, and thus an event will be sent`)
+                }
+              </b>
+            </p>
+
+            <Button
+              onClick={(): void => logEvent('analytics-button-test-event', {
+                file: fileLabel,
               })}
             >
-              {/* The event is automatically sent upon component mount */}
-              <LogOnMount eventType="page-displayed" />
-            </Amplitude>
-          `}
-        />
+              Click me
+            </Button>
+            <br />
+            <br />
 
-        <hr />
+            <Code
+              text={`
+                <Amplitude>
+                  {({ logEvent }): JSX.Element => (
+                    <Button
+                      onClick={(): void => logEvent('analytics-button-test-event', {
+                        file: fileLabel,
+                      })}
+                    >
+                      Click me
+                    </Button>
+                  )}
+                </Amplitude>
+              `}
+            />
 
-        <p>
-          Below is how we log events upon user interaction (i.e: click)
-        </p>
-
-        <Code
-          text={`
-            <Amplitude>
-              {({ logEvent }): JSX.Element => (
-                <NavLink
-                  id={'nav-link-github-doc'}
-                  href={\`https://unlyed.github.io/next-right-now/\`}
-                  target={'_blank'}
-                  rel={'noopener'}
-                  onClick={(): void => {
-                    logEvent('open-github-doc', {
-                      additionalProps1: 'something', // It automatically inherits the analytic context and allows override/overload
-                    }); // This will send the even to amplitude
-                  }}
-                >
-                  <FontAwesomeIcon icon={['fas', 'book']} />
-                  {t('nav.githubDocPage.link', 'Documentation')}
-                </NavLink>
-              )}
-            </Amplitude>
-          `}
-        />
-
-      </DocPage>
+          </DocPage>
+        )}
+      </Amplitude>
     </DefaultLayout>
   );
 };

--- a/src/pages/[locale]/examples/built-in-features/cookies-consent.tsx
+++ b/src/pages/[locale]/examples/built-in-features/cookies-consent.tsx
@@ -1,0 +1,98 @@
+/** @jsx jsx */
+import { Amplitude } from '@amplitude/react-amplitude';
+import { jsx } from '@emotion/core';
+import { createLogger } from '@unly/utils-simple-logger';
+import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars
+import React from 'react';
+import { Alert } from 'reactstrap';
+import BuiltInFeaturesSidebar from '../../../../components/doc/BuiltInFeaturesSidebar';
+import DocPage from '../../../../components/doc/DocPage';
+import DefaultLayout from '../../../../components/pageLayouts/DefaultLayout';
+import ExternalLink from '../../../../components/utils/ExternalLink';
+import useUserConsent from '../../../../hooks/useUserConsent';
+import { CommonServerSideParams } from '../../../../types/nextjs/CommonServerSideParams';
+import { OnlyBrowserPageProps } from '../../../../types/pageProps/OnlyBrowserPageProps';
+import { SSGPageProps } from '../../../../types/pageProps/SSGPageProps';
+import { getExamplesCommonStaticPaths, getExamplesCommonStaticProps } from '../../../../utils/nextjs/SSG';
+
+const fileLabel = 'pages/[locale]/examples/built-in-features/cookies-consent';
+const logger = createLogger({ // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
+  label: fileLabel,
+});
+
+/**
+ * Only executed on the server side at build time
+ * Necessary when a page has dynamic routes and uses "getStaticProps"
+ */
+export const getStaticPaths: GetStaticPaths<CommonServerSideParams> = getExamplesCommonStaticPaths;
+
+/**
+ * Only executed on the server side at build time.
+ *
+ * @return Props (as "SSGPageProps") that will be passed to the Page component, as props
+ *
+ * @see https://github.com/vercel/next.js/discussions/10949#discussioncomment-6884
+ * @see https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
+ */
+export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams> = getExamplesCommonStaticProps;
+
+/**
+ * SSG pages are first rendered by the server (during static bundling)
+ * Then, they're rendered by the client, and gain additional props (defined in OnlyBrowserPageProps)
+ * Because this last case is the most common (server bundle only happens during development stage), we consider it a default
+ * To represent this behaviour, we use the native Partial TS keyword to make all OnlyBrowserPageProps optional
+ *
+ * Beware props in OnlyBrowserPageProps are not available on the server
+ */
+type Props = {} & SSGPageProps<Partial<OnlyBrowserPageProps>>;
+
+const ExampleCookiesConsentPage: NextPage<Props> = (props): JSX.Element => {
+  const { isUserOptedOutOfAnalytics, hasUserGivenAnyCookieConsent } = useUserConsent();
+
+  return (
+    <DefaultLayout
+      {...props}
+      pageName={'cookies-consent'}
+      headProps={{
+        title: 'Cookies consent examples - Next Right Now',
+      }}
+      Sidebar={BuiltInFeaturesSidebar}
+    >
+      <Amplitude>
+        {({ logEvent }): JSX.Element => (
+          <DocPage>
+            <h1 className={'pcolor'}>Cookies consent examples, using <code>CookieConsent</code> OSS library</h1>
+
+            <Alert color={'info'}>
+              Make sure to check
+              <ExternalLink
+                href={'https://github.com/osano/cookieconsent'}
+              >
+                <code>CookieConsent</code>
+              </ExternalLink>
+              OSS library.<br />
+              User consent regarding cookies has become a must-have for many businesses, and it very, very complicated.<br />
+              The laws depends on the end-user's country, which means you need to use a geo-location system to know which laws apply.<br />
+              <br />
+              This implementation is based on open source and free software, and is configured to properly handle consent for simple applications.<br />
+              It's not meant to be used as-it for any business that process personal or identifiable information.<br />
+              NRN doesn't process any personal/identifiable information, and it makes the job much simpler.<br />
+              <br />
+              Also, you can (more or less easily) switch from the current implementation to <ExternalLink href={'https://www.osano.com/cookieconsent'}>Osano vendor</ExternalLink>, if you wish or need to.<br />
+              The OSS and Business versions seem to share part of their API (unsure about that), but they're two different pieces of software.
+            </Alert>
+
+            Amplitude has been configured to stop tracking all kind of analytics as soon as the user opts-out from analytics tracking.<br />
+            Also, the current behaviour has been configured to automatically opt-in into all analytics tracking by default.<br />
+            We've made this choice because no personal data are being processed in any way, and thus it should be safe for most apps that don't process personal data to have such default behaviour. (it's safe to be used as-it in France (CNIL + GDPR), which is tough to deal with, so most countries should be safe)
+            <br />
+            Consent isn't stored though, since we consider analytics is allowed by default, we didn't want to complicate the app with that. Also, we don't have any personal information to link to such consents, so it really wouldn't make any sense in our case.
+          </DocPage>
+        )}
+      </Amplitude>
+    </DefaultLayout>
+  );
+};
+
+export default (ExampleCookiesConsentPage);

--- a/src/pages/[locale]/examples/built-in-features/cookies-consent.tsx
+++ b/src/pages/[locale]/examples/built-in-features/cookies-consent.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { Alert } from 'reactstrap';
 import BuiltInFeaturesSidebar from '../../../../components/doc/BuiltInFeaturesSidebar';
 import DocPage from '../../../../components/doc/DocPage';
+import I18nLink from '../../../../components/i18n/I18nLink';
 import DefaultLayout from '../../../../components/pageLayouts/DefaultLayout';
 import ExternalLink from '../../../../components/utils/ExternalLink';
 import useUserConsent from '../../../../hooks/useUserConsent';
@@ -63,6 +64,11 @@ const ExampleCookiesConsentPage: NextPage<Props> = (props): JSX.Element => {
         {({ logEvent }): JSX.Element => (
           <DocPage>
             <h1 className={'pcolor'}>Cookies consent examples, using <code>CookieConsent</code> OSS library</h1>
+
+            <Alert color={'warning'}>
+              The consent popup has been enabled only on this page and the <I18nLink href={'/terms'}>terms</I18nLink> page to avoid undesired popups popping everywhere.<br />
+              Note that the consent implementation makes you opt-in to analytics tracking by default unless you manually refuse it.
+            </Alert>
 
             <Alert color={'info'}>
               Make sure to check

--- a/src/pages/[locale]/examples/built-in-features/cookies-consent.tsx
+++ b/src/pages/[locale]/examples/built-in-features/cookies-consent.tsx
@@ -84,10 +84,18 @@ const ExampleCookiesConsentPage: NextPage<Props> = (props): JSX.Element => {
             </Alert>
 
             Amplitude has been configured to stop tracking all kind of analytics as soon as the user opts-out from analytics tracking.<br />
-            Also, the current behaviour has been configured to automatically opt-in into all analytics tracking by default.<br />
-            We've made this choice because no personal data are being processed in any way, and thus it should be safe for most apps that don't process personal data to have such default behaviour. (it's safe to be used as-it in France (CNIL + GDPR), which is tough to deal with, so most countries should be safe)
             <br />
-            Consent isn't stored though, since we consider analytics is allowed by default, we didn't want to complicate the app with that. Also, we don't have any personal information to link to such consents, so it really wouldn't make any sense in our case.
+            Also, the current behaviour has been configured to automatically opt-in into all analytics tracking by default.<br />
+            We've made this choice because no personal data are being processed in any way, and thus it should be safe for most apps that don't process personal data to have such default behaviour. (it's safe to be used as-it in France (CNIL + GDPR), which is very tough to deal with regarding privacy, so it should be safe to use this behaviour in most countries)<br />
+            <br />
+            User consent is stored on Amplitude, and tagged with the time and message that were displayed to the user at the time of consent. Denies are stored as well for analytics purposes. (but you can easily disable this behaviour if you wish)<br />
+            <br />
+            <Alert color={'warning'}>
+              The <code>CookieConsent</code> OSS library is not perfect, it kinda does the job but feel free to replace it with something better if you wish.<br />
+              Also, it most likely won't cover all legal requirements for all regulations for all countries. But it's a start, and a free one.<br />
+              <br />
+              Feel free to propose your help to improve it a bit, either by sending a PR to <code>CookieConsent</code> or NRN directly.
+            </Alert>
           </DocPage>
         )}
       </Amplitude>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { faTimesCircle } from '@fortawesome/free-regular-svg-icons';
 import { faArrowCircleLeft, faArrowCircleRight, faBook, faBookReader, faCoffee, faHome, faQuestionCircle, faUserCog } from '@fortawesome/free-solid-svg-icons';
 import 'animate.css/animate.min.css'; // Loads animate.css CSS file. See https://github.com/daneden/animate.css
 import 'bootstrap/dist/css/bootstrap.min.css'; // Loads bootstrap CSS file. See https://stackoverflow.com/a/50002905/2391795
+import 'cookieconsent/build/cookieconsent.min.css'; // Loads CookieConsent CSS file. See https://github.com/osano/cookieconsent
 import 'rc-tooltip/assets/bootstrap.css';
 import React from 'react';
 import uuid from 'uuid/v1'; // XXX Use v1 for uniqueness - See https://www.sohamkamani.com/blog/2016/10/05/uuid1-vs-uuid4/

--- a/src/stores/userConsentContext.tsx
+++ b/src/stores/userConsentContext.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { UserConsent } from '../types/UserConsent';
+
+export type UserConsentContext = UserConsent
+
+const initialContext = {};
+
+/**
+ * Uses native React Context API
+ *
+ * @example Usage
+ *  import userConsentContext from './src/stores/userConsentContext';
+ *  const { getUserConsent }: UserConsentContext = React.useContext(userConsentContext);
+ *
+ * @see https://reactjs.org/docs/context.html
+ * @see https://medium.com/better-programming/react-hooks-usecontext-30eb560999f for useContext hook example (open in anonymous browser #paywall)
+ */
+export const userConsentContext = React.createContext<UserConsentContext>(initialContext);
+
+export default userConsentContext;

--- a/src/types/UserConsent.ts
+++ b/src/types/UserConsent.ts
@@ -1,0 +1,8 @@
+/**
+ * Represents the user consent
+ * Mostly focused at cookies consent for analytics tracking ATM, but could be extended if needs be
+ */
+export type UserConsent = {
+  isUserOptedOutOfAnalytics?: boolean; // Whether the user has been opted out from analytics tracking, whether it's the result of a manual action, or from app's default behaviour
+  hasUserGivenAnyCookieConsent?: boolean; // Whether the isUserOptedOutOfAnalytics value comes from a manual choice (if not, then it's due to the app's default behaviour)
+};

--- a/src/utils/analytics/amplitude.ts
+++ b/src/utils/analytics/amplitude.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { isBrowser } from '@unly/utils';
 import { AmplitudeClient, Identify } from 'amplitude-js';
 import { NextWebVitalsMetricsReport } from '../../types/nextjs/NextWebVitalsMetricsReport';
+import { UserConsent } from '../../types/UserConsent';
 import { UserSemiPersistentSession } from '../../types/UserSemiPersistentSession';
 import UniversalCookiesManager from '../cookies/UniversalCookiesManager';
 
@@ -29,6 +30,7 @@ type GetAmplitudeInstanceProps = {
   lang: string;
   locale: string;
   userId: string;
+  userConsent: UserConsent;
 }
 
 export const getAmplitudeInstance = (props: GetAmplitudeInstanceProps): AmplitudeClient | null => {
@@ -42,7 +44,9 @@ export const getAmplitudeInstance = (props: GetAmplitudeInstanceProps): Amplitud
       lang,
       locale,
       userId,
+      userConsent,
     } = props;
+    const { isUserOptedOutOfAnalytics, hasUserGivenAnyCookieConsent } = userConsent;
 
     Sentry.configureScope((scope) => { // See https://www.npmjs.com/package/@sentry/node
       scope.setTag('iframe', `${isInIframe}`);
@@ -67,6 +71,16 @@ export const getAmplitudeInstance = (props: GetAmplitudeInstanceProps): Amplitud
       },
     });
 
+    // Disable analytics tracking entirely if the user has opted-out
+    if (isUserOptedOutOfAnalytics) {
+      amplitudeInstance.setOptOut(true); // If true, then no events will be logged or sent.
+      console.info('User has opted-out of analytics tracking.'); // eslint-disable-line no-console
+    } else {
+      // Re-enable tracking (necessary if it was previously disabled!)
+      amplitudeInstance.setOptOut(false);
+      console.info(`User has opted-in into analytics tracking. (Thank you! This helps us make our product better, and we don't track any personal/identifiable data.`); // eslint-disable-line no-console
+    }
+
     amplitudeInstance.setVersionName(process.env.NEXT_PUBLIC_APP_VERSION); // e.g: 1.0.0
 
     // We're only doing this when detecting a new session, as it won't be executed multiple times for the same session anyway, and it avoids noise
@@ -86,6 +100,8 @@ export const getAmplitudeInstance = (props: GetAmplitudeInstanceProps): Amplitud
       visitor.setOnce('locale', locale);
       visitor.setOnce('iframe', isInIframe);
       visitor.setOnce('iframeReferrer', iframeReferrer);
+      visitor.setOnce('isUserOptedOutOfAnalytics', isUserOptedOutOfAnalytics);
+      visitor.setOnce('hasUserGivenAnyCookieConsent', hasUserGivenAnyCookieConsent);
 
       amplitudeInstance.identify(visitor); // Send the new identify event to amplitude (updates user's identity)
     }

--- a/src/utils/analytics/amplitude.ts
+++ b/src/utils/analytics/amplitude.ts
@@ -100,8 +100,9 @@ export const getAmplitudeInstance = (props: GetAmplitudeInstanceProps): Amplitud
       visitor.setOnce('locale', locale);
       visitor.setOnce('iframe', isInIframe);
       visitor.setOnce('iframeReferrer', iframeReferrer);
-      visitor.setOnce('isUserOptedOutOfAnalytics', isUserOptedOutOfAnalytics);
-      visitor.setOnce('hasUserGivenAnyCookieConsent', hasUserGivenAnyCookieConsent);
+
+      visitor.set('isUserOptedOutOfAnalytics', isUserOptedOutOfAnalytics);
+      visitor.set('hasUserGivenAnyCookieConsent', hasUserGivenAnyCookieConsent);
 
       amplitudeInstance.identify(visitor); // Send the new identify event to amplitude (updates user's identity)
     }

--- a/src/utils/cookies/cookieConsent.ts
+++ b/src/utils/cookies/cookieConsent.ts
@@ -48,6 +48,9 @@ export const getUserConsent = (): UserConsent => {
  * Initialise the Cookie Consent UI popup
  * Relies on Osano open source "cookieconsent" software (v3) https://github.com/osano/cookieconsent
  *
+ * XXX This component lives completely outside of React render tree, it could/should probably be rewritten as a React component to be more "react-friendly"
+ * XXX You'll need to refresh the browser when updating this file or changes won't be applied
+ *
  * @param amplitudeInstance
  * @param theme
  * @param t
@@ -133,15 +136,11 @@ const init = (amplitudeInstance: AmplitudeClient, theme: CustomerTheme, t: TFunc
 
     // Events
     onInitialise: function(status) {
-      console.info('onInitialise', status);
-    },
-    onPopupOpen: function() {
-      console.info('onPopupOpen');
-    },
-    onPopupClose: function() {
-      console.info('onPopupClose');
+      console.info('onInitialise', `User consent from "${CONSENT_COOKIE_NAME}" cookie:`, status);
     },
     /**
+     * When the user selects another choice (initial choice, or change) then we toggle analytics tracking
+     *
      * The previousChoice is for the status
      * This event may trigger multiple times (once per status changed)
      *
@@ -150,10 +149,23 @@ const init = (amplitudeInstance: AmplitudeClient, theme: CustomerTheme, t: TFunc
      */
     onStatusChange: function(status, previousChoice) {
       console.info('onStatusChange', status, previousChoice);
+      if (status === 'deny') {
+        amplitudeInstance.setOptOut(true);
+        console.info('User has opted-out of analytics tracking.'); // eslint-disable-line no-console
+      } else if (status === 'allow') {
+        amplitudeInstance.setOptOut(false);
+        console.info(`User has opted-in into analytics tracking. (Thank you! This helps us make our product better, and we don't track any personal/identifiable data.`); // eslint-disable-line no-console
+      }
     },
-    onRevokeChoice: function() {
-      console.info('onRevokeChoice');
-    },
+    // onRevokeChoice: function() {
+    //   console.info('onRevokeChoice');
+    // },
+    // onPopupOpen: function() {
+    //   console.info('onPopupOpen');
+    // },
+    // onPopupClose: function() {
+    //   console.info('onPopupClose');
+    // },
   };
   cc.initialise(cookieConsentSettings);
 };

--- a/src/utils/cookies/cookieConsent.ts
+++ b/src/utils/cookies/cookieConsent.ts
@@ -1,0 +1,111 @@
+import { TFunction } from 'i18next';
+import { CustomerTheme } from '../../types/data/CustomerTheme';
+
+/**
+ * Initialise the Cookie Consent UI popup
+ * Relies on Osano open source "cookieconsent" software (v3) https://github.com/osano/cookieconsent
+ *
+ * @param theme
+ * @param t
+ *
+ * @see https://www.osano.com/cookieconsent/documentation/
+ * @see https://www.osano.com/cookieconsent/documentation/javascript-api/
+ * @see https://www.osano.com/cookieconsent/download/
+ */
+const init = (theme: CustomerTheme, t: TFunction): void => {
+  const { primaryColor } = theme;
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('cookieconsent'); // XXX Requiring it will make it available in the browser (cannot be used properly as a module)
+
+  // @ts-ignore
+  const cc = window.cookieconsent;
+
+  // Use https://www.osano.com/cookieconsent/download/ "Start Coding" to use the UI configuration builder
+  // See https://www.osano.com/cookieconsent/documentation/javascript-api/ for advanced API options and documentation
+  const cookieConsentSettings = {
+    autoOpen: true,
+    autoAttach: true,
+    type: 'opt-out', //
+    revokable: true,
+    dismissOnScroll: false,
+    dismissOnTimeout: false,
+    dismissOnWindowClick: false,
+    whitelistPage: [],
+    blacklistPage: [],
+    location: true, // XXX Can also be an object with advanced configuration to implement your own geolocation resolvers
+    cookie: {
+      name: 'cookieconsent_status',
+      path: '/',
+      domain: '',
+      expiryDays: 365,
+      secure: process.env.NEXT_PUBLIC_APP_STAGE !== 'development', // Always use a secure cookie on non-dev stages
+    },
+    palette: {
+      popup: {
+        background: '#fff',
+      },
+      button: {
+        background: '#fff',
+        text: primaryColor,
+      },
+    },
+    theme: 'classic',
+    position: 'bottom-right',
+    content: {
+      header: 'Cookies used on the website!',
+      message: 'This website uses cookies to improve your experience.',
+      dismiss: 'Got it!',
+      allow: 'Allow cookies',
+      deny: 'Decline',
+      link: 'Learn more',
+      href: '/terms',
+      target: '', // Use "_blank" if you use an external "href" value
+      close: '&#x274c;',
+      policy: 'Cookie Policy',
+    },
+    // elements: {
+    //   header: '<span class="cc-header"></span>',
+    //   message: '<span id="cookieconsent:desc" class="cc-message"></span>',
+    //   messagelink: '<span id="cookieconsent:desc" class="cc-message"> <a aria-label="learn more about cookies" tabindex="0" class="cc-link" href="" target="_blank"></a></span>',
+    //   dismiss: '<a aria-label="dismiss cookie message" tabindex="0" class="cc-btn cc-dismiss"></a>',
+    //   allow: '<a aria-label="allow cookies" tabindex="0" class="cc-btn cc-allow"></a>',
+    //   deny: '<a aria-label="deny cookies" tabindex="0" class="cc-btn cc-deny"></a>',
+    //   link: '<a aria-label="learn more about cookies" tabindex="0" class="cc-link" href="" target="_blank"></a>',
+    //   close: '<span aria-label="dismiss cookie message" tabindex="0" class="cc-close"></span>',
+    // },
+    // window: '<div role="”dialog”" aria-label="”cookieconsent”" aria-describedby="”cookieconsent:desc”" class="”cc-window" ”></div>',
+    // compliance: {
+    //   'info': '<div class="cc-compliance"></div>',
+    //   'opt-in': '<div class="cc-compliance cc-highlight"></div>',
+    //   'opt-out': '<div class="cc-compliance cc-highlight"></div>',
+    // },
+    onInitialise: function(status) {
+      console.info('onInitialise', status);
+    },
+    onPopupOpen: function() {
+      console.info('onPopupOpen');
+    },
+    onPopupClose: function() {
+      console.info('onPopupClose');
+    },
+    onStatusChange: function(status, chosenBefore) {
+      console.info('onStatusChange', status, chosenBefore);
+    },
+    onRevokeChoice: function() {
+      console.info('onRevokeChoice');
+    },
+  };
+  cc.initialise(cookieConsentSettings);
+
+  // THis is v4...
+  // cc.on('initialized', (...args) => console.log(args));
+  // cc.on('error', console.error);
+  // cc.on('popupOpened', () => console.log('Popup Open'));
+  // cc.on('popupClosed', () => console.log('Popup Closed'));
+  // cc.on('revokeChoice', () => console.log('Popup Reset'));
+  // cc.on('statusChanged', (...args) => console.log(args));
+
+};
+
+export default init;

--- a/src/utils/cookies/cookieConsent.ts
+++ b/src/utils/cookies/cookieConsent.ts
@@ -102,8 +102,8 @@ const init = (options: InitOptions): void => {
 
   // @ts-ignore
   const cc = window.cookieconsent;
-  const additionalMessage = hasUserGivenAnyCookieConsent ? isUserOptedOutOfAnalytics ? `<br /><b>Vous aviez refusé les cookies. Veuillez reconfirmer votre choix.</b><br /><br />` : `<br /><b>Vous aviez autorisé les cookies. Veuillez reconfirmer votre choix.</b><br /><br />` : '';
-  const message = `Nous utilisons des cookies pour faire des mesures d'audience anonymes afin de nous permettre d'identifier les fonctionnalités les plus utilisées et les pages les plus consultées.<br /><br /><i>Aucune information personnelle n'est recueillie, ni partagée à quelconque tiers.</i><br />${additionalMessage}`;
+  const additionalMessage = hasUserGivenAnyCookieConsent ? isUserOptedOutOfAnalytics ? t('cookieConsent.message.userDenied', `<br /><b>Vous aviez refusé les cookies. Veuillez reconfirmer votre choix.</b><br /><br />`) : t('cookieConsent.message.userAllowed', `<br /><b>Vous aviez autorisé les cookies. Veuillez reconfirmer votre choix.</b><br /><br />`) : '';
+  const message = t('cookieConsent.message.cookieUsage', `Nous utilisons des cookies pour faire des mesures d'audience anonymes afin de nous permettre d'identifier les fonctionnalités les plus utilisées et les pages les plus consultées.<br /><br /><i>Aucune information personnelle n'est recueillie, ni partagée à quelconque tiers.</i><br />${additionalMessage}`);
 
   // Use https://www.osano.com/cookieconsent/download/ "Start Coding" to use the UI configuration builder
   // See https://www.osano.com/cookieconsent/documentation/javascript-api/ for advanced API options and documentation
@@ -158,22 +158,28 @@ const init = (options: InitOptions): void => {
 
     // Content (texts, wording)
     content: {
-      header: `Cookies utilisés sur le site`,
+      header: t('cookieConsent.content.header', `Cookies utilisés sur le site`),
       message: message,
-      dismiss: `Ok !`,
-      allow: `Accepter`,
-      deny: `Refuser`,
-      link: `En savoir plus`,
+      dismiss: t('cookieConsent.content.dismiss', `Ok !`),
+      allow: t('cookieConsent.content.allow', `Accepter`),
+      deny: t('cookieConsent.content.deny', `Refuser`),
+      link: t('cookieConsent.content.link', `En savoir plus`),
       href: `/${locale}/terms`,
       target: ``, // Use "_blank" if you use an external "href" value
-      close: `fermer&#x274c;`,
-      policy: `Politique de confidentialité`,
+      close: `&#x274c;`,
+      policy: t('cookieConsent.content.policy', `Politique de confidentialité`),
     },
 
     // Events
+
+    /**
+     * Triggers when the lib initialises
+     * Will provide the value contained in CONSENT_COOKIE_NAME cookie
+     */
     onInitialise: function(status) {
       console.info('onInitialise', `User consent from "${CONSENT_COOKIE_NAME}" cookie:`, status);
     },
+
     /**
      * When the user selects another choice (initial choice, or change) then we toggle analytics tracking
      *
@@ -193,7 +199,7 @@ const init = (options: InitOptions): void => {
           message, // Store the text that was displayed to the user at the time
         });
         amplitudeInstance.setOptOut(true);
-        // TODO Delete the amplitude cookie to clear all traces? It'd be better, but cookie's name is random... See https://github.com/amplitude/Amplitude-JavaScript/issues/277
+        // TODO Delete the amplitude cookie to clear all traces? It'd be better, but cookie's name is random... And it'd be regenerated anyway... See https://github.com/amplitude/Amplitude-JavaScript/issues/277
         console.info('User has opted-out of analytics tracking.'); // eslint-disable-line no-console
       } else if (status === 'allow') {
         // Enable analytics tracking, then store user choice
@@ -206,6 +212,7 @@ const init = (options: InitOptions): void => {
         console.info(`User has opted-in into analytics tracking. (Thank you! This helps us make our product better, and we don't track any personal/identifiable data.`); // eslint-disable-line no-console
       }
     },
+
     /**
      * Triggers when the current choice has been revoked.
      *
@@ -218,9 +225,17 @@ const init = (options: InitOptions): void => {
       console.info('onRevokeChoice');
       console.info(`Previous choice has been revoked, "${CONSENT_COOKIE_NAME}" cookie has been deleted.`);
     },
+
+    /**
+     * Triggers when the popup opens
+     */
     onPopupOpen: function() {
       console.info('onPopupOpen');
     },
+
+    /**
+     * Triggers when the popup closes
+     */
     onPopupClose: function() {
       console.info('onPopupClose');
     },

--- a/src/utils/cookies/cookies.ts
+++ b/src/utils/cookies/cookies.ts
@@ -1,4 +1,6 @@
 /**
+ * Delete all existing cookies in the browser
+ *
  * @see https://stackoverflow.com/a/179514/2391795
  */
 export const deleteAllCookies = (): void => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4024,6 +4024,11 @@ cookie@^0.3.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
+cookieconsent@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/cookieconsent/-/cookieconsent-3.1.1.tgz#f90bfadcaeef7d2bdcdd8278257f7264cb5d6819"
+  integrity sha512-v8JWLJcI7Zs9NWrs8hiVldVtm3EBF70TJI231vxn6YToBGj0c9dvdnYwltydkAnrbBMOM/qX1xLFrnTfm5wTag==
+
 cookies@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.8.0.tgz#1293ce4b391740a8406e3c9870e828c4b54f3f90"


### PR DESCRIPTION
Demo: https://nrn-v2-mst-aptd-at-lcz-sty-c1-cookies-con.vercel.app

Allow end-users to consent (or not) to cookies.

Simple implementation based on the open-source tool "[cookieconsent](https://github.com/osano/cookieconsent)", only handle agree/deny/dismiss choices.

Creates a cookie to store the user's choice on the device.
When users don't consent, all analytics is disabled (Amplitude). 
When users consent, their choice is stored on Amplitude, and their behavior is tracked.

Stores events for people who deny/allow, so that we can have some stats about how many agree and don't, also stores metadata associated with the consent (time, message displayed to the user)

The Amplitude cookie is not destroyed when user denies though, or it wouldn't be possible to switch on/off easily during navigation without a full page refresh, this isn't perfect according to GDPR, but I don't see how to do it better without completely disabling Amplitude when user has denied. Which would likely lead to other issues.