### PR TITLE
Auto-alias custom domains

### DIFF
--- a/.github/workflows/deploy-zeit-production.yml
+++ b/.github/workflows/deploy-zeit-production.yml
@@ -56,24 +56,20 @@ jobs:
           MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
           echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
 
-          CUSTOMER_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq -r '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-          echo "Customer to deploy: " $CUSTOMER_TO_DEPLOY
+          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
+          echo "Customer to deploy: " $CUSTOMER_REF_TO_DEPLOY
 
           # Deploy the customer on Vercel using the customer specified in now.json (e.g: "yarn deploy:customer1:production:simple")
-          yarn deploy:$CUSTOMER_TO_DEPLOY:production:simple --token $ZEIT_TOKEN
-
-          # Apply all aliases specified in the now.json file (if any is specified)
-          # Find all aliases configured in the customer deployment configuration file (now.json)
-          ZEIT_DEPLOYMENT_ALIASES_JSON=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.alias')
-          echo "Custom aliases: " $ZEIT_DEPLOYMENT_ALIASES_JSON
-
+          yarn deploy:$CUSTOMER_REF_TO_DEPLOY:production:simple --token $ZEIT_TOKEN
           # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
           readarray -t ZEIT_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < now.$CUSTOMER_REF_TO_DEPLOY.staging.json)
 
-          # Check if there are no aliases configured (it will return "null" in such case, which is not the same as bash "empty")
-          if [ "$ZEIT_DEPLOYMENT_ALIASES" != null ] || [ ${#ZEIT_DEPLOYMENT_ALIASES[@]} > 0 ]
+          # Count the number of element in the array, will be 0 if it's an empty array, or if the "alias" key wasn't defined
+          ZEIT_DEPLOYMENT_ALIASES_COUNT=${#ZEIT_DEPLOYMENT_ALIASES[@]}
+
+          # Check if there are no aliases configured
+          if [ "$ZEIT_DEPLOYMENT_ALIASES" > 0 ]
           then
-            ZEIT_DEPLOYMENT_ALIASES_COUNT=${#ZEIT_DEPLOYMENT_ALIASES[@]}
             echo "$ZEIT_DEPLOYMENT_ALIASES_COUNT alias(es) found. Aliasing them now..."
 
             # For each alias configured, then assign it to the deployed domain
@@ -86,7 +82,6 @@ jobs:
             echo "There are no more aliases to configure. You can add more aliases from your now.json 'alias' property. See https://vercel.com/docs/configuration?query=alias%20domain#project/alias"
             echo "$ZEIT_DEPLOYMENT_ALIASES"
           fi
-
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
 
@@ -115,17 +110,17 @@ jobs:
           echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
           echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
 
-          CUSTOMER_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq -r '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-          echo "Customer that was deployed: " $CUSTOMER_TO_DEPLOY
-          echo "CUSTOMER_TO_DEPLOY=$CUSTOMER_TO_DEPLOY" >> $GITHUB_ENV
+          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
+          echo "Customer that was deployed: " $CUSTOMER_REF_TO_DEPLOY
+          echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
 
           # Resolve Vercel team ID
-          VERCEL_TEAM_ID=`cat now.$CUSTOMER_TO_DEPLOY.production.json | jq -r '.scope'`
+          VERCEL_TEAM_ID=`cat now.$CUSTOMER_REF_TO_DEPLOY.production.json | jq --raw-output '.scope'`
           echo "Vercel team ID: " $VERCEL_TEAM_ID
           echo "VERCEL_TEAM_ID=$VERCEL_TEAM_ID" >> $GITHUB_ENV
 
           # Resolve Vercel project name
-          VERCEL_PROJECT_NAME=`cat now.$CUSTOMER_TO_DEPLOY.production.json | jq -r '.name'`
+          VERCEL_PROJECT_NAME=`cat now.$CUSTOMER_REF_TO_DEPLOY.production.json | jq --raw-output '.name'`
           echo "Vercel project name: " $VERCEL_PROJECT_NAME
           echo "VERCEL_PROJECT_NAME=$VERCEL_PROJECT_NAME" >> $GITHUB_ENV
 
@@ -149,7 +144,7 @@ jobs:
         uses: cypress-io/github-action@v1 # XXX See https://github.com/cypress-io/github-action
         with:
           wait-on: ${{ env.ZEIT_DEPLOYMENT_URL }} # Be sure that the endpoint is ready by pinging it before starting tests, it has a timeout of 60seconds
-          config-file: cypress/config-${{ env.CUSTOMER_TO_DEPLOY }}.json # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
+          config-file: cypress/config-${{ env.CUSTOMER_REF_TO_DEPLOY }}.json # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
           config: baseUrl=${{ env.ZEIT_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
         env:
           # Enables Cypress debugging logs, very useful if Cypress crashes, like out-of-memory issues.
@@ -194,17 +189,17 @@ jobs:
           echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
           echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
 
-          CUSTOMER_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq -r '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-          echo "Customer that was deployed: " $CUSTOMER_TO_DEPLOY
-          echo "CUSTOMER_TO_DEPLOY=$CUSTOMER_TO_DEPLOY" >> $GITHUB_ENV
+          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
+          echo "Customer that was deployed: " $CUSTOMER_REF_TO_DEPLOY
+          echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
 
           # Resolve Vercel team ID
-          VERCEL_TEAM_ID=`cat now.$CUSTOMER_TO_DEPLOY.production.json | jq -r '.scope'`
+          VERCEL_TEAM_ID=`cat now.$CUSTOMER_REF_TO_DEPLOY.production.json | jq --raw-output '.scope'`
           echo "Vercel team ID: " $VERCEL_TEAM_ID
           echo "VERCEL_TEAM_ID=$VERCEL_TEAM_ID" >> $GITHUB_ENV
 
           # Resolve Vercel project name
-          VERCEL_PROJECT_NAME=`cat now.$CUSTOMER_TO_DEPLOY.production.json | jq -r '.name'`
+          VERCEL_PROJECT_NAME=`cat now.$CUSTOMER_REF_TO_DEPLOY.production.json | jq --raw-output '.name'`
           echo "Vercel project name: " $VERCEL_PROJECT_NAME
           echo "VERCEL_PROJECT_NAME=$VERCEL_PROJECT_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/deploy-zeit-production.yml
+++ b/.github/workflows/deploy-zeit-production.yml
@@ -47,6 +47,7 @@ jobs:
         # Workflow overview:
         #   - Resolve customer to deploy from github event input (falls back to resolving it from now.json file)
         #   - Deploy the customer in production
+        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
           # Print the version of the "now" CLI being used (helps debugging)
           now --version
@@ -103,6 +104,7 @@ jobs:
         #     - Resolve the last url (from `response.deployments[0].url`)
         #     - Remove the `"` character to pre-format url
         # We need to set env the url for next step, formatted as `https://${$ZEIT_DEPLOYMENT}`
+        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
           apt update -y >/dev/null && apt install -y jq >/dev/null
 
@@ -182,6 +184,7 @@ jobs:
         #     - Resolve the last url (from `response.deployments[0].url`)
         #     - Remove the `"` character to pre-format url
         # We need to set env the url for next step, formatted as `https://${$ZEIT_DEPLOYMENT}/en` using /en endpoint to improve perfs by avoiding the url redirect on /
+        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
           apt update -y >/dev/null && apt install -y jq >/dev/null
 

--- a/.github/workflows/deploy-zeit-production.yml
+++ b/.github/workflows/deploy-zeit-production.yml
@@ -61,6 +61,32 @@ jobs:
 
           # Deploy the customer on Vercel using the customer specified in now.json (e.g: "yarn deploy:customer1:production:simple")
           yarn deploy:$CUSTOMER_TO_DEPLOY:production:simple --token $ZEIT_TOKEN
+
+          # Apply all aliases specified in the now.json file (if any is specified)
+          # Find all aliases configured in the customer deployment configuration file (now.json)
+          ZEIT_DEPLOYMENT_ALIASES_JSON=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.alias')
+          echo "Custom aliases: " $ZEIT_DEPLOYMENT_ALIASES_JSON
+
+          # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
+          readarray -t ZEIT_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < now.$CUSTOMER_REF_TO_DEPLOY.staging.json)
+
+          # Check if there are no aliases configured (it will return "null" in such case, which is not the same as bash "empty")
+          if [ "$ZEIT_DEPLOYMENT_ALIASES" != null ] || [ ${#ZEIT_DEPLOYMENT_ALIASES[@]} > 0 ]
+          then
+            ZEIT_DEPLOYMENT_ALIASES_COUNT=${#ZEIT_DEPLOYMENT_ALIASES[@]}
+            echo "$ZEIT_DEPLOYMENT_ALIASES_COUNT alias(es) found. Aliasing them now..."
+
+            # For each alias configured, then assign it to the deployed domain
+            for DEPLOYMENT_ALIAS in "${ZEIT_DEPLOYMENT_ALIASES[@]}"; do
+              echo "npx now alias "$ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS
+              npx now alias $ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed for '$DEPLOYMENT_ALIAS', but the build will continue regardless."
+            done
+          else
+            # $ZEIT_DEPLOYMENT_ALIASES is null, this happens when it was not defined in the now.json file
+            echo "There are no more aliases to configure. You can add more aliases from your now.json 'alias' property. See https://vercel.com/docs/configuration?query=alias%20domain#project/alias"
+            echo "$ZEIT_DEPLOYMENT_ALIASES"
+          fi
+
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
 

--- a/.github/workflows/deploy-zeit-production.yml
+++ b/.github/workflows/deploy-zeit-production.yml
@@ -62,6 +62,11 @@ jobs:
 
           # Deploy the customer on Vercel using the customer specified in now.json (e.g: "yarn deploy:customer1:production:simple")
           yarn deploy:$CUSTOMER_REF_TO_DEPLOY:production:simple --token $ZEIT_TOKEN
+
+          # Find all custom aliases configured in the customer deployment configuration file (now.json)
+          ZEIT_DEPLOYMENT_ALIASES_JSON=$(cat now.$CUSTOMER_REF_TO_DEPLOY.production.json | jq --raw-output '.alias')
+          echo "Custom aliases: " $ZEIT_DEPLOYMENT_ALIASES_JSON
+
           # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
           readarray -t ZEIT_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < now.$CUSTOMER_REF_TO_DEPLOY.staging.json)
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -145,6 +145,7 @@ jobs:
         #     - Resolve the last url (from `response.deployments[0].url`)
         #     - Remove the `"` character to pre-format url
         # We need to set env the url for next step, formatted as `https://${$ZEIT_DEPLOYMENT}`
+        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
           apt update -y >/dev/null && apt install -y jq >/dev/null
 
@@ -255,6 +256,7 @@ jobs:
         #     - Resolve the last url (from `response.deployments[0].url`)
         #     - Remove the `"` character to pre-format url
         # We need to set env the url for next step, formatted as `https://${$ZEIT_DEPLOYMENT}/en` using /en endpoint to improve perfs by avoiding the url redirect on /
+        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
           apt update -y >/dev/null && apt install -y jq >/dev/null
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -108,8 +108,7 @@ jobs:
            echo $ZEIT_ALIASING_OUTPUT
            # TODO Resolve whether the aliasing has worked and change the GitHub comment "Comment PR (Deployment success)"
 
-           # Apply all aliases specified in the now.json file (if any is specified)
-           # Find all aliases configured in the customer deployment configuration file (now.json)
+           # Find all custom aliases configured in the customer deployment configuration file (now.json)
            ZEIT_DEPLOYMENT_ALIASES_JSON=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.alias')
            echo "Custom aliases: " $ZEIT_DEPLOYMENT_ALIASES_JSON
 

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -53,44 +53,87 @@ jobs:
         # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
           # Print the version of the "now" CLI being used (helps debugging)
-          now --version
+           now --version
 
-          # Resolving customer to deploy based on the github event input, when using manual deployment triggerer through "workflow_dispatch" event
-          # Falls back to the customer specified in the now.json file, which is most useful when deployment is triggered through "push" event
-          MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
-          echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
-          echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
+           # Resolving customer to deploy based on the github event input, when using manual deployment triggerer through "workflow_dispatch" event
+           # Falls back to the customer specified in the now.json file, which is most useful when deployment is triggered through "push" event
+           MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
+           echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
+           echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
 
-          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-          echo "Customer to deploy: " $CUSTOMER_REF_TO_DEPLOY
-          echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
+           CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
+           echo "Customer to deploy: " $CUSTOMER_REF_TO_DEPLOY
+           echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
 
-          # Apply all aliases specified in the now.json file (if any is specified)
-          # Find all aliases configured in the customer deployment configuration file (now.json)
-          ZEIT_DEPLOYMENT_ALIASES_JSON=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.alias')
-          echo "Custom aliases: " $ZEIT_DEPLOYMENT_ALIASES_JSON
+           # Deploy the customer on Vercel using the customer ref (e.g: "yarn deploy:customer1")
+           # Store the output in a variable so we can extract metadata from it
+           ZEIT_DEPLOYMENT_OUTPUT=`yarn deploy:$CUSTOMER_REF_TO_DEPLOY --token $ZEIT_TOKEN`
 
-          # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
-          readarray -t ZEIT_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < now.$CUSTOMER_REF_TO_DEPLOY.staging.json)
+           # Extract the Vercel deployment url from the deployment output
+           ZEIT_DEPLOYMENT_URL=`echo $ZEIT_DEPLOYMENT_OUTPUT | egrep -o 'https?://[^ ]+.vercel.app'`
+           echo "Deployment url: " $ZEIT_DEPLOYMENT_URL
+           echo "ZEIT_DEPLOYMENT_URL=$ZEIT_DEPLOYMENT_URL" >> $GITHUB_ENV
 
-          # Count the number of element in the array, will be 0 if it's an empty array, or if the "alias" key wasn't defined
-          ZEIT_DEPLOYMENT_ALIASES_COUNT=${#ZEIT_DEPLOYMENT_ALIASES[@]}
+           # Build the alias domain based on our own rules (NRN own rules)
+           # Basically, if a branch starts with "v[0-9]" then we consider it to be a "preset branch" and we use the branch name as alias (e.g: "v2-mst-xxx")
+           # Otherwise, we use the deployment name and suffix it using the branch name (e.g: "v2-mst-xxx-branch-name")
+           if [[ ${CURRENT_BRANCH##*/} =~ ^v[0-9]{1,}- ]]; then # Checking if pattern matches with "vX-" where X is a number
+             ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=${CURRENT_BRANCH##*/}
+           else
+             ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.name')-${CURRENT_BRANCH##*/}
+           fi
+           echo "Resolved domain alias: " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
 
-          # Check if there are no aliases configured
-          if [ "$ZEIT_DEPLOYMENT_ALIASES" > 0 ]
-          then
-            echo "$ZEIT_DEPLOYMENT_ALIASES_COUNT alias(es) found. Aliasing them now..."
+           # Zeit alias only allows 41 characters in the domain name, so we only keep the first 41 (41 = 53 - 11 - 1) characters (because Zeit needs 7 chars for ".vercel.app" at the end of the domain name, and count starts at 1, not 0)
+           # Also, in order to remove forbidden characters, we transform every characters which are not a "alnum" and \n or \r into '-'
+           ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=$(echo $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS | head -c 41 | tr -c '[:alnum:]\r\n' - | tr '[:upper:]' '[:lower:]')
+           echo "Sanitized domain alias (1): " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
 
-            # For each alias configured, then assign it to the deployed domain
-            for DEPLOYMENT_ALIAS in "${ZEIT_DEPLOYMENT_ALIASES[@]}"; do
-              echo "npx now alias "$ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS
-              npx now alias $ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed for '$DEPLOYMENT_ALIAS', but the build will continue regardless."
-            done
-          else
-            # $ZEIT_DEPLOYMENT_ALIASES is null, this happens when it was not defined in the now.json file
-            echo "There are no more aliases to configure. You can add more aliases from your now.json 'alias' property. See https://vercel.com/docs/configuration?query=alias%20domain#project/alias"
-            echo "$ZEIT_DEPLOYMENT_ALIASES"
-          fi
+           # Recursively remove any trailing dash ('-') to protect against invalid alias domain (not allowed to end with a trailing slash)
+           while [[ "$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS" == *- ]]
+           do
+             ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=${ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS::-1}
+           done
+           echo "Sanitized domain alias (2): " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
+
+           # Build alias url
+           ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS="${ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS}.vercel.app"
+           echo "ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS" >> $GITHUB_ENV
+           echo "Alias domain: "$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
+           echo "Aliasing the deployment using the git branch alias:"
+           echo "npx now alias "$ZEIT_DEPLOYMENT_URL $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
+
+           # Create Vercel alias, use "||" to allow failure (keep the build going) even if the alias fails
+           ZEIT_ALIASING_OUTPUT=`npx now alias $ZEIT_DEPLOYMENT_URL $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed for '$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS', but the build will continue regardless."`
+           echo $ZEIT_ALIASING_OUTPUT
+           # TODO Resolve whether the aliasing has worked and change the GitHub comment "Comment PR (Deployment success)"
+
+           # Apply all aliases specified in the now.json file (if any is specified)
+           # Find all aliases configured in the customer deployment configuration file (now.json)
+           ZEIT_DEPLOYMENT_ALIASES_JSON=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.alias')
+           echo "Custom aliases: " $ZEIT_DEPLOYMENT_ALIASES_JSON
+
+           # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
+           readarray -t ZEIT_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < now.$CUSTOMER_REF_TO_DEPLOY.staging.json)
+
+           # Count the number of element in the array, will be 0 if it's an empty array, or if the "alias" key wasn't defined
+           ZEIT_DEPLOYMENT_ALIASES_COUNT=${#ZEIT_DEPLOYMENT_ALIASES[@]}
+
+           # Check if there are no aliases configured
+           if [ "$ZEIT_DEPLOYMENT_ALIASES" > 0 ]
+           then
+             echo "$ZEIT_DEPLOYMENT_ALIASES_COUNT alias(es) found. Aliasing them now..."
+
+             # For each alias configured, then assign it to the deployed domain
+             for DEPLOYMENT_ALIAS in "${ZEIT_DEPLOYMENT_ALIASES[@]}"; do
+               echo "npx now alias "$ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS
+               npx now alias $ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed for '$DEPLOYMENT_ALIAS', but the build will continue regardless."
+             done
+           else
+             # $ZEIT_DEPLOYMENT_ALIASES is null, this happens when it was not defined in the now.json file
+             echo "There are no more aliases to configure. You can add more aliases from your now.json 'alias' property. See https://vercel.com/docs/configuration?query=alias%20domain#project/alias"
+             echo "$ZEIT_DEPLOYMENT_ALIASES"
+           fi
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to the worker

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -91,9 +91,9 @@ jobs:
 
           # Recursively remove any trailing dash ('-') to protect against invalid alias domain (not allowed to end with a trailing slash)
           while [[ "$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS" == *- ]]
-            do
-              ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=${ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS::-1}
-            done
+          do
+            ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=${ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS::-1}
+          done
           echo "Sanitized domain alias (2): " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
 
            # Build alias url

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -50,6 +50,7 @@ jobs:
         #   - Get stdout from deploy command (stderr prints build steps and stdout prints deployment url, which is what we are really looking for)
         #   - Set the deployment url that will be included in the eventual PR comment
         #   - Create a deployment alias based on the branch name, and link it to the deployment (so that each branch has its own domain automatically aliased to the latest commit)
+        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
           # Print the version of the "now" CLI being used (helps debugging)
           now --version
@@ -60,52 +61,9 @@ jobs:
           echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
           echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
 
-          CUSTOMER_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq -r '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-          echo "Customer to deploy: " $CUSTOMER_TO_DEPLOY
-          echo "CUSTOMER_TO_DEPLOY=$CUSTOMER_TO_DEPLOY" >> $GITHUB_ENV
-
-          # Deploy the customer on Vercel using the customer specified in now.json (e.g: "yarn deploy:customer1")
-          # Store the output in a variable so we can extract metadata from it
-          ZEIT_DEPLOYMENT_OUTPUT=`yarn deploy:$CUSTOMER_TO_DEPLOY --token $ZEIT_TOKEN`
-
-          # Extract the Vercel deployment url from the deployment output
-          ZEIT_DEPLOYMENT_URL=`echo $ZEIT_DEPLOYMENT_OUTPUT | egrep -o 'https?://[^ ]+.vercel.app'`
-          echo "Deployment url: " $ZEIT_DEPLOYMENT_URL
-          echo "ZEIT_DEPLOYMENT_URL=$ZEIT_DEPLOYMENT_URL" >> $GITHUB_ENV
-
-          # Build the alias domain based on our own rules (NRN own rules)
-          # Basically, if a branch starts with "v[0-9]" then we consider it to be a "preset branch" and we use the branch name as alias (e.g: "v2-mst-xxx")
-          # Otherwise, we use the deployment name and suffix it using the branch name (e.g: "v2-mst-xxx-branch-name")
-          if [[ ${CURRENT_BRANCH##*/} =~ ^v[0-9]{1,}- ]]; then # Checking if pattern matches with "vX-" where X is a number
-            ZEIT_DEPLOYMENT_ALIAS=${CURRENT_BRANCH##*/}
-          else
-            ZEIT_DEPLOYMENT_ALIAS=$(cat now.$CUSTOMER_TO_DEPLOY.staging.json | jq -r '.name')-${CURRENT_BRANCH##*/}
-          fi
-          echo "Resolved domain alias: " $ZEIT_DEPLOYMENT_ALIAS
-
-          # Zeit alias only allows 41 characters in the domain name, so we only keep the first 41 (41 = 53 - 11 - 1) characters (because Zeit needs 7 chars for ".vercel.app" at the end of the domain name, and count starts at 1, not 0)
-          # Also, in order to remove forbidden characters, we transform every characters which are not a "alnum" and \n or \r into '-'
-          ZEIT_DEPLOYMENT_ALIAS=$(echo $ZEIT_DEPLOYMENT_ALIAS | head -c 41 | tr -c '[:alnum:]\r\n' - | tr '[:upper:]' '[:lower:]')
-          echo "Sanitized domain alias (1): " $ZEIT_DEPLOYMENT_ALIAS
-
-          # Recursively remove any trailing dash ('-') to protect against invalid alias domain (not allowed to end with a trailing slash)
-          while [[ "$ZEIT_DEPLOYMENT_ALIAS" == *- ]]
-          do
-            ZEIT_DEPLOYMENT_ALIAS=${ZEIT_DEPLOYMENT_ALIAS::-1}
-          done
-          echo "Sanitized domain alias (2): " $ZEIT_DEPLOYMENT_ALIAS
-
-          # Build alias url
-          ZEIT_DEPLOYMENT_ALIAS="${ZEIT_DEPLOYMENT_ALIAS}.vercel.app"
-          echo "ZEIT_DEPLOYMENT_ALIAS=$ZEIT_DEPLOYMENT_ALIAS" >> $GITHUB_ENV
-          echo "Alias domain: "$ZEIT_DEPLOYMENT_ALIAS
-          echo "Aliasing the deployment using the git branch alias:"
-          echo "npx now alias "$ZEIT_DEPLOYMENT_URL $ZEIT_DEPLOYMENT_ALIAS
-
-          # Create Vercel alias, use "||" to allow failure (keep the build going) even if the alias fails
-          ZEIT_ALIASING_OUTPUT=`npx now alias $ZEIT_DEPLOYMENT_URL $ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed, but the build will continue regardless."`
-          echo $ZEIT_ALIASING_OUTPUT
-          # TODO Resolve whether the aliasing has worked and change the GitHub comment "Comment PR (Deployment success)"
+          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
+          echo "Customer to deploy: " $CUSTOMER_REF_TO_DEPLOY
+          echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
 
           # Apply all aliases specified in the now.json file (if any is specified)
           # Find all aliases configured in the customer deployment configuration file (now.json)
@@ -115,10 +73,12 @@ jobs:
           # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
           readarray -t ZEIT_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < now.$CUSTOMER_REF_TO_DEPLOY.staging.json)
 
-          # Check if there are no aliases configured (it will return "null" in such case, which is not the same as bash "empty")
-          if [ "$ZEIT_DEPLOYMENT_ALIASES" != null ] || [ ${#ZEIT_DEPLOYMENT_ALIASES[@]} > 0 ]
+          # Count the number of element in the array, will be 0 if it's an empty array, or if the "alias" key wasn't defined
+          ZEIT_DEPLOYMENT_ALIASES_COUNT=${#ZEIT_DEPLOYMENT_ALIASES[@]}
+
+          # Check if there are no aliases configured
+          if [ "$ZEIT_DEPLOYMENT_ALIASES" > 0 ]
           then
-            ZEIT_DEPLOYMENT_ALIASES_COUNT=${#ZEIT_DEPLOYMENT_ALIASES[@]}
             echo "$ZEIT_DEPLOYMENT_ALIASES_COUNT alias(es) found. Aliasing them now..."
 
             # For each alias configured, then assign it to the deployed domain
@@ -131,7 +91,6 @@ jobs:
             echo "There are no more aliases to configure. You can add more aliases from your now.json 'alias' property. See https://vercel.com/docs/configuration?query=alias%20domain#project/alias"
             echo "$ZEIT_DEPLOYMENT_ALIASES"
           fi
-
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to the worker
@@ -166,7 +125,7 @@ jobs:
           body: |
             :white_check_mark:&nbsp; Deployment **SUCCESS**
             Commit ${{ github.sha }} successfully deployed to [${{ env.ZEIT_DEPLOYMENT_URL }}](${{ env.ZEIT_DEPLOYMENT_URL }})
-            Deployment aliased as [${{ env.ZEIT_DEPLOYMENT_ALIAS }}](https://${{ env.ZEIT_DEPLOYMENT_ALIAS }})
+            Deployment aliased as [${{ env.ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS }}](https://${{ env.ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS }})
 
   # Runs E2E tests against the Zeit deployment
   run-2e2-tests:
@@ -193,17 +152,17 @@ jobs:
           echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
           echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
 
-          CUSTOMER_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq -r '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-          echo "Customer that was deployed: " $CUSTOMER_TO_DEPLOY
-          echo "CUSTOMER_TO_DEPLOY=$CUSTOMER_TO_DEPLOY" >> $GITHUB_ENV
+          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
+          echo "Customer that was deployed: " $CUSTOMER_REF_TO_DEPLOY
+          echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
 
           # Resolve Vercel team ID
-          VERCEL_TEAM_ID=`cat now.$CUSTOMER_TO_DEPLOY.staging.json | jq -r '.scope'`
+          VERCEL_TEAM_ID=`cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.scope'`
           echo "Vercel team ID: " $VERCEL_TEAM_ID
           echo "VERCEL_TEAM_ID=$VERCEL_TEAM_ID" >> $GITHUB_ENV
 
           # Resolve Vercel project name
-          VERCEL_PROJECT_NAME=`cat now.$CUSTOMER_TO_DEPLOY.staging.json | jq -r '.name'`
+          VERCEL_PROJECT_NAME=`cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.name'`
           echo "Vercel project name: " $VERCEL_PROJECT_NAME
           echo "VERCEL_PROJECT_NAME=$VERCEL_PROJECT_NAME" >> $GITHUB_ENV
 
@@ -227,7 +186,7 @@ jobs:
         uses: cypress-io/github-action@v1 # XXX See https://github.com/cypress-io/github-action
         with:
           wait-on: ${{ env.ZEIT_DEPLOYMENT_URL }} # Be sure that the endpoint is ready by pinging it before starting tests, it has a timeout of 60seconds
-          config-file: cypress/config-${{ env.CUSTOMER_TO_DEPLOY }}.json # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
+          config-file: cypress/config-${{ env.CUSTOMER_REF_TO_DEPLOY }}.json # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
           config: baseUrl=${{ env.ZEIT_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
         env:
           # Enables Cypress debugging logs, very useful if Cypress crashes, like out-of-memory issues.
@@ -303,17 +262,17 @@ jobs:
           echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
           echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
 
-          CUSTOMER_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq -r '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-          echo "Customer that was deployed: " $CUSTOMER_TO_DEPLOY
-          echo "CUSTOMER_TO_DEPLOY=$CUSTOMER_TO_DEPLOY" >> $GITHUB_ENV
+          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
+          echo "Customer that was deployed: " $CUSTOMER_REF_TO_DEPLOY
+          echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
 
           # Resolve Vercel team ID
-          VERCEL_TEAM_ID=`cat now.$CUSTOMER_TO_DEPLOY.staging.json | jq -r '.scope'`
+          VERCEL_TEAM_ID=`cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.scope'`
           echo "Vercel team ID: " $VERCEL_TEAM_ID
           echo "VERCEL_TEAM_ID=$VERCEL_TEAM_ID" >> $GITHUB_ENV
 
           # Resolve Vercel project name
-          VERCEL_PROJECT_NAME=`cat now.$CUSTOMER_TO_DEPLOY.staging.json | jq -r '.name'`
+          VERCEL_PROJECT_NAME=`cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.name'`
           echo "Vercel project name: " $VERCEL_PROJECT_NAME
           echo "VERCEL_PROJECT_NAME=$VERCEL_PROJECT_NAME" >> $GITHUB_ENV
 
@@ -349,7 +308,7 @@ jobs:
           prCommentSaveOld: true # If true, then add a new comment for each commit. Otherwise, update the latest comment (default: false).
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           emulatedFormFactor: all # Run LightHouse against "mobile", "desktop", or "all" devices
-          urls: ${{ env.ZEIT_DEPLOYMENT_URL }}, ${{ env.ZEIT_DEPLOYMENT_URL }}/en, ${{ env.ZEIT_DEPLOYMENT_URL }}/fr, ${{ env.ZEIT_DEPLOYMENT_URL }}/en-US, ${{ env.ZEIT_DEPLOYMENT_URL }}/fr-FR
+          urls: ${{ env.ZEIT_DEPLOYMENT_URL }}, ${{ env.ZEIT_DEPLOYMENT_URL }}/en, ${{ env.ZEIT_DEPLOYMENT_URL }}/fr
           locale: en
 
       # Upload HTML report create by lighthouse, could be useful

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -106,6 +106,32 @@ jobs:
           ZEIT_ALIASING_OUTPUT=`npx now alias $ZEIT_DEPLOYMENT_URL $ZEIT_DEPLOYMENT_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed, but the build will continue regardless."`
           echo $ZEIT_ALIASING_OUTPUT
           # TODO Resolve whether the aliasing has worked and change the GitHub comment "Comment PR (Deployment success)"
+
+          # Apply all aliases specified in the now.json file (if any is specified)
+          # Find all aliases configured in the customer deployment configuration file (now.json)
+          ZEIT_DEPLOYMENT_ALIASES_JSON=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.alias')
+          echo "Custom aliases: " $ZEIT_DEPLOYMENT_ALIASES_JSON
+
+          # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
+          readarray -t ZEIT_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < now.$CUSTOMER_REF_TO_DEPLOY.staging.json)
+
+          # Check if there are no aliases configured (it will return "null" in such case, which is not the same as bash "empty")
+          if [ "$ZEIT_DEPLOYMENT_ALIASES" != null ] || [ ${#ZEIT_DEPLOYMENT_ALIASES[@]} > 0 ]
+          then
+            ZEIT_DEPLOYMENT_ALIASES_COUNT=${#ZEIT_DEPLOYMENT_ALIASES[@]}
+            echo "$ZEIT_DEPLOYMENT_ALIASES_COUNT alias(es) found. Aliasing them now..."
+
+            # For each alias configured, then assign it to the deployed domain
+            for DEPLOYMENT_ALIAS in "${ZEIT_DEPLOYMENT_ALIASES[@]}"; do
+              echo "npx now alias "$ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS
+              npx now alias $ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed for '$DEPLOYMENT_ALIAS', but the build will continue regardless."
+            done
+          else
+            # $ZEIT_DEPLOYMENT_ALIASES is null, this happens when it was not defined in the now.json file
+            echo "There are no more aliases to configure. You can add more aliases from your now.json 'alias' property. See https://vercel.com/docs/configuration?query=alias%20domain#project/alias"
+            echo "$ZEIT_DEPLOYMENT_ALIASES"
+          fi
+
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to the worker

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -53,86 +53,86 @@ jobs:
         # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
           # Print the version of the "now" CLI being used (helps debugging)
-           now --version
+          now --version
 
-           # Resolving customer to deploy based on the github event input, when using manual deployment triggerer through "workflow_dispatch" event
-           # Falls back to the customer specified in the now.json file, which is most useful when deployment is triggered through "push" event
-           MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
-           echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
-           echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
+          # Resolving customer to deploy based on the github event input, when using manual deployment triggerer through "workflow_dispatch" event
+          # Falls back to the customer specified in the now.json file, which is most useful when deployment is triggered through "push" event
+          MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
+          echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
+          echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
 
-           CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-           echo "Customer to deploy: " $CUSTOMER_REF_TO_DEPLOY
-           echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
+          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat now.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
+          echo "Customer to deploy: " $CUSTOMER_REF_TO_DEPLOY
+          echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
 
-           # Deploy the customer on Vercel using the customer ref (e.g: "yarn deploy:customer1")
-           # Store the output in a variable so we can extract metadata from it
-           ZEIT_DEPLOYMENT_OUTPUT=`yarn deploy:$CUSTOMER_REF_TO_DEPLOY --token $ZEIT_TOKEN`
+          # Deploy the customer on Vercel using the customer ref (e.g: "yarn deploy:customer1")
+          # Store the output in a variable so we can extract metadata from it
+          ZEIT_DEPLOYMENT_OUTPUT=`yarn deploy:$CUSTOMER_REF_TO_DEPLOY --token $ZEIT_TOKEN`
 
-           # Extract the Vercel deployment url from the deployment output
-           ZEIT_DEPLOYMENT_URL=`echo $ZEIT_DEPLOYMENT_OUTPUT | egrep -o 'https?://[^ ]+.vercel.app'`
-           echo "Deployment url: " $ZEIT_DEPLOYMENT_URL
-           echo "ZEIT_DEPLOYMENT_URL=$ZEIT_DEPLOYMENT_URL" >> $GITHUB_ENV
+          # Extract the Vercel deployment url from the deployment output
+          ZEIT_DEPLOYMENT_URL=`echo $ZEIT_DEPLOYMENT_OUTPUT | egrep -o 'https?://[^ ]+.vercel.app'`
+          echo "Deployment url: " $ZEIT_DEPLOYMENT_URL
+          echo "ZEIT_DEPLOYMENT_URL=$ZEIT_DEPLOYMENT_URL" >> $GITHUB_ENV
 
-           # Build the alias domain based on our own rules (NRN own rules)
-           # Basically, if a branch starts with "v[0-9]" then we consider it to be a "preset branch" and we use the branch name as alias (e.g: "v2-mst-xxx")
-           # Otherwise, we use the deployment name and suffix it using the branch name (e.g: "v2-mst-xxx-branch-name")
-           if [[ ${CURRENT_BRANCH##*/} =~ ^v[0-9]{1,}- ]]; then # Checking if pattern matches with "vX-" where X is a number
-             ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=${CURRENT_BRANCH##*/}
-           else
-             ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.name')-${CURRENT_BRANCH##*/}
-           fi
-           echo "Resolved domain alias: " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
+          # Build the alias domain based on our own rules (NRN own rules)
+          # Basically, if a branch starts with "v[0-9]" then we consider it to be a "preset branch" and we use the branch name as alias (e.g: "v2-mst-xxx")
+          # Otherwise, we use the deployment name and suffix it using the branch name (e.g: "v2-mst-xxx-branch-name")
+          if [[ ${CURRENT_BRANCH##*/} =~ ^v[0-9]{1,}- ]]; then # Checking if pattern matches with "vX-" where X is a number
+            ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=${CURRENT_BRANCH##*/}
+          else
+            ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.name')-${CURRENT_BRANCH##*/}
+          fi
+          echo "Resolved domain alias: " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
 
-           # Zeit alias only allows 41 characters in the domain name, so we only keep the first 41 (41 = 53 - 11 - 1) characters (because Zeit needs 7 chars for ".vercel.app" at the end of the domain name, and count starts at 1, not 0)
-           # Also, in order to remove forbidden characters, we transform every characters which are not a "alnum" and \n or \r into '-'
-           ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=$(echo $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS | head -c 41 | tr -c '[:alnum:]\r\n' - | tr '[:upper:]' '[:lower:]')
-           echo "Sanitized domain alias (1): " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
+          # Zeit alias only allows 41 characters in the domain name, so we only keep the first 41 (41 = 53 - 11 - 1) characters (because Zeit needs 7 chars for ".vercel.app" at the end of the domain name, and count starts at 1, not 0)
+          # Also, in order to remove forbidden characters, we transform every characters which are not a "alnum" and \n or \r into '-'
+          ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=$(echo $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS | head -c 41 | tr -c '[:alnum:]\r\n' - | tr '[:upper:]' '[:lower:]')
+          echo "Sanitized domain alias (1): " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
 
-           # Recursively remove any trailing dash ('-') to protect against invalid alias domain (not allowed to end with a trailing slash)
-           while [[ "$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS" == *- ]]
+          # Recursively remove any trailing dash ('-') to protect against invalid alias domain (not allowed to end with a trailing slash)
+          while [[ "$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS" == *- ]]
            do
-             ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=${ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS::-1}
+            ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=${ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS::-1}
            done
-           echo "Sanitized domain alias (2): " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
+          echo "Sanitized domain alias (2): " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
 
            # Build alias url
-           ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS="${ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS}.vercel.app"
-           echo "ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS" >> $GITHUB_ENV
-           echo "Alias domain: "$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
-           echo "Aliasing the deployment using the git branch alias:"
-           echo "npx now alias "$ZEIT_DEPLOYMENT_URL $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
+          ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS="${ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS}.vercel.app"
+          echo "ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS" >> $GITHUB_ENV
+          echo "Alias domain: "$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
+          echo "Aliasing the deployment using the git branch alias:"
+          echo "npx now alias "$ZEIT_DEPLOYMENT_URL $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
 
-           # Create Vercel alias, use "||" to allow failure (keep the build going) even if the alias fails
-           ZEIT_ALIASING_OUTPUT=`npx now alias $ZEIT_DEPLOYMENT_URL $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed for '$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS', but the build will continue regardless."`
-           echo $ZEIT_ALIASING_OUTPUT
-           # TODO Resolve whether the aliasing has worked and change the GitHub comment "Comment PR (Deployment success)"
+          # Create Vercel alias, use "||" to allow failure (keep the build going) even if the alias fails
+          ZEIT_ALIASING_OUTPUT=`npx now alias $ZEIT_DEPLOYMENT_URL $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed for '$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS', but the build will continue regardless."`
+          echo $ZEIT_ALIASING_OUTPUT
+          # TODO Resolve whether the aliasing has worked and change the GitHub comment "Comment PR (Deployment success)"
 
-           # Find all custom aliases configured in the customer deployment configuration file (now.json)
-           ZEIT_DEPLOYMENT_ALIASES_JSON=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.alias')
-           echo "Custom aliases: " $ZEIT_DEPLOYMENT_ALIASES_JSON
+          # Find all custom aliases configured in the customer deployment configuration file (now.json)
+          ZEIT_DEPLOYMENT_ALIASES_JSON=$(cat now.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.alias')
+          echo "Custom aliases: " $ZEIT_DEPLOYMENT_ALIASES_JSON
 
-           # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
-           readarray -t ZEIT_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < now.$CUSTOMER_REF_TO_DEPLOY.staging.json)
+          # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
+          readarray -t ZEIT_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < now.$CUSTOMER_REF_TO_DEPLOY.staging.json)
 
-           # Count the number of element in the array, will be 0 if it's an empty array, or if the "alias" key wasn't defined
-           ZEIT_DEPLOYMENT_ALIASES_COUNT=${#ZEIT_DEPLOYMENT_ALIASES[@]}
+          # Count the number of element in the array, will be 0 if it's an empty array, or if the "alias" key wasn't defined
+          ZEIT_DEPLOYMENT_ALIASES_COUNT=${#ZEIT_DEPLOYMENT_ALIASES[@]}
 
-           # Check if there are no aliases configured
-           if [ "$ZEIT_DEPLOYMENT_ALIASES" > 0 ]
-           then
-             echo "$ZEIT_DEPLOYMENT_ALIASES_COUNT alias(es) found. Aliasing them now..."
+          # Check if there are no aliases configured
+          if [ "$ZEIT_DEPLOYMENT_ALIASES" > 0 ]
+          then
+            echo "$ZEIT_DEPLOYMENT_ALIASES_COUNT alias(es) found. Aliasing them now..."
 
-             # For each alias configured, then assign it to the deployed domain
-             for DEPLOYMENT_ALIAS in "${ZEIT_DEPLOYMENT_ALIASES[@]}"; do
-               echo "npx now alias "$ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS
-               npx now alias $ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed for '$DEPLOYMENT_ALIAS', but the build will continue regardless."
-             done
-           else
-             # $ZEIT_DEPLOYMENT_ALIASES is null, this happens when it was not defined in the now.json file
-             echo "There are no more aliases to configure. You can add more aliases from your now.json 'alias' property. See https://vercel.com/docs/configuration?query=alias%20domain#project/alias"
-             echo "$ZEIT_DEPLOYMENT_ALIASES"
-           fi
+            # For each alias configured, then assign it to the deployed domain
+            for DEPLOYMENT_ALIAS in "${ZEIT_DEPLOYMENT_ALIASES[@]}"; do
+              echo "npx now alias "$ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS
+              npx now alias $ZEIT_DEPLOYMENT_URL $DEPLOYMENT_ALIAS --token $ZEIT_TOKEN || echo "Aliasing failed for '$DEPLOYMENT_ALIAS', but the build will continue regardless."
+            done
+          else
+            # $ZEIT_DEPLOYMENT_ALIASES is null, this happens when it was not defined in the now.json file
+            echo "There are no more aliases to configure. You can add more aliases from your now.json 'alias' property. See https://vercel.com/docs/configuration?query=alias%20domain#project/alias"
+            echo "$ZEIT_DEPLOYMENT_ALIASES"
+          fi
         env:
           ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }} # Passing github's secret to the worker
           CURRENT_BRANCH: ${{ github.ref }} # Passing current branch to the worker

--- a/.github/workflows/deploy-zeit-staging.yml
+++ b/.github/workflows/deploy-zeit-staging.yml
@@ -91,9 +91,9 @@ jobs:
 
           # Recursively remove any trailing dash ('-') to protect against invalid alias domain (not allowed to end with a trailing slash)
           while [[ "$ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS" == *- ]]
-           do
-            ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=${ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS::-1}
-           done
+            do
+              ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS=${ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS::-1}
+            done
           echo "Sanitized domain alias (2): " $ZEIT_DEPLOYMENT_AUTO_BRANCH_ALIAS
 
            # Build alias url

--- a/now.customer1.staging.json
+++ b/now.customer1.staging.json
@@ -16,5 +16,8 @@
       "SENTRY_DSN": "@nrn-sentry-dsn"
     }
   },
+  "alias": [
+    "nrn-v2-mst-aptd-at-lcz-sty-c1-preview.vercel.app"
+  ],
   "public": false
 }

--- a/now.customer2.staging.json
+++ b/now.customer2.staging.json
@@ -16,5 +16,8 @@
       "SENTRY_DSN": "@nrn-sentry-dsn"
     }
   },
+  "alias": [
+    "nrn-v2-mst-aptd-at-lcz-sty-c2-preview.vercel.app"
+  ],
   "public": false
 }

--- a/src/components/appBootstrap/MultiversalAppBootstrap.tsx
+++ b/src/components/appBootstrap/MultiversalAppBootstrap.tsx
@@ -213,6 +213,7 @@ const MultiversalAppBootstrap: React.FunctionComponent<Props> = (props): JSX.Ele
     // We wait for out props to contain "isReadyToRender: true", which means they've been set correctly by either getInitialProps/getStaticProps/getServerProps
     // This helps avoid multiple useless renders (especially in development mode) and thus avoid noisy logs
     // XXX I've recently tested without it and didn't notice any more logs than expected/usual. Maybe this was from a time where there were multiple full-renders? It may be removed if so (TODO later with proper testing)
+    // eslint-disable-next-line no-console
     console.info('MultiversalAppBootstrap - App is not ready yet, waiting for isReadyToRender');
     return null;
   }


### PR DESCRIPTION
Uses the Vercel native `alias` option to automatically alias deployments when any alias is defined in the now.json file. Allows to automatically configure different aliases per project, per stage. (staging|production)

See https://vercel.com/docs/configuration?query=alias%20domain#project/alias for official documentation

Useful to automatically alias a domain when a deployment in done by Vercel.

Especially useful for **staging** _(not so much for production because Vercel already has a good native feature for production domains and already takes care of them)_. But for the sake of proposing the same "api" between staging/production it was implemented in both. 

Besides, it might be useful (for production) to some people who might not be contented by the dashboard way of configuring production domains. (the NRN implementation might be friendlier with automation)

Anyway, a potentially future version of it might be more powerful and assign domain aliases based on conditions (branch name, etc.) and then it'd be useful to both staging/production. (but this enhancement is not planned as of now) 

> **For the record**: It used to exist a "custom domains for staging" in Zeit, but it seems to have disappeared. Also, it was a paid option, and quite expensive at it. Only production domain aliases are free.