### PR TITLE
Improve LightHouse performances

### DIFF
--- a/src/components/appBootstrap/BrowserPageBootstrap.tsx
+++ b/src/components/appBootstrap/BrowserPageBootstrap.tsx
@@ -27,6 +27,8 @@ import {
   isRunningInIframe,
 } from '../../utils/iframe';
 import { configureSentryUser } from '../../utils/monitoring/sentry';
+import { detectLightHouse } from '../../utils/quality/lighthouse';
+import { detectCypress } from '../../utils/testing/cypress';
 
 const fileLabel = 'components/appBootstrap/BrowserPageBootstrap';
 const logger = createLogger({
@@ -67,6 +69,8 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
     userSession,
   };
   const theme = useTheme<CustomerTheme>();
+  const isCypressRunning = detectCypress();
+  const isLightHouseRunning = detectLightHouse();
 
   // Configure Sentry user and track navigation through breadcrumb
   configureSentryUser(userSession);
@@ -147,6 +151,8 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
           iframeReferrer: iframeReferrer,
           isUserOptedOutOfAnalytics: isUserOptedOutOfAnalytics,
           hasUserGivenAnyCookieConsent: hasUserGivenAnyCookieConsent,
+          isCypressRunning,
+          isLightHouseRunning,
         }}
         // XXX Do not use "userProperties" here, add default user-related properties in getAmplitudeInstance instead
         //  Because "event" had priority over "user event" and will be executed before

--- a/src/components/appBootstrap/MultiversalAppBootstrap.tsx
+++ b/src/components/appBootstrap/MultiversalAppBootstrap.tsx
@@ -23,6 +23,8 @@ import {
   startPreviewMode,
   stopPreviewMode,
 } from '../../utils/nextjs/previewMode';
+import { detectLightHouse } from '../../utils/quality/lighthouse';
+import { detectCypress } from '../../utils/testing/cypress';
 import Loader from '../animations/Loader';
 import DefaultErrorLayout from '../errors/DefaultErrorLayout';
 import BrowserPageBootstrap, { BrowserPageBootstrapProps } from './BrowserPageBootstrap';
@@ -93,12 +95,15 @@ const MultiversalAppBootstrap: React.FunctionComponent<Props> = (props): JSX.Ele
 
       if (isBrowser()) {
         const queryParameters: string = stringifyQueryParameters(router);
+        const isCypressRunning = detectCypress();
+        const isLightHouseRunning = detectLightHouse();
 
         // XXX If we are running in staging stage and the preview mode is not enabled, then we force enable it
         //  We do this to enforce the staging stage is being used as a "preview environment" so it satisfies our publication workflow
         //  If we're running in development, then we don't enforce anything
         //  If we're running in production, then we force disable the preview mode, because we don't want to allow it in production
-        if (process.env.NEXT_PUBLIC_APP_STAGE === 'staging' && !preview) {
+        // XXX Also, don't enable preview mode when Cypress or LightHouse are running to avoid bad performances
+        if (process.env.NEXT_PUBLIC_APP_STAGE === 'staging' && !preview && !isCypressRunning && !isLightHouseRunning) {
           startPreviewMode(queryParameters);
         } else if (process.env.NEXT_PUBLIC_APP_STAGE === 'production' && preview) {
           logger.error('Preview mode is not allowed in production, but was detected as enabled. It will now be disabled by force.');

--- a/src/utils/quality/lighthouse.ts
+++ b/src/utils/quality/lighthouse.ts
@@ -1,0 +1,12 @@
+/**
+ * Detects whether LightHouse is running on the page or not.
+ *
+ * Returns null when not executed from the browser.
+ */
+export const detectLightHouse = (): boolean | null => {
+  if (typeof window) {
+    return navigator?.userAgent?.indexOf('Chrome-Lighthouse') > -1;
+  }
+
+  return null;
+};

--- a/src/utils/testing/cypress.ts
+++ b/src/utils/testing/cypress.ts
@@ -1,0 +1,14 @@
+/**
+ * Detects whether Cypress is running on the page or not.
+ *
+ * Returns null when not executed from the browser.
+ *
+ * @see https://docs.cypress.io/faq/questions/using-cypress-faq.html#Is-there-any-way-to-detect-if-my-app-is-running-under-Cypress
+ */
+export const detectCypress = (): boolean | null => {
+  if (typeof window) {
+    return !!window['Cypress'];
+  }
+
+  return null;
+};


### PR DESCRIPTION
Disable preview mode when LightHouse or Cypress are detected improves performances a lot and avoids false-positive "bad perfs" in staging/preview environment.