### PR TITLE
Migrate demo to GraphCMS v2 API

### DIFF
--- a/.env
+++ b/.env
@@ -41,15 +41,15 @@ NEXT_PUBLIC_LOCIZE_PROJECT_ID=658fc999-dfa8-4307-b9d7-b4870ad5b968
 # Tip: The value being used below is valid, so that you can run the demo locally without having to create your own Amplitude account, but you cannot access the data
 NEXT_PUBLIC_AMPLITUDE_API_KEY=5ea02d86a6840c165fcc01377131fa13
 
-# GraphQL API endpoint (using GraphCMS vendor)
+# GraphQL v2 API endpoint (using GraphCMS vendor)
 # Used to fetch content from GraphCMS
 # Tip: The value being used below is valid, so that you can run the demo locally without having to create your own GraphCMS account
 # XXX We only use one stage ("master") due to the free plan's limitation, but using two stages is more secure for enterprise-grade apps
-GRAPHQL_API_ENDPOINT=https://api-euwest.graphcms.com/v1/ck73ixhlv09yt01dv2ga1bkbp/master
+GRAPHQL_API_ENDPOINT=https://api-eu-central-1.graphcms.com/v2/ck73ixhlv09yt01dv2ga1bkbp/master
 
-# GraphQL API key (using GraphCMS vendor), can be found under "Settings > Auth token"
+# GraphQL API key (using GraphCMS vendor), can be found under "Settings > API Access > Permanent Auth Tokens"
 # Used to fetch content from GraphCMS, this token only has read-only permissions to avoid data tempering (especially since we made it public within NRN)
 # This variable is only used server-side
 # Tip: The value being used below is valid, so that you can run the demo locally without having to create your own GraphCMS account
 # XXX For the purpose of this demo, we're tracking this in git, but unless you're building an open API you'll want to move it to ".env.local" (especially if this is your "master" token)
-GRAPHQL_API_KEY=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImdjbXMtbWFpbi1wcm9kdWN0aW9uIn0.eyJ2ZXJzaW9uIjoyLCJ0b2tlbklkIjoiMGEyZWYwZWYtYmY4Ny00ZmVlLTkzYmQtMzBkMzIzYzAwODM4IiwiaWF0IjoxNTgyNzQ2MDc1LCJpc3MiOiJodHRwczovL21hbmFnZW1lbnQuZ3JhcGhjbXMuY29tLyJ9.wE-IDwFnCNpwUj5AMeGsbf2CGcTgkT1KkE9_l6s-bU03sckdDgV2LXCHH5Fb8XwJGAkoeD5bK9yDnY6oNapiusvg4xRqY-hkRxgh8lB_lTXXpIka6HhjIJz1RQO_dObNGFqr41dKihseBqN5Ce4AJvQBIHyJasKX63xe2eEzdUnWfuNUmrG_XStRu1-xDKKp7vFVox272rr-LqgwRymF3eYcw7J-IAag4qpztoU6zNhKJNYzQKdMMejvMDNg34bHNp4TRIbIUIYpytkwCaAb5TsH98xEiFziU5rUr4EYToSltgE46VnqX2npm56qK-AGp5zauMZgvA20Djtb7BuYqGAqCdOHEQtjjyVLufCu6Y72i9gNQqFQ-WGQ6AFN84KT7BJgRoTruduYG9VhGMOR59HR3jG2QIWXOCt55aI9YwAGNQii0b_QqaoSO08Pb_Ooji5abFLISs70jQb-z1QcnvHIzHnsKqymEWwZhbkxpwf8bv8C6-8k4JGB5YdVj3T_0XQ-OCyvWQIGwVxKysLj8HBeVvXOKUyz7p-thOHbO4qSaRaV7w6_Yy2XtdwBlkIiTTqLezN34vCnsyhZ7N1IgLzp0bwNCyCoPOFs5Q9Ccw7hwJRP3kDT2cW4COJWVt-V5YF_9nnlZN8JjcIgv7FMZKoKRHi004vSosPYGd-v3Uw
+GRAPHQL_API_KEY=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImdjbXMtbWFpbi1wcm9kdWN0aW9uIn0.eyJ2ZXJzaW9uIjozLCJpYXQiOjE2MDYyMTEyNDgsImF1ZCI6WyJodHRwczovL2FwaS1ldS1jZW50cmFsLTEuZ3JhcGhjbXMuY29tL3YyL2NrNzNpeGhsdjA5eXQwMWR2MmdhMWJrYnAvbWFzdGVyIl0sImlzcyI6Imh0dHBzOi8vbWFuYWdlbWVudC5ncmFwaGNtcy5jb20vIiwic3ViIjoiMzRiNGMxZDgtNWY1Mi00MWM3LWJjNDYtMDM5MzM1NDc0OTVlIiwianRpIjoiY2todnNwZjA4bXg0aDAxdzliMmN6YXVwZCJ9.TfJDn4V9gGK5n7sI8limca4DnFjxREgsPDV5lf5yhA74BSwHq8XH-nU6cP18qf-IQ_wN7Ujw4MRY4LcazylR0IBli4dzrtKHZ0pEvZilZ0AfJ-80LBJQCVLNEiSuFKnIDUHe58MqMUZT8UoYFaWMH_cl7a3SOmdRCwsm93U5JYkjt7mqoH5Y-WaC3yl4Cq9IYexjHCJZLiFRZh8CL0jV6ddu8ghScegYTo_nJsZxHow12tuKI0I_3cJhdpcRL3HsTZWTQV8PPL0bhbLE1F7y0GksquKuSRScrTMBewYCgDWkxt7EcjRSuUR9WixQPVcTjHpnm_c3lL0HqUsDc_5aJV0POJUa9_T8m4_uFstZtBMtfmg6yBGOB8f06f27JyrCA5NZLNXMScmG06DbGOM8gbquN4-XigTj4t3jwSrzCRZ1zuFZEMoBruH0ElOqJ9hq05_WnGSpyD4NQl9l0bV1TXz5WMzoThlShrpL3f0A74ojXdel8awq9uTPB8qX7AAQa5m7n7lEmsD0tfom4ijiJeFdJakyNpoxY8TXPAgO819MPxE_z3qEynxu3QLS3jW2hc0mteLO0pNkl_twPGIwn7eBlv4u6S31pLXOT5aAIIMqsa1eoi8XwGKFLGhjZzDN_AsF-aBudoK8uhmNYCA7DyqWMXi2rvGyuYNU9Wu3XAs

--- a/.graphqlconfig
+++ b/.graphqlconfig
@@ -3,7 +3,7 @@
   "extensions": {
     "endpoints": {
       "master": {
-        "url": "https://api-euwest.graphcms.com/v1/ck73ixhlv09yt01dv2ga1bkbp/master",
+        "url": "https://api-eu-central-1.graphcms.com/v2/ck73ixhlv09yt01dv2ga1bkbp/master",
         "introspect": true,
         "headers": {
           "user-agent": "JS GraphQL",

--- a/schema.graphql
+++ b/schema.graphql
@@ -9,46 +9,121 @@ schema {
 interface Node {
   "The id of the object."
   id: ID!
+  "The Stage of an object"
+  stage: Stage!
 }
 
-type AggregateAsset {
+type Aggregate {
   count: Int!
 }
 
-type AggregateCustomer {
-  count: Int!
-}
-
-type AggregateProduct {
-  count: Int!
-}
-
-type AggregateTheme {
-  count: Int!
-}
-
+"Asset system model"
 type Asset implements Node {
-  createdAt: DateTime!
+  "The time the document was created"
+  createdAt(
+    "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both"
+    variation: SystemDateTimeFieldVariation! = COMBINED
+  ): DateTime!
+  "Get the document in other stages"
+  documentInStages(
+    "Decides if the current stage should be included or not"
+    includeCurrent: Boolean! = false,
+    "Decides if the documents should match the parent documents locale or should use the fallback order defined in the tree"
+    inheritLocale: Boolean! = false,
+    "Potential stages that should be returned"
+    stages: [Stage!]! = [PUBLISHED, DRAFT]
+  ): [Asset!]!
+  "The file name"
   fileName: String!
+  "The file handle"
   handle: String!
+  "The height of the file"
   height: Float
+  "List of Asset versions"
+  history(
+    limit: Int! = 10,
+    skip: Int! = 0,
+    "This is optional and can be used to fetch the document version history for a specific stage instead of the current one"
+    stageOverride: Stage
+  ): [Version!]!
+  "The unique identifier"
   id: ID!
-  imagesProduct(after: String, before: String, first: Int, last: Int, orderBy: ProductOrderByInput, skip: Int, where: ProductWhereInput): [Product!]
-  logoTheme(after: String, before: String, first: Int, last: Int, orderBy: ThemeOrderByInput, skip: Int, where: ThemeWhereInput): [Theme!]
+  imagesProduct(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+
+    Note that `imagesProduct` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!],
+    orderBy: ProductOrderByInput,
+    skip: Int,
+    where: ProductWhereInput
+  ): [Product!]!
+  "System Locale field"
+  locale: Locale!
+  "Get the other localizations for this document"
+  localizations(
+    "Decides if the current locale should be included or not"
+    includeCurrent: Boolean! = false,
+    "Potential locales that should be returned"
+    locales: [Locale!]! = [en, fr]
+  ): [Asset!]!
+  logoTheme(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+
+    Note that `logoTheme` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!],
+    orderBy: ThemeOrderByInput,
+    skip: Int,
+    where: ThemeWhereInput
+  ): [Theme!]!
+  "The mime type of the file"
   mimeType: String
+  "The time the document was published. Null on documents in draft stage."
+  publishedAt(
+    "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both"
+    variation: SystemDateTimeFieldVariation! = COMBINED
+  ): DateTime
+  "The file size"
   size: Float
-  status: Status!
-  updatedAt: DateTime!
+  "System stage field"
+  stage: Stage!
+  "Title + alternative text"
+  title: String
+  "The time the document was updated"
+  updatedAt(
+    "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both"
+    variation: SystemDateTimeFieldVariation! = COMBINED
+  ): DateTime!
   "Get the url for the asset with provided transformations applied."
   url(transformation: AssetTransformationInput): String!
+  "The file width"
   width: Float
 }
 
 "A connection to a list of items."
 type AssetConnection {
-  aggregate: AggregateAsset!
+  aggregate: Aggregate!
   "A list of edges."
-  edges: [AssetEdge]!
+  edges: [AssetEdge!]!
   "Information to aid in pagination."
   pageInfo: PageInfo!
 }
@@ -61,48 +136,105 @@ type AssetEdge {
   node: Asset!
 }
 
-type AssetPreviousValues {
-  createdAt: DateTime!
-  fileName: String!
-  handle: String!
-  height: Float
-  id: ID!
-  mimeType: String
-  size: Float
-  status: Status!
-  updatedAt: DateTime!
-  width: Float
-}
-
-type AssetSubscriptionPayload {
-  mutation: MutationType!
-  node: Asset
-  previousValues: AssetPreviousValues
-  updatedFields: [String!]
-}
-
 type BatchPayload {
   "The number of nodes that have been affected by the Batch operation."
   count: Long!
 }
 
+"Representing a color value comprising of HEX, RGBA and css color values"
+type Color {
+  css: String!
+  hex: Hex!
+  rgba: RGBA!
+}
+
+"A B2B customer. All content belongs to a customer."
 type Customer implements Node {
-  createdAt: DateTime!
+  "The time the document was created"
+  createdAt(
+    "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both"
+    variation: SystemDateTimeFieldVariation! = COMBINED
+  ): DateTime!
+  "Get the document in other stages"
+  documentInStages(
+    "Decides if the current stage should be included or not"
+    includeCurrent: Boolean! = false,
+    "Decides if the documents should match the parent documents locale or should use the fallback order defined in the tree"
+    inheritLocale: Boolean! = false,
+    "Potential stages that should be returned"
+    stages: [Stage!]! = [PUBLISHED, DRAFT]
+  ): [Customer!]!
+  "List of Customer versions"
+  history(
+    limit: Int! = 10,
+    skip: Int! = 0,
+    "This is optional and can be used to fetch the document version history for a specific stage instead of the current one"
+    stageOverride: Stage
+  ): [Version!]!
+  "The unique identifier"
   id: ID!
-  label(locale: Locale): String
-  products(after: String, before: String, first: Int, last: Int, orderBy: ProductOrderByInput, skip: Int, where: ProductWhereInput): [Product!]
+  label: String
+  "System Locale field"
+  locale: Locale!
+  "Get the other localizations for this document"
+  localizations(
+    "Decides if the current locale should be included or not"
+    includeCurrent: Boolean! = false,
+    "Potential locales that should be returned"
+    locales: [Locale!]! = [en, fr]
+  ): [Customer!]!
+  products(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+
+    Note that `products` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!],
+    orderBy: ProductOrderByInput,
+    skip: Int,
+    where: ProductWhereInput
+  ): [Product!]!
+  "The time the document was published. Null on documents in draft stage."
+  publishedAt(
+    "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both"
+    variation: SystemDateTimeFieldVariation! = COMBINED
+  ): DateTime
   ref: String!
-  status: Status!
-  terms(locale: Locale): RichText
-  theme: Theme
-  updatedAt: DateTime!
+  "System stage field"
+  stage: Stage!
+  terms: RichText
+  theme(
+    """
+
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+
+    Note that `theme` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!]
+  ): Theme
+  "The time the document was updated"
+  updatedAt(
+    "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both"
+    variation: SystemDateTimeFieldVariation! = COMBINED
+  ): DateTime!
 }
 
 "A connection to a list of items."
 type CustomerConnection {
-  aggregate: AggregateCustomer!
+  aggregate: Aggregate!
   "A list of edges."
-  edges: [CustomerEdge]!
+  edges: [CustomerEdge!]!
   "Information to aid in pagination."
   pageInfo: PageInfo!
 }
@@ -115,51 +247,516 @@ type CustomerEdge {
   node: Customer!
 }
 
-type CustomerPreviousValues {
+type DocumentVersion {
   createdAt: DateTime!
+  data: Json
   id: ID!
-  labelEN: String
-  labelFR: String
-  ref: String!
-  status: Status!
-  termsEN: RichText
-  termsFR: RichText
-  updatedAt: DateTime!
+  revision: Int!
+  stage: Stage!
 }
 
-type CustomerSubscriptionPayload {
-  mutation: MutationType!
-  node: Customer
-  previousValues: CustomerPreviousValues
-  updatedFields: [String!]
+"Representing a geolocation point with latitude and longitude"
+type Location {
+  distance(from: LocationInput!): Float!
+  latitude: Float!
+  longitude: Float!
 }
 
 type Mutation {
-  createAsset(data: AssetCreateInput!): Asset!
-  createCustomer(data: CustomerCreateInput!): Customer!
-  createProduct(data: ProductCreateInput!): Product!
-  createTheme(data: ThemeCreateInput!): Theme!
-  deleteAsset(where: AssetWhereUniqueInput!): Asset
-  deleteCustomer(where: CustomerWhereUniqueInput!): Customer
-  deleteManyAssets(where: AssetWhereInput): BatchPayload!
-  deleteManyCustomers(where: CustomerWhereInput): BatchPayload!
-  deleteManyProducts(where: ProductWhereInput): BatchPayload!
-  deleteManyThemes(where: ThemeWhereInput): BatchPayload!
-  deleteProduct(where: ProductWhereUniqueInput!): Product
-  deleteTheme(where: ThemeWhereUniqueInput!): Theme
+  "Create one asset"
+  createAsset(data: AssetCreateInput!): Asset @deprecated(reason : "Asset mutations will be overhauled soon")
+  "Create one customer"
+  createCustomer(data: CustomerCreateInput!): Customer
+  "Create one product"
+  createProduct(data: ProductCreateInput!): Product
+  "Create one theme"
+  createTheme(data: ThemeCreateInput!): Theme
+  "Delete one asset from _all_ existing stages. Returns deleted document."
+  deleteAsset(
+    "Document to delete"
+    where: AssetWhereUniqueInput!
+  ): Asset
+  "Delete one customer from _all_ existing stages. Returns deleted document."
+  deleteCustomer(
+    "Document to delete"
+    where: CustomerWhereUniqueInput!
+  ): Customer
+  "Delete many Asset documents"
+  deleteManyAssets(
+    "Documents to delete"
+    where: AssetManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (deleteManyAssetsConnection)")
+  "Delete many Asset documents, return deleted documents"
+  deleteManyAssetsConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    last: Int,
+    skip: Int,
+    "Documents to delete"
+    where: AssetManyWhereInput
+  ): AssetConnection!
+  "Delete many Customer documents"
+  deleteManyCustomers(
+    "Documents to delete"
+    where: CustomerManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (deleteManyCustomersConnection)")
+  "Delete many Customer documents, return deleted documents"
+  deleteManyCustomersConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    last: Int,
+    skip: Int,
+    "Documents to delete"
+    where: CustomerManyWhereInput
+  ): CustomerConnection!
+  "Delete many Product documents"
+  deleteManyProducts(
+    "Documents to delete"
+    where: ProductManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (deleteManyProductsConnection)")
+  "Delete many Product documents, return deleted documents"
+  deleteManyProductsConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    last: Int,
+    skip: Int,
+    "Documents to delete"
+    where: ProductManyWhereInput
+  ): ProductConnection!
+  "Delete many Theme documents"
+  deleteManyThemes(
+    "Documents to delete"
+    where: ThemeManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (deleteManyThemesConnection)")
+  "Delete many Theme documents, return deleted documents"
+  deleteManyThemesConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    last: Int,
+    skip: Int,
+    "Documents to delete"
+    where: ThemeManyWhereInput
+  ): ThemeConnection!
+  "Delete one product from _all_ existing stages. Returns deleted document."
+  deleteProduct(
+    "Document to delete"
+    where: ProductWhereUniqueInput!
+  ): Product
+  "Delete one theme from _all_ existing stages. Returns deleted document."
+  deleteTheme(
+    "Document to delete"
+    where: ThemeWhereUniqueInput!
+  ): Theme
+  "Publish one asset"
+  publishAsset(
+    "Optional localizations to publish"
+    locales: [Locale!],
+    "Whether to publish the base document"
+    publishBase: Boolean = true,
+    "Publishing target stage"
+    to: [Stage!]! = [PUBLISHED],
+    "Document to publish"
+    where: AssetWhereUniqueInput!,
+    "Whether to include the default locale when publishBase is set"
+    withDefaultLocale: Boolean = true
+  ): Asset
+  "Publish one customer"
+  publishCustomer(
+    "Optional localizations to publish"
+    locales: [Locale!],
+    "Whether to publish the base document"
+    publishBase: Boolean = true,
+    "Publishing target stage"
+    to: [Stage!]! = [PUBLISHED],
+    "Document to publish"
+    where: CustomerWhereUniqueInput!,
+    "Whether to include the default locale when publishBase is set"
+    withDefaultLocale: Boolean = true
+  ): Customer
+  "Publish many Asset documents"
+  publishManyAssets(
+    "Document localizations to publish"
+    locales: [Locale!],
+    "Whether to publish the base document"
+    publishBase: Boolean = true,
+    "Stages to publish documents to"
+    to: [Stage!]! = [PUBLISHED],
+    "Identifies documents in each stage to be published"
+    where: AssetManyWhereInput,
+    "Whether to include the default locale when publishBase is true"
+    withDefaultLocale: Boolean = true
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (publishManyAssetsConnection)")
+  "Publish many Asset documents"
+  publishManyAssetsConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    "Stage to find matching documents in"
+    from: Stage = DRAFT,
+    last: Int,
+    "Document localizations to publish"
+    locales: [Locale!],
+    "Whether to publish the base document"
+    publishBase: Boolean = true,
+    skip: Int,
+    "Stages to publish documents to"
+    to: [Stage!]! = [PUBLISHED],
+    "Identifies documents in each stage to be published"
+    where: AssetManyWhereInput,
+    "Whether to include the default locale when publishBase is true"
+    withDefaultLocale: Boolean = true
+  ): AssetConnection!
+  "Publish many Customer documents"
+  publishManyCustomers(
+    "Document localizations to publish"
+    locales: [Locale!],
+    "Whether to publish the base document"
+    publishBase: Boolean = true,
+    "Stages to publish documents to"
+    to: [Stage!]! = [PUBLISHED],
+    "Identifies documents in each stage to be published"
+    where: CustomerManyWhereInput,
+    "Whether to include the default locale when publishBase is true"
+    withDefaultLocale: Boolean = true
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (publishManyCustomersConnection)")
+  "Publish many Customer documents"
+  publishManyCustomersConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    "Stage to find matching documents in"
+    from: Stage = DRAFT,
+    last: Int,
+    "Document localizations to publish"
+    locales: [Locale!],
+    "Whether to publish the base document"
+    publishBase: Boolean = true,
+    skip: Int,
+    "Stages to publish documents to"
+    to: [Stage!]! = [PUBLISHED],
+    "Identifies documents in each stage to be published"
+    where: CustomerManyWhereInput,
+    "Whether to include the default locale when publishBase is true"
+    withDefaultLocale: Boolean = true
+  ): CustomerConnection!
+  "Publish many Product documents"
+  publishManyProducts(
+    "Document localizations to publish"
+    locales: [Locale!],
+    "Whether to publish the base document"
+    publishBase: Boolean = true,
+    "Stages to publish documents to"
+    to: [Stage!]! = [PUBLISHED],
+    "Identifies documents in each stage to be published"
+    where: ProductManyWhereInput,
+    "Whether to include the default locale when publishBase is true"
+    withDefaultLocale: Boolean = true
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (publishManyProductsConnection)")
+  "Publish many Product documents"
+  publishManyProductsConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    "Stage to find matching documents in"
+    from: Stage = DRAFT,
+    last: Int,
+    "Document localizations to publish"
+    locales: [Locale!],
+    "Whether to publish the base document"
+    publishBase: Boolean = true,
+    skip: Int,
+    "Stages to publish documents to"
+    to: [Stage!]! = [PUBLISHED],
+    "Identifies documents in each stage to be published"
+    where: ProductManyWhereInput,
+    "Whether to include the default locale when publishBase is true"
+    withDefaultLocale: Boolean = true
+  ): ProductConnection!
+  "Publish many Theme documents"
+  publishManyThemes(
+    "Stages to publish documents to"
+    to: [Stage!]! = [PUBLISHED],
+    "Identifies documents in each stage to be published"
+    where: ThemeManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (publishManyThemesConnection)")
+  "Publish many Theme documents"
+  publishManyThemesConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    "Stage to find matching documents in"
+    from: Stage = DRAFT,
+    last: Int,
+    skip: Int,
+    "Stages to publish documents to"
+    to: [Stage!]! = [PUBLISHED],
+    "Identifies documents in each stage to be published"
+    where: ThemeManyWhereInput
+  ): ThemeConnection!
+  "Publish one product"
+  publishProduct(
+    "Optional localizations to publish"
+    locales: [Locale!],
+    "Whether to publish the base document"
+    publishBase: Boolean = true,
+    "Publishing target stage"
+    to: [Stage!]! = [PUBLISHED],
+    "Document to publish"
+    where: ProductWhereUniqueInput!,
+    "Whether to include the default locale when publishBase is set"
+    withDefaultLocale: Boolean = true
+  ): Product
+  "Publish one theme"
+  publishTheme(
+    "Publishing target stage"
+    to: [Stage!]! = [PUBLISHED],
+    "Document to publish"
+    where: ThemeWhereUniqueInput!
+  ): Theme
+  "Unpublish one asset from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only."
+  unpublishAsset(
+    "Stages to unpublish document from"
+    from: [Stage!]! = [PUBLISHED],
+    "Optional locales to unpublish. Unpublishing the default locale will completely remove the document from the selected stages"
+    locales: [Locale!],
+    "Unpublish complete document including default localization and relations from stages. Can be disabled."
+    unpublishBase: Boolean = true,
+    "Document to unpublish"
+    where: AssetWhereUniqueInput!
+  ): Asset
+  "Unpublish one customer from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only."
+  unpublishCustomer(
+    "Stages to unpublish document from"
+    from: [Stage!]! = [PUBLISHED],
+    "Optional locales to unpublish. Unpublishing the default locale will completely remove the document from the selected stages"
+    locales: [Locale!],
+    "Unpublish complete document including default localization and relations from stages. Can be disabled."
+    unpublishBase: Boolean = true,
+    "Document to unpublish"
+    where: CustomerWhereUniqueInput!
+  ): Customer
+  "Unpublish many Asset documents"
+  unpublishManyAssets(
+    "Stages to unpublish documents from"
+    from: [Stage!]! = [PUBLISHED],
+    "Locales to unpublish"
+    locales: [Locale!],
+    "Whether to unpublish the base document and default localization"
+    unpublishBase: Boolean = true,
+    "Identifies documents in each stage"
+    where: AssetManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (unpublishManyAssetsConnection)")
+  "Find many Asset documents that match criteria in specified stage and unpublish from target stages"
+  unpublishManyAssetsConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    "Stages to unpublish documents from"
+    from: [Stage!]! = [PUBLISHED],
+    last: Int,
+    "Locales to unpublish"
+    locales: [Locale!],
+    skip: Int,
+    "Stage to find matching documents in"
+    stage: Stage = DRAFT,
+    "Whether to unpublish the base document and default localization"
+    unpublishBase: Boolean = true,
+    "Identifies documents in draft stage"
+    where: AssetManyWhereInput
+  ): AssetConnection!
+  "Unpublish many Customer documents"
+  unpublishManyCustomers(
+    "Stages to unpublish documents from"
+    from: [Stage!]! = [PUBLISHED],
+    "Locales to unpublish"
+    locales: [Locale!],
+    "Whether to unpublish the base document and default localization"
+    unpublishBase: Boolean = true,
+    "Identifies documents in each stage"
+    where: CustomerManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (unpublishManyCustomersConnection)")
+  "Find many Customer documents that match criteria in specified stage and unpublish from target stages"
+  unpublishManyCustomersConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    "Stages to unpublish documents from"
+    from: [Stage!]! = [PUBLISHED],
+    last: Int,
+    "Locales to unpublish"
+    locales: [Locale!],
+    skip: Int,
+    "Stage to find matching documents in"
+    stage: Stage = DRAFT,
+    "Whether to unpublish the base document and default localization"
+    unpublishBase: Boolean = true,
+    "Identifies documents in draft stage"
+    where: CustomerManyWhereInput
+  ): CustomerConnection!
+  "Unpublish many Product documents"
+  unpublishManyProducts(
+    "Stages to unpublish documents from"
+    from: [Stage!]! = [PUBLISHED],
+    "Locales to unpublish"
+    locales: [Locale!],
+    "Whether to unpublish the base document and default localization"
+    unpublishBase: Boolean = true,
+    "Identifies documents in each stage"
+    where: ProductManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (unpublishManyProductsConnection)")
+  "Find many Product documents that match criteria in specified stage and unpublish from target stages"
+  unpublishManyProductsConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    "Stages to unpublish documents from"
+    from: [Stage!]! = [PUBLISHED],
+    last: Int,
+    "Locales to unpublish"
+    locales: [Locale!],
+    skip: Int,
+    "Stage to find matching documents in"
+    stage: Stage = DRAFT,
+    "Whether to unpublish the base document and default localization"
+    unpublishBase: Boolean = true,
+    "Identifies documents in draft stage"
+    where: ProductManyWhereInput
+  ): ProductConnection!
+  "Unpublish many Theme documents"
+  unpublishManyThemes(
+    "Stages to unpublish documents from"
+    from: [Stage!]! = [PUBLISHED],
+    "Identifies documents in each stage"
+    where: ThemeManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (unpublishManyThemesConnection)")
+  "Find many Theme documents that match criteria in specified stage and unpublish from target stages"
+  unpublishManyThemesConnection(
+    after: ID,
+    before: ID,
+    first: Int,
+    "Stages to unpublish documents from"
+    from: [Stage!]! = [PUBLISHED],
+    last: Int,
+    skip: Int,
+    "Stage to find matching documents in"
+    stage: Stage = DRAFT,
+    "Identifies documents in draft stage"
+    where: ThemeManyWhereInput
+  ): ThemeConnection!
+  "Unpublish one product from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only."
+  unpublishProduct(
+    "Stages to unpublish document from"
+    from: [Stage!]! = [PUBLISHED],
+    "Optional locales to unpublish. Unpublishing the default locale will completely remove the document from the selected stages"
+    locales: [Locale!],
+    "Unpublish complete document including default localization and relations from stages. Can be disabled."
+    unpublishBase: Boolean = true,
+    "Document to unpublish"
+    where: ProductWhereUniqueInput!
+  ): Product
+  "Unpublish one theme from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only."
+  unpublishTheme(
+    "Stages to unpublish document from"
+    from: [Stage!]! = [PUBLISHED],
+    "Document to unpublish"
+    where: ThemeWhereUniqueInput!
+  ): Theme
+  "Update one asset"
   updateAsset(data: AssetUpdateInput!, where: AssetWhereUniqueInput!): Asset
+  "Update one customer"
   updateCustomer(data: CustomerUpdateInput!, where: CustomerWhereUniqueInput!): Customer
-  updateManyAssets(data: AssetUpdateManyMutationInput!, where: AssetWhereInput): BatchPayload!
-  updateManyCustomers(data: CustomerUpdateManyMutationInput!, where: CustomerWhereInput): BatchPayload!
-  updateManyProducts(data: ProductUpdateManyMutationInput!, where: ProductWhereInput): BatchPayload!
-  updateManyThemes(data: ThemeUpdateManyMutationInput!, where: ThemeWhereInput): BatchPayload!
+  "Update many assets"
+  updateManyAssets(
+    "Updates to document content"
+    data: AssetUpdateManyInput!,
+    "Documents to apply update on"
+    where: AssetManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (updateManyAssetsConnection)")
+  "Update many Asset documents"
+  updateManyAssetsConnection(
+    after: ID,
+    before: ID,
+    "Updates to document content"
+    data: AssetUpdateManyInput!,
+    first: Int,
+    last: Int,
+    skip: Int,
+    "Documents to apply update on"
+    where: AssetManyWhereInput
+  ): AssetConnection!
+  "Update many customers"
+  updateManyCustomers(
+    "Updates to document content"
+    data: CustomerUpdateManyInput!,
+    "Documents to apply update on"
+    where: CustomerManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (updateManyCustomersConnection)")
+  "Update many Customer documents"
+  updateManyCustomersConnection(
+    after: ID,
+    before: ID,
+    "Updates to document content"
+    data: CustomerUpdateManyInput!,
+    first: Int,
+    last: Int,
+    skip: Int,
+    "Documents to apply update on"
+    where: CustomerManyWhereInput
+  ): CustomerConnection!
+  "Update many products"
+  updateManyProducts(
+    "Updates to document content"
+    data: ProductUpdateManyInput!,
+    "Documents to apply update on"
+    where: ProductManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (updateManyProductsConnection)")
+  "Update many Product documents"
+  updateManyProductsConnection(
+    after: ID,
+    before: ID,
+    "Updates to document content"
+    data: ProductUpdateManyInput!,
+    first: Int,
+    last: Int,
+    skip: Int,
+    "Documents to apply update on"
+    where: ProductManyWhereInput
+  ): ProductConnection!
+  "Update many themes"
+  updateManyThemes(
+    "Updates to document content"
+    data: ThemeUpdateManyInput!,
+    "Documents to apply update on"
+    where: ThemeManyWhereInput
+  ): BatchPayload! @deprecated(reason : "Please use the new paginated many mutation (updateManyThemesConnection)")
+  "Update many Theme documents"
+  updateManyThemesConnection(
+    after: ID,
+    before: ID,
+    "Updates to document content"
+    data: ThemeUpdateManyInput!,
+    first: Int,
+    last: Int,
+    skip: Int,
+    "Documents to apply update on"
+    where: ThemeManyWhereInput
+  ): ThemeConnection!
+  "Update one product"
   updateProduct(data: ProductUpdateInput!, where: ProductWhereUniqueInput!): Product
+  "Update one theme"
   updateTheme(data: ThemeUpdateInput!, where: ThemeWhereUniqueInput!): Theme
-  uploadAsset(data: AssetUploadInput!): Asset!
-  upsertAsset(create: AssetCreateInput!, update: AssetUpdateInput!, where: AssetWhereUniqueInput!): Asset!
-  upsertCustomer(create: CustomerCreateInput!, update: CustomerUpdateInput!, where: CustomerWhereUniqueInput!): Customer!
-  upsertProduct(create: ProductCreateInput!, update: ProductUpdateInput!, where: ProductWhereUniqueInput!): Product!
-  upsertTheme(create: ThemeCreateInput!, update: ThemeUpdateInput!, where: ThemeWhereUniqueInput!): Theme!
+  "Upsert one asset"
+  upsertAsset(upsert: AssetUpsertInput!, where: AssetWhereUniqueInput!): Asset
+  "Upsert one customer"
+  upsertCustomer(upsert: CustomerUpsertInput!, where: CustomerWhereUniqueInput!): Customer
+  "Upsert one product"
+  upsertProduct(upsert: ProductUpsertInput!, where: ProductWhereUniqueInput!): Product
+  "Upsert one theme"
+  upsertTheme(upsert: ThemeUpsertInput!, where: ThemeWhereUniqueInput!): Theme
 }
 
 "Information about pagination in a connection."
@@ -170,27 +767,98 @@ type PageInfo {
   hasNextPage: Boolean!
   "When paginating backwards, are there more items?"
   hasPreviousPage: Boolean!
+  "Number of items in the current page."
+  pageSize: Int
   "When paginating backwards, the cursor to continue."
   startCursor: String
 }
 
 type Product implements Node {
-  createdAt: DateTime!
-  customer: Customer
-  description(locale: Locale): String
+  "The time the document was created"
+  createdAt(
+    "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both"
+    variation: SystemDateTimeFieldVariation! = COMBINED
+  ): DateTime!
+  customer(
+    """
+
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+
+    Note that `customer` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!]
+  ): Customer
+  description: String
+  "Get the document in other stages"
+  documentInStages(
+    "Decides if the current stage should be included or not"
+    includeCurrent: Boolean! = false,
+    "Decides if the documents should match the parent documents locale or should use the fallback order defined in the tree"
+    inheritLocale: Boolean! = false,
+    "Potential stages that should be returned"
+    stages: [Stage!]! = [PUBLISHED, DRAFT]
+  ): [Product!]!
+  "List of Product versions"
+  history(
+    limit: Int! = 10,
+    skip: Int! = 0,
+    "This is optional and can be used to fetch the document version history for a specific stage instead of the current one"
+    stageOverride: Stage
+  ): [Version!]!
+  "The unique identifier"
   id: ID!
-  images(after: String, before: String, first: Int, last: Int, orderBy: AssetOrderByInput, skip: Int, where: AssetWhereInput): [Asset!]
+  images(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+
+    Note that `images` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!],
+    orderBy: AssetOrderByInput,
+    skip: Int,
+    where: AssetWhereInput
+  ): [Asset!]!
+  "System Locale field"
+  locale: Locale!
+  "Get the other localizations for this document"
+  localizations(
+    "Decides if the current locale should be included or not"
+    includeCurrent: Boolean! = false,
+    "Potential locales that should be returned"
+    locales: [Locale!]! = [en, fr]
+  ): [Product!]!
   price: Float
-  status: Status!
-  title(locale: Locale): String
-  updatedAt: DateTime!
+  "The time the document was published. Null on documents in draft stage."
+  publishedAt(
+    "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both"
+    variation: SystemDateTimeFieldVariation! = COMBINED
+  ): DateTime
+  "System stage field"
+  stage: Stage!
+  title: String
+  "The time the document was updated"
+  updatedAt(
+    "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both"
+    variation: SystemDateTimeFieldVariation! = COMBINED
+  ): DateTime!
 }
 
 "A connection to a list of items."
 type ProductConnection {
-  aggregate: AggregateProduct!
+  aggregate: Aggregate!
   "A list of edges."
-  edges: [ProductEdge]!
+  edges: [ProductEdge!]!
   "Information to aid in pagination."
   pageInfo: PageInfo!
 }
@@ -203,68 +871,340 @@ type ProductEdge {
   node: Product!
 }
 
-type ProductPreviousValues {
-  createdAt: DateTime!
-  descriptionEN: String
-  descriptionFR: String
-  id: ID!
-  price: Float
-  status: Status!
-  titleEN: String
-  titleFR: String
-  updatedAt: DateTime!
-}
-
-type ProductSubscriptionPayload {
-  mutation: MutationType!
-  node: Product
-  previousValues: ProductPreviousValues
-  updatedFields: [String!]
-}
-
 type Query {
-  asset(where: AssetWhereUniqueInput!): Asset
-  assets(after: String, before: String, first: Int, last: Int, orderBy: AssetOrderByInput, skip: Int, where: AssetWhereInput): [Asset]!
-  assetsConnection(after: String, before: String, first: Int, last: Int, orderBy: AssetOrderByInput, skip: Int, where: AssetWhereInput): AssetConnection!
-  customer(where: CustomerWhereUniqueInput!): Customer
-  customers(after: String, before: String, first: Int, last: Int, orderBy: CustomerOrderByInput, skip: Int, where: CustomerWhereInput): [Customer]!
-  customersConnection(after: String, before: String, first: Int, last: Int, orderBy: CustomerOrderByInput, skip: Int, where: CustomerWhereInput): CustomerConnection!
+  "Retrieve a single asset"
+  asset(
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Asset` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    stage: Stage! = DRAFT,
+    where: AssetWhereUniqueInput!
+  ): Asset
+  "Retrieve document version"
+  assetVersion(where: VersionWhereInput!): DocumentVersion
+  "Retrieve multiple assets"
+  assets(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Asset` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    orderBy: AssetOrderByInput,
+    skip: Int,
+    stage: Stage! = DRAFT,
+    where: AssetWhereInput
+  ): [Asset!]!
+  "Retrieve multiple assets using the Relay connection interface"
+  assetsConnection(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Asset` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    orderBy: AssetOrderByInput,
+    skip: Int,
+    stage: Stage! = DRAFT,
+    where: AssetWhereInput
+  ): AssetConnection!
+  "Retrieve a single customer"
+  customer(
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Customer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    stage: Stage! = DRAFT,
+    where: CustomerWhereUniqueInput!
+  ): Customer
+  "Retrieve document version"
+  customerVersion(where: VersionWhereInput!): DocumentVersion
+  "Retrieve multiple customers"
+  customers(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Customer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    orderBy: CustomerOrderByInput,
+    skip: Int,
+    stage: Stage! = DRAFT,
+    where: CustomerWhereInput
+  ): [Customer!]!
+  "Retrieve multiple customers using the Relay connection interface"
+  customersConnection(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Customer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    orderBy: CustomerOrderByInput,
+    skip: Int,
+    stage: Stage! = DRAFT,
+    where: CustomerWhereInput
+  ): CustomerConnection!
   "Fetches an object given its ID"
   node(
-    #The ID of an object
-    id: ID!
+    "The ID of an object"
+    id: ID!,
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Node` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    stage: Stage! = DRAFT
   ): Node
-  product(where: ProductWhereUniqueInput!): Product
-  products(after: String, before: String, first: Int, last: Int, orderBy: ProductOrderByInput, skip: Int, where: ProductWhereInput): [Product]!
-  productsConnection(after: String, before: String, first: Int, last: Int, orderBy: ProductOrderByInput, skip: Int, where: ProductWhereInput): ProductConnection!
-  theme(where: ThemeWhereUniqueInput!): Theme
-  themes(after: String, before: String, first: Int, last: Int, orderBy: ThemeOrderByInput, skip: Int, where: ThemeWhereInput): [Theme]!
-  themesConnection(after: String, before: String, first: Int, last: Int, orderBy: ThemeOrderByInput, skip: Int, where: ThemeWhereInput): ThemeConnection!
+  "Retrieve a single product"
+  product(
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Product` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    stage: Stage! = DRAFT,
+    where: ProductWhereUniqueInput!
+  ): Product
+  "Retrieve document version"
+  productVersion(where: VersionWhereInput!): DocumentVersion
+  "Retrieve multiple products"
+  products(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Product` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    orderBy: ProductOrderByInput,
+    skip: Int,
+    stage: Stage! = DRAFT,
+    where: ProductWhereInput
+  ): [Product!]!
+  "Retrieve multiple products using the Relay connection interface"
+  productsConnection(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Product` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    orderBy: ProductOrderByInput,
+    skip: Int,
+    stage: Stage! = DRAFT,
+    where: ProductWhereInput
+  ): ProductConnection!
+  "Retrieve a single theme"
+  theme(
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Theme` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    stage: Stage! = DRAFT,
+    where: ThemeWhereUniqueInput!
+  ): Theme
+  "Retrieve document version"
+  themeVersion(where: VersionWhereInput!): DocumentVersion
+  "Retrieve multiple themes"
+  themes(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Theme` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    orderBy: ThemeOrderByInput,
+    skip: Int,
+    stage: Stage! = DRAFT,
+    where: ThemeWhereInput
+  ): [Theme!]!
+  "Retrieve multiple themes using the Relay connection interface"
+  themesConnection(
+    after: String,
+    before: String,
+    first: Int,
+    last: Int,
+    """
+
+    Defines which locales should be returned.
+
+    Note that `Theme` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en, fr],
+    orderBy: ThemeOrderByInput,
+    skip: Int,
+    stage: Stage! = DRAFT,
+    where: ThemeWhereInput
+  ): ThemeConnection!
+}
+
+"Representing a RGBA color value: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb()_and_rgba()"
+type RGBA {
+  a: RGBATransparency!
+  b: RGBAHue!
+  g: RGBAHue!
+  r: RGBAHue!
 }
 
 "Custom type representing a rich text value comprising of raw rich text ast, html, markdown and text values"
 type RichText {
-  html: String
-  markdown: String
-  raw: RichTextAST
-  text: String
+  "Returns HTMl representation"
+  html: String!
+  "Returns Markdown representation"
+  markdown: String!
+  "Returns AST representation"
+  raw: RichTextAST!
+  "Returns plain-text contents of RichText"
+  text: String!
 }
 
 type Theme implements Node {
+  "The time the document was created"
   createdAt: DateTime!
-  customer: Customer
+  customer(
+    """
+
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+
+    Note that `customer` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!]
+  ): Customer
+  "Get the document in other stages"
+  documentInStages(
+    "Decides if the current stage should be included or not"
+    includeCurrent: Boolean! = false,
+    "Decides if the documents should match the parent documents locale or should use the fallback order defined in the tree"
+    inheritLocale: Boolean! = false,
+    "Potential stages that should be returned"
+    stages: [Stage!]! = [PUBLISHED, DRAFT]
+  ): [Theme!]!
+  "List of Theme versions"
+  history(
+    limit: Int! = 10,
+    skip: Int! = 0,
+    "This is optional and can be used to fetch the document version history for a specific stage instead of the current one"
+    stageOverride: Stage
+  ): [Version!]!
+  "The unique identifier"
   id: ID!
-  logo: Asset
+  logo(
+    """
+
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+
+    Note that `logo` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.
+    For related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.
+
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!]
+  ): Asset!
   primaryColor: String!
-  status: Status!
+  "The time the document was published. Null on documents in draft stage."
+  publishedAt: DateTime
+  "System stage field"
+  stage: Stage!
+  "The time the document was updated"
   updatedAt: DateTime!
 }
 
 "A connection to a list of items."
 type ThemeConnection {
-  aggregate: AggregateTheme!
+  aggregate: Aggregate!
   "A list of edges."
-  edges: [ThemeEdge]!
+  edges: [ThemeEdge!]!
   "Information to aid in pagination."
   pageInfo: PageInfo!
 }
@@ -277,19 +1217,11 @@ type ThemeEdge {
   node: Theme!
 }
 
-type ThemePreviousValues {
+type Version {
   createdAt: DateTime!
   id: ID!
-  primaryColor: String!
-  status: Status!
-  updatedAt: DateTime!
-}
-
-type ThemeSubscriptionPayload {
-  mutation: MutationType!
-  node: Theme
-  previousValues: ThemePreviousValues
-  updatedFields: [String!]
+  revision: Int!
+  stage: Stage!
 }
 
 enum AssetOrderByInput {
@@ -305,10 +1237,12 @@ enum AssetOrderByInput {
   id_DESC
   mimeType_ASC
   mimeType_DESC
+  publishedAt_ASC
+  publishedAt_DESC
   size_ASC
   size_DESC
-  status_ASC
-  status_DESC
+  title_ASC
+  title_DESC
   updatedAt_ASC
   updatedAt_DESC
   width_ASC
@@ -320,18 +1254,12 @@ enum CustomerOrderByInput {
   createdAt_DESC
   id_ASC
   id_DESC
-  labelEN_ASC
-  labelEN_DESC
-  labelFR_ASC
-  labelFR_DESC
+  label_ASC
+  label_DESC
+  publishedAt_ASC
+  publishedAt_DESC
   ref_ASC
   ref_DESC
-  status_ASC
-  status_DESC
-  termsEN_ASC
-  termsEN_DESC
-  termsFR_ASC
-  termsFR_DESC
   updatedAt_ASC
   updatedAt_DESC
 }
@@ -356,52 +1284,51 @@ enum DocumentFileTypes {
 }
 
 enum ImageFit {
-  #Resizes the image to fit within the specified parameters without distorting, cropping, or changing the aspect ratio.
+  "Resizes the image to fit within the specified parameters without distorting, cropping, or changing the aspect ratio."
   clip
-  #Resizes the image to fit the specified parameters exactly by removing any parts of the image that don't fit within the boundaries.
+  "Resizes the image to fit the specified parameters exactly by removing any parts of the image that don't fit within the boundaries."
   crop
-  #Resizes the image to fit within the parameters, but as opposed to 'fit:clip' will not scale the image if the image is smaller than the output size.
+  "Resizes the image to fit within the parameters, but as opposed to 'fit:clip' will not scale the image if the image is smaller than the output size."
   max
-  #Resizes the image to fit the specified parameters exactly by scaling the image to the desired size. The aspect ratio of the image is not respected and the image can be distorted using this method.
+  "Resizes the image to fit the specified parameters exactly by scaling the image to the desired size. The aspect ratio of the image is not respected and the image can be distorted using this method."
   scale
 }
 
+"Locale system enumeration"
 enum Locale {
-  EN
-  FR
-}
-
-enum MutationType {
-  CREATED
-  DELETED
-  UPDATED
+  en
+  fr
 }
 
 enum ProductOrderByInput {
   createdAt_ASC
   createdAt_DESC
-  descriptionEN_ASC
-  descriptionEN_DESC
-  descriptionFR_ASC
-  descriptionFR_DESC
+  description_ASC
+  description_DESC
   id_ASC
   id_DESC
   price_ASC
   price_DESC
-  status_ASC
-  status_DESC
-  titleEN_ASC
-  titleEN_DESC
-  titleFR_ASC
-  titleFR_DESC
+  publishedAt_ASC
+  publishedAt_DESC
+  title_ASC
+  title_DESC
   updatedAt_ASC
   updatedAt_DESC
 }
 
-enum Status {
-  ARCHIVED
+"Stage system enumeration"
+enum Stage {
+  "The Draft is the default stage for all your content."
   DRAFT
+  "The Published stage is where you can publish your content to."
   PUBLISHED
+}
+
+enum SystemDateTimeFieldVariation {
+  BASE
+  COMBINED
+  LOCALIZATION
 }
 
 enum ThemeOrderByInput {
@@ -411,65 +1338,164 @@ enum ThemeOrderByInput {
   id_DESC
   primaryColor_ASC
   primaryColor_DESC
-  status_ASC
-  status_DESC
+  publishedAt_ASC
+  publishedAt_DESC
   updatedAt_ASC
   updatedAt_DESC
 }
 
+"System User Kind"
+enum UserKind {
+  MEMBER
+  PAT
+  PUBLIC
+  WEBHOOK
+}
+
+enum _FilterKind {
+  AND
+  NOT
+  OR
+  contains
+  contains_all
+  contains_none
+  contains_some
+  ends_with
+  eq
+  eq_not
+  gt
+  gte
+  in
+  lt
+  lte
+  not_contains
+  not_ends_with
+  not_in
+  not_starts_with
+  relational_every
+  relational_none
+  relational_single
+  relational_some
+  search
+  starts_with
+}
+
+enum _MutationInputFieldKind {
+  enum
+  relation
+  richText
+  scalar
+  union
+  virtual
+}
+
+enum _MutationKind {
+  create
+  delete
+  deleteMany
+  publish
+  publishMany
+  unpublish
+  unpublishMany
+  update
+  updateMany
+  upsert
+}
+
+enum _OrderDirection {
+  asc
+  desc
+}
+
+enum _RelationInputCardinality {
+  many
+  one
+}
+
+enum _RelationInputKind {
+  create
+  update
+}
+
+enum _RelationKind {
+  regular
+  union
+}
+
+enum _SystemDateTimeFieldVariation {
+  base
+  combined
+  localization
+}
+
+input AssetConnectInput {
+  "Allow to specify document position in list of connected documents, will default to appending at end of list"
+  position: ConnectPositionInput
+  "Document to connect"
+  where: AssetWhereUniqueInput!
+}
+
 input AssetCreateInput {
+  createdAt: DateTime
   fileName: String!
   handle: String!
   height: Float
-  imagesProduct: ProductCreateManyWithoutImagesInput
-  logoTheme: ThemeCreateManyWithoutLogoInput
+  imagesProduct: ProductCreateManyInlineInput
+  "Inline mutations for managing document localizations excluding the default locale"
+  localizations: AssetCreateLocalizationsInput
+  logoTheme: ThemeCreateManyInlineInput
   mimeType: String
   size: Float
-  status: Status
+  title: String
+  updatedAt: DateTime
   width: Float
 }
 
-input AssetCreateManyWithoutImagesProductInput {
+input AssetCreateLocalizationDataInput {
+  createdAt: DateTime
+  fileName: String!
+  handle: String!
+  height: Float
+  mimeType: String
+  size: Float
+  updatedAt: DateTime
+  width: Float
+}
+
+input AssetCreateLocalizationInput {
+  "Localization input"
+  data: AssetCreateLocalizationDataInput!
+  locale: Locale!
+}
+
+input AssetCreateLocalizationsInput {
+  "Create localizations for the newly-created document"
+  create: [AssetCreateLocalizationInput!]
+}
+
+input AssetCreateManyInlineInput {
+  "Connect multiple existing Asset documents"
   connect: [AssetWhereUniqueInput!]
-  create: [AssetCreateWithoutImagesProductInput!]
-  upload: [AssetUploadWithoutImagesProductInput!]
+  "Create and connect multiple existing Asset documents"
+  create: [AssetCreateInput!]
 }
 
-input AssetCreateOneWithoutLogoThemeInput {
+input AssetCreateOneInlineInput {
+  "Connect one existing Asset document"
   connect: AssetWhereUniqueInput
-  create: AssetCreateWithoutLogoThemeInput
-  upload: AssetUploadWithoutLogoThemeInput
+  "Create and connect one Asset document"
+  create: AssetCreateInput
 }
 
-input AssetCreateWithoutImagesProductInput {
-  fileName: String!
-  handle: String!
-  height: Float
-  logoTheme: ThemeCreateManyWithoutLogoInput
-  mimeType: String
-  size: Float
-  status: Status
-  width: Float
-}
-
-input AssetCreateWithoutLogoThemeInput {
-  fileName: String!
-  handle: String!
-  height: Float
-  imagesProduct: ProductCreateManyWithoutImagesInput
-  mimeType: String
-  size: Float
-  status: Status
-  width: Float
-}
-
-input AssetScalarWhereInput {
+"Identifies documents"
+input AssetManyWhereInput {
   "Logical AND on all given filters."
-  AND: [AssetScalarWhereInput!]
+  AND: [AssetWhereInput!]
   "Logical NOT on all given filters combined by AND."
-  NOT: [AssetScalarWhereInput!]
+  NOT: [AssetWhereInput!]
   "Logical OR on all given filters."
-  OR: [AssetScalarWhereInput!]
+  OR: [AssetWhereInput!]
+  "Contains search across all appropriate fields."
   _search: String
   createdAt: DateTime
   "All values greater than the given value."
@@ -486,95 +1512,18 @@ input AssetScalarWhereInput {
   createdAt_not: DateTime
   "All values that are not contained in given list."
   createdAt_not_in: [DateTime!]
-  fileName: String
-  "All values containing the given string."
-  fileName_contains: String
-  "All values ending with the given string."
-  fileName_ends_with: String
-  "All values greater than the given value."
-  fileName_gt: String
-  "All values greater than or equal the given value."
-  fileName_gte: String
-  "All values that are contained in given list."
-  fileName_in: [String!]
-  "All values less than the given value."
-  fileName_lt: String
-  "All values less than or equal the given value."
-  fileName_lte: String
-  "All values that are not equal to given value."
-  fileName_not: String
-  "All values not containing the given string."
-  fileName_not_contains: String
-  "All values not ending with the given string."
-  fileName_not_ends_with: String
-  "All values that are not contained in given list."
-  fileName_not_in: [String!]
-  "All values not starting with the given string."
-  fileName_not_starts_with: String
-  "All values starting with the given string."
-  fileName_starts_with: String
-  handle: String
-  "All values containing the given string."
-  handle_contains: String
-  "All values ending with the given string."
-  handle_ends_with: String
-  "All values greater than the given value."
-  handle_gt: String
-  "All values greater than or equal the given value."
-  handle_gte: String
-  "All values that are contained in given list."
-  handle_in: [String!]
-  "All values less than the given value."
-  handle_lt: String
-  "All values less than or equal the given value."
-  handle_lte: String
-  "All values that are not equal to given value."
-  handle_not: String
-  "All values not containing the given string."
-  handle_not_contains: String
-  "All values not ending with the given string."
-  handle_not_ends_with: String
-  "All values that are not contained in given list."
-  handle_not_in: [String!]
-  "All values not starting with the given string."
-  handle_not_starts_with: String
-  "All values starting with the given string."
-  handle_starts_with: String
-  height: Float
-  "All values greater than the given value."
-  height_gt: Float
-  "All values greater than or equal the given value."
-  height_gte: Float
-  "All values that are contained in given list."
-  height_in: [Float!]
-  "All values less than the given value."
-  height_lt: Float
-  "All values less than or equal the given value."
-  height_lte: Float
-  "All values that are not equal to given value."
-  height_not: Float
-  "All values that are not contained in given list."
-  height_not_in: [Float!]
   id: ID
   "All values containing the given string."
   id_contains: ID
   "All values ending with the given string."
   id_ends_with: ID
-  "All values greater than the given value."
-  id_gt: ID
-  "All values greater than or equal the given value."
-  id_gte: ID
   "All values that are contained in given list."
   id_in: [ID!]
-  "All values less than the given value."
-  id_lt: ID
-  "All values less than or equal the given value."
-  id_lte: ID
   "All values that are not equal to given value."
   id_not: ID
   "All values not containing the given string."
   id_not_contains: ID
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   id_not_ends_with: ID
   "All values that are not contained in given list."
   id_not_in: [ID!]
@@ -582,55 +1531,46 @@ input AssetScalarWhereInput {
   id_not_starts_with: ID
   "All values starting with the given string."
   id_starts_with: ID
-  mimeType: String
+  imagesProduct_every: ProductWhereInput
+  imagesProduct_none: ProductWhereInput
+  imagesProduct_some: ProductWhereInput
+  logoTheme_every: ThemeWhereInput
+  logoTheme_none: ThemeWhereInput
+  logoTheme_some: ThemeWhereInput
+  publishedAt: DateTime
+  "All values greater than the given value."
+  publishedAt_gt: DateTime
+  "All values greater than or equal the given value."
+  publishedAt_gte: DateTime
+  "All values that are contained in given list."
+  publishedAt_in: [DateTime!]
+  "All values less than the given value."
+  publishedAt_lt: DateTime
+  "All values less than or equal the given value."
+  publishedAt_lte: DateTime
+  "All values that are not equal to given value."
+  publishedAt_not: DateTime
+  "All values that are not contained in given list."
+  publishedAt_not_in: [DateTime!]
+  title: String
   "All values containing the given string."
-  mimeType_contains: String
+  title_contains: String
   "All values ending with the given string."
-  mimeType_ends_with: String
-  "All values greater than the given value."
-  mimeType_gt: String
-  "All values greater than or equal the given value."
-  mimeType_gte: String
+  title_ends_with: String
   "All values that are contained in given list."
-  mimeType_in: [String!]
-  "All values less than the given value."
-  mimeType_lt: String
-  "All values less than or equal the given value."
-  mimeType_lte: String
+  title_in: [String!]
   "All values that are not equal to given value."
-  mimeType_not: String
+  title_not: String
   "All values not containing the given string."
-  mimeType_not_contains: String
-  "All values not ending with the given string."
-  mimeType_not_ends_with: String
+  title_not_contains: String
+  "All values not ending with the given string"
+  title_not_ends_with: String
   "All values that are not contained in given list."
-  mimeType_not_in: [String!]
+  title_not_in: [String!]
   "All values not starting with the given string."
-  mimeType_not_starts_with: String
+  title_not_starts_with: String
   "All values starting with the given string."
-  mimeType_starts_with: String
-  size: Float
-  "All values greater than the given value."
-  size_gt: Float
-  "All values greater than or equal the given value."
-  size_gte: Float
-  "All values that are contained in given list."
-  size_in: [Float!]
-  "All values less than the given value."
-  size_lt: Float
-  "All values less than or equal the given value."
-  size_lte: Float
-  "All values that are not equal to given value."
-  size_not: Float
-  "All values that are not contained in given list."
-  size_not_in: [Float!]
-  status: Status
-  "All values that are contained in given list."
-  status_in: [Status!]
-  "All values that are not equal to given value."
-  status_not: Status
-  "All values that are not contained in given list."
-  status_not_in: [Status!]
+  title_starts_with: String
   updatedAt: DateTime
   "All values greater than the given value."
   updatedAt_gt: DateTime
@@ -646,46 +1586,13 @@ input AssetScalarWhereInput {
   updatedAt_not: DateTime
   "All values that are not contained in given list."
   updatedAt_not_in: [DateTime!]
-  width: Float
-  "All values greater than the given value."
-  width_gt: Float
-  "All values greater than or equal the given value."
-  width_gte: Float
-  "All values that are contained in given list."
-  width_in: [Float!]
-  "All values less than the given value."
-  width_lt: Float
-  "All values less than or equal the given value."
-  width_lte: Float
-  "All values that are not equal to given value."
-  width_not: Float
-  "All values that are not contained in given list."
-  width_not_in: [Float!]
-}
-
-input AssetSubscriptionWhereInput {
-  "Logical AND on all given filters."
-  AND: [AssetSubscriptionWhereInput!]
-  "Logical NOT on all given filters combined by AND."
-  NOT: [AssetSubscriptionWhereInput!]
-  "Logical OR on all given filters."
-  OR: [AssetSubscriptionWhereInput!]
-  "The subscription event gets dispatched when it's listed in mutation_in"
-  mutation_in: [MutationType!]
-  node: AssetWhereInput
-  "The subscription event gets only dispatched when one of the updated fields names is included in this list"
-  updatedFields_contains: String
-  "The subscription event gets only dispatched when all of the field names included in this list have been updated"
-  updatedFields_contains_every: [String!]
-  "The subscription event gets only dispatched when some of the field names included in this list have been updated"
-  updatedFields_contains_some: [String!]
 }
 
 "Transformations for Assets"
 input AssetTransformationInput {
   document: DocumentTransformationInput
   image: ImageTransformationInput
-  "Pass `true` if you want to validate the passed transformation parameters"
+  "Pass true if you want to validate the passed transformation parameters"
   validateOptions: Boolean = false
 }
 
@@ -693,117 +1600,136 @@ input AssetUpdateInput {
   fileName: String
   handle: String
   height: Float
-  imagesProduct: ProductUpdateManyWithoutImagesInput
-  logoTheme: ThemeUpdateManyWithoutLogoInput
+  imagesProduct: ProductUpdateManyInlineInput
+  "Manage document localizations"
+  localizations: AssetUpdateLocalizationsInput
+  logoTheme: ThemeUpdateManyInlineInput
   mimeType: String
   size: Float
-  status: Status
+  title: String
   width: Float
 }
 
-input AssetUpdateManyDataInput {
+input AssetUpdateLocalizationDataInput {
   fileName: String
   handle: String
   height: Float
   mimeType: String
   size: Float
-  status: Status
   width: Float
 }
 
-input AssetUpdateManyMutationInput {
-  fileName: String
-  handle: String
-  height: Float
-  mimeType: String
-  size: Float
-  status: Status
-  width: Float
+input AssetUpdateLocalizationInput {
+  data: AssetUpdateLocalizationDataInput!
+  locale: Locale!
 }
 
-input AssetUpdateManyWithWhereNestedInput {
-  data: AssetUpdateManyDataInput!
-  where: AssetScalarWhereInput!
+input AssetUpdateLocalizationsInput {
+  "Localizations to create"
+  create: [AssetCreateLocalizationInput!]
+  "Localizations to delete"
+  delete: [Locale!]
+  "Localizations to update"
+  update: [AssetUpdateLocalizationInput!]
+  upsert: [AssetUpsertLocalizationInput!]
 }
 
-input AssetUpdateManyWithoutImagesProductInput {
-  connect: [AssetWhereUniqueInput!]
-  create: [AssetCreateWithoutImagesProductInput!]
+input AssetUpdateManyInlineInput {
+  "Connect multiple existing Asset documents"
+  connect: [AssetConnectInput!]
+  "Create and connect multiple Asset documents"
+  create: [AssetCreateInput!]
+  "Delete multiple Asset documents"
   delete: [AssetWhereUniqueInput!]
-  deleteMany: [AssetScalarWhereInput!]
+  "Disconnect multiple Asset documents"
   disconnect: [AssetWhereUniqueInput!]
+  "Override currently-connected documents with multiple existing Asset documents"
   set: [AssetWhereUniqueInput!]
-  update: [AssetUpdateWithWhereUniqueWithoutImagesProductInput!]
-  updateMany: [AssetUpdateManyWithWhereNestedInput!]
-  upsert: [AssetUpsertWithWhereUniqueWithoutImagesProductInput!]
+  "Update multiple Asset documents"
+  update: [AssetUpdateWithNestedWhereUniqueInput!]
+  "Upsert multiple Asset documents"
+  upsert: [AssetUpsertWithNestedWhereUniqueInput!]
 }
 
-input AssetUpdateOneWithoutLogoThemeInput {
+input AssetUpdateManyInput {
+  fileName: String
+  height: Float
+  "Optional updates to localizations"
+  localizations: AssetUpdateManyLocalizationsInput
+  mimeType: String
+  size: Float
+  title: String
+  width: Float
+}
+
+input AssetUpdateManyLocalizationDataInput {
+  fileName: String
+  height: Float
+  mimeType: String
+  size: Float
+  width: Float
+}
+
+input AssetUpdateManyLocalizationInput {
+  data: AssetUpdateManyLocalizationDataInput!
+  locale: Locale!
+}
+
+input AssetUpdateManyLocalizationsInput {
+  "Localizations to update"
+  update: [AssetUpdateManyLocalizationInput!]
+}
+
+input AssetUpdateManyWithNestedWhereInput {
+  "Update many input"
+  data: AssetUpdateManyInput!
+  "Document search"
+  where: AssetWhereInput!
+}
+
+input AssetUpdateOneInlineInput {
+  "Connect existing Asset document"
   connect: AssetWhereUniqueInput
-  create: AssetCreateWithoutLogoThemeInput
+  "Create and connect one Asset document"
+  create: AssetCreateInput
+  "Delete currently connected Asset document"
   delete: Boolean
+  "Disconnect currently connected Asset document"
   disconnect: Boolean
-  update: AssetUpdateWithoutLogoThemeDataInput
-  upsert: AssetUpsertWithoutLogoThemeInput
+  "Update single Asset document"
+  update: AssetUpdateWithNestedWhereUniqueInput
+  "Upsert single Asset document"
+  upsert: AssetUpsertWithNestedWhereUniqueInput
 }
 
-input AssetUpdateWithWhereUniqueWithoutImagesProductInput {
-  data: AssetUpdateWithoutImagesProductDataInput!
+input AssetUpdateWithNestedWhereUniqueInput {
+  "Document to update"
+  data: AssetUpdateInput!
+  "Unique document search"
   where: AssetWhereUniqueInput!
 }
 
-input AssetUpdateWithoutImagesProductDataInput {
-  fileName: String
-  handle: String
-  height: Float
-  logoTheme: ThemeUpdateManyWithoutLogoInput
-  mimeType: String
-  size: Float
-  status: Status
-  width: Float
+input AssetUpsertInput {
+  "Create document if it didn't exist"
+  create: AssetCreateInput!
+  "Update document if it exists"
+  update: AssetUpdateInput!
 }
 
-input AssetUpdateWithoutLogoThemeDataInput {
-  fileName: String
-  handle: String
-  height: Float
-  imagesProduct: ProductUpdateManyWithoutImagesInput
-  mimeType: String
-  size: Float
-  status: Status
-  width: Float
+input AssetUpsertLocalizationInput {
+  create: AssetCreateLocalizationDataInput!
+  locale: Locale!
+  update: AssetUpdateLocalizationDataInput!
 }
 
-input AssetUploadInput {
-  imagesProduct: ProductCreateManyWithoutImagesInput
-  logoTheme: ThemeCreateManyWithoutLogoInput
-  status: Status
-  url: String!
-}
-
-input AssetUploadWithoutImagesProductInput {
-  logoTheme: ThemeCreateManyWithoutLogoInput
-  status: Status
-  url: String!
-}
-
-input AssetUploadWithoutLogoThemeInput {
-  imagesProduct: ProductCreateManyWithoutImagesInput
-  status: Status
-  url: String!
-}
-
-input AssetUpsertWithWhereUniqueWithoutImagesProductInput {
-  create: AssetCreateWithoutImagesProductInput!
-  update: AssetUpdateWithoutImagesProductDataInput!
+input AssetUpsertWithNestedWhereUniqueInput {
+  "Upsert data"
+  data: AssetUpsertInput!
+  "Unique document search"
   where: AssetWhereUniqueInput!
 }
 
-input AssetUpsertWithoutLogoThemeInput {
-  create: AssetCreateWithoutLogoThemeInput!
-  update: AssetUpdateWithoutLogoThemeDataInput!
-}
-
+"Identifies documents"
 input AssetWhereInput {
   "Logical AND on all given filters."
   AND: [AssetWhereInput!]
@@ -811,6 +1737,7 @@ input AssetWhereInput {
   NOT: [AssetWhereInput!]
   "Logical OR on all given filters."
   OR: [AssetWhereInput!]
+  "Contains search across all appropriate fields."
   _search: String
   createdAt: DateTime
   "All values greater than the given value."
@@ -832,21 +1759,13 @@ input AssetWhereInput {
   fileName_contains: String
   "All values ending with the given string."
   fileName_ends_with: String
-  "All values greater than the given value."
-  fileName_gt: String
-  "All values greater than or equal the given value."
-  fileName_gte: String
   "All values that are contained in given list."
   fileName_in: [String!]
-  "All values less than the given value."
-  fileName_lt: String
-  "All values less than or equal the given value."
-  fileName_lte: String
   "All values that are not equal to given value."
   fileName_not: String
   "All values not containing the given string."
   fileName_not_contains: String
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   fileName_not_ends_with: String
   "All values that are not contained in given list."
   fileName_not_in: [String!]
@@ -859,21 +1778,13 @@ input AssetWhereInput {
   handle_contains: String
   "All values ending with the given string."
   handle_ends_with: String
-  "All values greater than the given value."
-  handle_gt: String
-  "All values greater than or equal the given value."
-  handle_gte: String
   "All values that are contained in given list."
   handle_in: [String!]
-  "All values less than the given value."
-  handle_lt: String
-  "All values less than or equal the given value."
-  handle_lte: String
   "All values that are not equal to given value."
   handle_not: String
   "All values not containing the given string."
   handle_not_contains: String
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   handle_not_ends_with: String
   "All values that are not contained in given list."
   handle_not_in: [String!]
@@ -901,21 +1812,13 @@ input AssetWhereInput {
   id_contains: ID
   "All values ending with the given string."
   id_ends_with: ID
-  "All values greater than the given value."
-  id_gt: ID
-  "All values greater than or equal the given value."
-  id_gte: ID
   "All values that are contained in given list."
   id_in: [ID!]
-  "All values less than the given value."
-  id_lt: ID
-  "All values less than or equal the given value."
-  id_lte: ID
   "All values that are not equal to given value."
   id_not: ID
   "All values not containing the given string."
   id_not_contains: ID
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   id_not_ends_with: ID
   "All values that are not contained in given list."
   id_not_in: [ID!]
@@ -934,21 +1837,13 @@ input AssetWhereInput {
   mimeType_contains: String
   "All values ending with the given string."
   mimeType_ends_with: String
-  "All values greater than the given value."
-  mimeType_gt: String
-  "All values greater than or equal the given value."
-  mimeType_gte: String
   "All values that are contained in given list."
   mimeType_in: [String!]
-  "All values less than the given value."
-  mimeType_lt: String
-  "All values less than or equal the given value."
-  mimeType_lte: String
   "All values that are not equal to given value."
   mimeType_not: String
   "All values not containing the given string."
   mimeType_not_contains: String
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   mimeType_not_ends_with: String
   "All values that are not contained in given list."
   mimeType_not_in: [String!]
@@ -956,6 +1851,21 @@ input AssetWhereInput {
   mimeType_not_starts_with: String
   "All values starting with the given string."
   mimeType_starts_with: String
+  publishedAt: DateTime
+  "All values greater than the given value."
+  publishedAt_gt: DateTime
+  "All values greater than or equal the given value."
+  publishedAt_gte: DateTime
+  "All values that are contained in given list."
+  publishedAt_in: [DateTime!]
+  "All values less than the given value."
+  publishedAt_lt: DateTime
+  "All values less than or equal the given value."
+  publishedAt_lte: DateTime
+  "All values that are not equal to given value."
+  publishedAt_not: DateTime
+  "All values that are not contained in given list."
+  publishedAt_not_in: [DateTime!]
   size: Float
   "All values greater than the given value."
   size_gt: Float
@@ -971,13 +1881,25 @@ input AssetWhereInput {
   size_not: Float
   "All values that are not contained in given list."
   size_not_in: [Float!]
-  status: Status
+  title: String
+  "All values containing the given string."
+  title_contains: String
+  "All values ending with the given string."
+  title_ends_with: String
   "All values that are contained in given list."
-  status_in: [Status!]
+  title_in: [String!]
   "All values that are not equal to given value."
-  status_not: Status
+  title_not: String
+  "All values not containing the given string."
+  title_not_contains: String
+  "All values not ending with the given string"
+  title_not_ends_with: String
   "All values that are not contained in given list."
-  status_not_in: [Status!]
+  title_not_in: [String!]
+  "All values not starting with the given string."
+  title_not_starts_with: String
+  "All values starting with the given string."
+  title_starts_with: String
   updatedAt: DateTime
   "All values greater than the given value."
   updatedAt_gt: DateTime
@@ -1010,145 +1932,90 @@ input AssetWhereInput {
   width_not_in: [Float!]
 }
 
+"References Asset record uniquely"
 input AssetWhereUniqueInput {
-  handle: String
   id: ID
 }
 
+"Accepts either HEX or RGBA color value. At least one of hex or rgba value should be passed. If both are passed RGBA is used."
+input ColorInput {
+  hex: Hex
+  rgba: RGBAInput
+}
+
+input ConnectPositionInput {
+  "Connect document after specified document"
+  after: ID
+  "Connect document before specified document"
+  before: ID
+  "Connect document at last position"
+  end: Boolean
+  "Connect document at first position"
+  start: Boolean
+}
+
+input CustomerConnectInput {
+  "Allow to specify document position in list of connected documents, will default to appending at end of list"
+  position: ConnectPositionInput
+  "Document to connect"
+  where: CustomerWhereUniqueInput!
+}
+
 input CustomerCreateInput {
-  labelEN: String
-  labelFR: String
-  products: ProductCreateManyWithoutCustomerInput
+  createdAt: DateTime
+  "label input for default locale (en)"
+  label: String
+  "Inline mutations for managing document localizations excluding the default locale"
+  localizations: CustomerCreateLocalizationsInput
+  products: ProductCreateManyInlineInput
   ref: String!
-  status: Status
-  termsEN: RichTextAST
-  termsFR: RichTextAST
-  theme: ThemeCreateOneWithoutCustomerInput
+  "terms input for default locale (en)"
+  terms: RichTextAST
+  theme: ThemeCreateOneInlineInput
+  updatedAt: DateTime
 }
 
-input CustomerCreateOneWithoutProductsInput {
+input CustomerCreateLocalizationDataInput {
+  createdAt: DateTime
+  label: String
+  terms: RichTextAST
+  updatedAt: DateTime
+}
+
+input CustomerCreateLocalizationInput {
+  "Localization input"
+  data: CustomerCreateLocalizationDataInput!
+  locale: Locale!
+}
+
+input CustomerCreateLocalizationsInput {
+  "Create localizations for the newly-created document"
+  create: [CustomerCreateLocalizationInput!]
+}
+
+input CustomerCreateManyInlineInput {
+  "Connect multiple existing Customer documents"
+  connect: [CustomerWhereUniqueInput!]
+  "Create and connect multiple existing Customer documents"
+  create: [CustomerCreateInput!]
+}
+
+input CustomerCreateOneInlineInput {
+  "Connect one existing Customer document"
   connect: CustomerWhereUniqueInput
-  create: CustomerCreateWithoutProductsInput
+  "Create and connect one Customer document"
+  create: CustomerCreateInput
 }
 
-input CustomerCreateOneWithoutThemeInput {
-  connect: CustomerWhereUniqueInput
-  create: CustomerCreateWithoutThemeInput
-}
-
-input CustomerCreateWithoutProductsInput {
-  labelEN: String
-  labelFR: String
-  ref: String!
-  status: Status
-  termsEN: RichTextAST
-  termsFR: RichTextAST
-  theme: ThemeCreateOneWithoutCustomerInput
-}
-
-input CustomerCreateWithoutThemeInput {
-  labelEN: String
-  labelFR: String
-  products: ProductCreateManyWithoutCustomerInput
-  ref: String!
-  status: Status
-  termsEN: RichTextAST
-  termsFR: RichTextAST
-}
-
-input CustomerSubscriptionWhereInput {
-  "Logical AND on all given filters."
-  AND: [CustomerSubscriptionWhereInput!]
-  "Logical NOT on all given filters combined by AND."
-  NOT: [CustomerSubscriptionWhereInput!]
-  "Logical OR on all given filters."
-  OR: [CustomerSubscriptionWhereInput!]
-  "The subscription event gets dispatched when it's listed in mutation_in"
-  mutation_in: [MutationType!]
-  node: CustomerWhereInput
-  "The subscription event gets only dispatched when one of the updated fields names is included in this list"
-  updatedFields_contains: String
-  "The subscription event gets only dispatched when all of the field names included in this list have been updated"
-  updatedFields_contains_every: [String!]
-  "The subscription event gets only dispatched when some of the field names included in this list have been updated"
-  updatedFields_contains_some: [String!]
-}
-
-input CustomerUpdateInput {
-  labelEN: String
-  labelFR: String
-  products: ProductUpdateManyWithoutCustomerInput
-  ref: String
-  status: Status
-  termsEN: RichTextAST
-  termsFR: RichTextAST
-  theme: ThemeUpdateOneWithoutCustomerInput
-}
-
-input CustomerUpdateManyMutationInput {
-  labelEN: String
-  labelFR: String
-  ref: String
-  status: Status
-  termsEN: RichTextAST
-  termsFR: RichTextAST
-}
-
-input CustomerUpdateOneWithoutProductsInput {
-  connect: CustomerWhereUniqueInput
-  create: CustomerCreateWithoutProductsInput
-  delete: Boolean
-  disconnect: Boolean
-  update: CustomerUpdateWithoutProductsDataInput
-  upsert: CustomerUpsertWithoutProductsInput
-}
-
-input CustomerUpdateOneWithoutThemeInput {
-  connect: CustomerWhereUniqueInput
-  create: CustomerCreateWithoutThemeInput
-  delete: Boolean
-  disconnect: Boolean
-  update: CustomerUpdateWithoutThemeDataInput
-  upsert: CustomerUpsertWithoutThemeInput
-}
-
-input CustomerUpdateWithoutProductsDataInput {
-  labelEN: String
-  labelFR: String
-  ref: String
-  status: Status
-  termsEN: RichTextAST
-  termsFR: RichTextAST
-  theme: ThemeUpdateOneWithoutCustomerInput
-}
-
-input CustomerUpdateWithoutThemeDataInput {
-  labelEN: String
-  labelFR: String
-  products: ProductUpdateManyWithoutCustomerInput
-  ref: String
-  status: Status
-  termsEN: RichTextAST
-  termsFR: RichTextAST
-}
-
-input CustomerUpsertWithoutProductsInput {
-  create: CustomerCreateWithoutProductsInput!
-  update: CustomerUpdateWithoutProductsDataInput!
-}
-
-input CustomerUpsertWithoutThemeInput {
-  create: CustomerCreateWithoutThemeInput!
-  update: CustomerUpdateWithoutThemeDataInput!
-}
-
-input CustomerWhereInput {
+"Identifies documents"
+input CustomerManyWhereInput {
   "Logical AND on all given filters."
   AND: [CustomerWhereInput!]
   "Logical NOT on all given filters combined by AND."
   NOT: [CustomerWhereInput!]
   "Logical OR on all given filters."
   OR: [CustomerWhereInput!]
+  "Contains search across all appropriate fields."
   _search: String
   createdAt: DateTime
   "All values greater than the given value."
@@ -1170,21 +2037,13 @@ input CustomerWhereInput {
   id_contains: ID
   "All values ending with the given string."
   id_ends_with: ID
-  "All values greater than the given value."
-  id_gt: ID
-  "All values greater than or equal the given value."
-  id_gte: ID
   "All values that are contained in given list."
   id_in: [ID!]
-  "All values less than the given value."
-  id_lt: ID
-  "All values less than or equal the given value."
-  id_lte: ID
   "All values that are not equal to given value."
   id_not: ID
   "All values not containing the given string."
   id_not_contains: ID
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   id_not_ends_with: ID
   "All values that are not contained in given list."
   id_not_in: [ID!]
@@ -1192,83 +2051,36 @@ input CustomerWhereInput {
   id_not_starts_with: ID
   "All values starting with the given string."
   id_starts_with: ID
-  labelEN: String
-  "All values containing the given string."
-  labelEN_contains: String
-  "All values ending with the given string."
-  labelEN_ends_with: String
-  "All values greater than the given value."
-  labelEN_gt: String
-  "All values greater than or equal the given value."
-  labelEN_gte: String
-  "All values that are contained in given list."
-  labelEN_in: [String!]
-  "All values less than the given value."
-  labelEN_lt: String
-  "All values less than or equal the given value."
-  labelEN_lte: String
-  "All values that are not equal to given value."
-  labelEN_not: String
-  "All values not containing the given string."
-  labelEN_not_contains: String
-  "All values not ending with the given string."
-  labelEN_not_ends_with: String
-  "All values that are not contained in given list."
-  labelEN_not_in: [String!]
-  "All values not starting with the given string."
-  labelEN_not_starts_with: String
-  "All values starting with the given string."
-  labelEN_starts_with: String
-  labelFR: String
-  "All values containing the given string."
-  labelFR_contains: String
-  "All values ending with the given string."
-  labelFR_ends_with: String
-  "All values greater than the given value."
-  labelFR_gt: String
-  "All values greater than or equal the given value."
-  labelFR_gte: String
-  "All values that are contained in given list."
-  labelFR_in: [String!]
-  "All values less than the given value."
-  labelFR_lt: String
-  "All values less than or equal the given value."
-  labelFR_lte: String
-  "All values that are not equal to given value."
-  labelFR_not: String
-  "All values not containing the given string."
-  labelFR_not_contains: String
-  "All values not ending with the given string."
-  labelFR_not_ends_with: String
-  "All values that are not contained in given list."
-  labelFR_not_in: [String!]
-  "All values not starting with the given string."
-  labelFR_not_starts_with: String
-  "All values starting with the given string."
-  labelFR_starts_with: String
   products_every: ProductWhereInput
   products_none: ProductWhereInput
   products_some: ProductWhereInput
+  publishedAt: DateTime
+  "All values greater than the given value."
+  publishedAt_gt: DateTime
+  "All values greater than or equal the given value."
+  publishedAt_gte: DateTime
+  "All values that are contained in given list."
+  publishedAt_in: [DateTime!]
+  "All values less than the given value."
+  publishedAt_lt: DateTime
+  "All values less than or equal the given value."
+  publishedAt_lte: DateTime
+  "All values that are not equal to given value."
+  publishedAt_not: DateTime
+  "All values that are not contained in given list."
+  publishedAt_not_in: [DateTime!]
   ref: String
   "All values containing the given string."
   ref_contains: String
   "All values ending with the given string."
   ref_ends_with: String
-  "All values greater than the given value."
-  ref_gt: String
-  "All values greater than or equal the given value."
-  ref_gte: String
   "All values that are contained in given list."
   ref_in: [String!]
-  "All values less than the given value."
-  ref_lt: String
-  "All values less than or equal the given value."
-  ref_lte: String
   "All values that are not equal to given value."
   ref_not: String
   "All values not containing the given string."
   ref_not_contains: String
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   ref_not_ends_with: String
   "All values that are not contained in given list."
   ref_not_in: [String!]
@@ -1276,13 +2088,6 @@ input CustomerWhereInput {
   ref_not_starts_with: String
   "All values starting with the given string."
   ref_starts_with: String
-  status: Status
-  "All values that are contained in given list."
-  status_in: [Status!]
-  "All values that are not equal to given value."
-  status_not: Status
-  "All values that are not contained in given list."
-  status_not_in: [Status!]
   theme: ThemeWhereInput
   updatedAt: DateTime
   "All values greater than the given value."
@@ -1301,6 +2106,247 @@ input CustomerWhereInput {
   updatedAt_not_in: [DateTime!]
 }
 
+input CustomerUpdateInput {
+  "label input for default locale (en)"
+  label: String
+  "Manage document localizations"
+  localizations: CustomerUpdateLocalizationsInput
+  products: ProductUpdateManyInlineInput
+  ref: String
+  "terms input for default locale (en)"
+  terms: RichTextAST
+  theme: ThemeUpdateOneInlineInput
+}
+
+input CustomerUpdateLocalizationDataInput {
+  label: String
+  terms: RichTextAST
+}
+
+input CustomerUpdateLocalizationInput {
+  data: CustomerUpdateLocalizationDataInput!
+  locale: Locale!
+}
+
+input CustomerUpdateLocalizationsInput {
+  "Localizations to create"
+  create: [CustomerCreateLocalizationInput!]
+  "Localizations to delete"
+  delete: [Locale!]
+  "Localizations to update"
+  update: [CustomerUpdateLocalizationInput!]
+  upsert: [CustomerUpsertLocalizationInput!]
+}
+
+input CustomerUpdateManyInlineInput {
+  "Connect multiple existing Customer documents"
+  connect: [CustomerConnectInput!]
+  "Create and connect multiple Customer documents"
+  create: [CustomerCreateInput!]
+  "Delete multiple Customer documents"
+  delete: [CustomerWhereUniqueInput!]
+  "Disconnect multiple Customer documents"
+  disconnect: [CustomerWhereUniqueInput!]
+  "Override currently-connected documents with multiple existing Customer documents"
+  set: [CustomerWhereUniqueInput!]
+  "Update multiple Customer documents"
+  update: [CustomerUpdateWithNestedWhereUniqueInput!]
+  "Upsert multiple Customer documents"
+  upsert: [CustomerUpsertWithNestedWhereUniqueInput!]
+}
+
+input CustomerUpdateManyInput {
+  "label input for default locale (en)"
+  label: String
+  "Optional updates to localizations"
+  localizations: CustomerUpdateManyLocalizationsInput
+  "terms input for default locale (en)"
+  terms: RichTextAST
+}
+
+input CustomerUpdateManyLocalizationDataInput {
+  label: String
+  terms: RichTextAST
+}
+
+input CustomerUpdateManyLocalizationInput {
+  data: CustomerUpdateManyLocalizationDataInput!
+  locale: Locale!
+}
+
+input CustomerUpdateManyLocalizationsInput {
+  "Localizations to update"
+  update: [CustomerUpdateManyLocalizationInput!]
+}
+
+input CustomerUpdateManyWithNestedWhereInput {
+  "Update many input"
+  data: CustomerUpdateManyInput!
+  "Document search"
+  where: CustomerWhereInput!
+}
+
+input CustomerUpdateOneInlineInput {
+  "Connect existing Customer document"
+  connect: CustomerWhereUniqueInput
+  "Create and connect one Customer document"
+  create: CustomerCreateInput
+  "Delete currently connected Customer document"
+  delete: Boolean
+  "Disconnect currently connected Customer document"
+  disconnect: Boolean
+  "Update single Customer document"
+  update: CustomerUpdateWithNestedWhereUniqueInput
+  "Upsert single Customer document"
+  upsert: CustomerUpsertWithNestedWhereUniqueInput
+}
+
+input CustomerUpdateWithNestedWhereUniqueInput {
+  "Document to update"
+  data: CustomerUpdateInput!
+  "Unique document search"
+  where: CustomerWhereUniqueInput!
+}
+
+input CustomerUpsertInput {
+  "Create document if it didn't exist"
+  create: CustomerCreateInput!
+  "Update document if it exists"
+  update: CustomerUpdateInput!
+}
+
+input CustomerUpsertLocalizationInput {
+  create: CustomerCreateLocalizationDataInput!
+  locale: Locale!
+  update: CustomerUpdateLocalizationDataInput!
+}
+
+input CustomerUpsertWithNestedWhereUniqueInput {
+  "Upsert data"
+  data: CustomerUpsertInput!
+  "Unique document search"
+  where: CustomerWhereUniqueInput!
+}
+
+"Identifies documents"
+input CustomerWhereInput {
+  "Logical AND on all given filters."
+  AND: [CustomerWhereInput!]
+  "Logical NOT on all given filters combined by AND."
+  NOT: [CustomerWhereInput!]
+  "Logical OR on all given filters."
+  OR: [CustomerWhereInput!]
+  "Contains search across all appropriate fields."
+  _search: String
+  createdAt: DateTime
+  "All values greater than the given value."
+  createdAt_gt: DateTime
+  "All values greater than or equal the given value."
+  createdAt_gte: DateTime
+  "All values that are contained in given list."
+  createdAt_in: [DateTime!]
+  "All values less than the given value."
+  createdAt_lt: DateTime
+  "All values less than or equal the given value."
+  createdAt_lte: DateTime
+  "All values that are not equal to given value."
+  createdAt_not: DateTime
+  "All values that are not contained in given list."
+  createdAt_not_in: [DateTime!]
+  id: ID
+  "All values containing the given string."
+  id_contains: ID
+  "All values ending with the given string."
+  id_ends_with: ID
+  "All values that are contained in given list."
+  id_in: [ID!]
+  "All values that are not equal to given value."
+  id_not: ID
+  "All values not containing the given string."
+  id_not_contains: ID
+  "All values not ending with the given string"
+  id_not_ends_with: ID
+  "All values that are not contained in given list."
+  id_not_in: [ID!]
+  "All values not starting with the given string."
+  id_not_starts_with: ID
+  "All values starting with the given string."
+  id_starts_with: ID
+  label: String
+  "All values containing the given string."
+  label_contains: String
+  "All values ending with the given string."
+  label_ends_with: String
+  "All values that are contained in given list."
+  label_in: [String!]
+  "All values that are not equal to given value."
+  label_not: String
+  "All values not containing the given string."
+  label_not_contains: String
+  "All values not ending with the given string"
+  label_not_ends_with: String
+  "All values that are not contained in given list."
+  label_not_in: [String!]
+  "All values not starting with the given string."
+  label_not_starts_with: String
+  "All values starting with the given string."
+  label_starts_with: String
+  products_every: ProductWhereInput
+  products_none: ProductWhereInput
+  products_some: ProductWhereInput
+  publishedAt: DateTime
+  "All values greater than the given value."
+  publishedAt_gt: DateTime
+  "All values greater than or equal the given value."
+  publishedAt_gte: DateTime
+  "All values that are contained in given list."
+  publishedAt_in: [DateTime!]
+  "All values less than the given value."
+  publishedAt_lt: DateTime
+  "All values less than or equal the given value."
+  publishedAt_lte: DateTime
+  "All values that are not equal to given value."
+  publishedAt_not: DateTime
+  "All values that are not contained in given list."
+  publishedAt_not_in: [DateTime!]
+  ref: String
+  "All values containing the given string."
+  ref_contains: String
+  "All values ending with the given string."
+  ref_ends_with: String
+  "All values that are contained in given list."
+  ref_in: [String!]
+  "All values that are not equal to given value."
+  ref_not: String
+  "All values not containing the given string."
+  ref_not_contains: String
+  "All values not ending with the given string"
+  ref_not_ends_with: String
+  "All values that are not contained in given list."
+  ref_not_in: [String!]
+  "All values not starting with the given string."
+  ref_not_starts_with: String
+  "All values starting with the given string."
+  ref_starts_with: String
+  theme: ThemeWhereInput
+  updatedAt: DateTime
+  "All values greater than the given value."
+  updatedAt_gt: DateTime
+  "All values greater than or equal the given value."
+  updatedAt_gte: DateTime
+  "All values that are contained in given list."
+  updatedAt_in: [DateTime!]
+  "All values less than the given value."
+  updatedAt_lt: DateTime
+  "All values less than or equal the given value."
+  updatedAt_lte: DateTime
+  "All values that are not equal to given value."
+  updatedAt_not: DateTime
+  "All values that are not contained in given list."
+  updatedAt_not_in: [DateTime!]
+}
+
+"References Customer record uniquely"
 input CustomerWhereUniqueInput {
   id: ID
   ref: String
@@ -1308,30 +2354,31 @@ input CustomerWhereUniqueInput {
 
 input DocumentOutputInput {
   """
+
   Transforms a document into a desired file type.
   See this matrix for format support:
 
-  PDF:\tjpg, odp, ods, odt, png, svg, txt, and webp
-  DOC:\tdocx, html, jpg, odt, pdf, png, svg, txt, and webp
-  DOCX:\tdoc, html, jpg, odt, pdf, png, svg, txt, and webp
-  ODT:\tdoc, docx, html, jpg, pdf, png, svg, txt, and webp
-  XLS:\tjpg, pdf, ods, png, svg, xlsx, and webp
-  XLSX:\tjpg, pdf, ods, png, svg, xls, and webp
-  ODS:\tjpg, pdf, png, xls, svg, xlsx, and webp
-  PPT:\tjpg, odp, pdf, png, svg, pptx, and webp
-  PPTX:\tjpg, odp, pdf, png, svg, ppt, and webp
-  ODP:\tjpg, pdf, png, ppt, svg, pptx, and webp
-  BMP:\tjpg, odp, ods, odt, pdf, png, svg, and webp
-  GIF:\tjpg, odp, ods, odt, pdf, png, svg, and webp
-  JPG:\tjpg, odp, ods, odt, pdf, png, svg, and webp
-  PNG:\tjpg, odp, ods, odt, pdf, png, svg, and webp
-  WEBP:\tjpg, odp, ods, odt, pdf, png, svg, and webp
-  TIFF:\tjpg, odp, ods, odt, pdf, png, svg, and webp
-  AI:\t    jpg, odp, ods, odt, pdf, png, svg, and webp
-  PSD:\tjpg, odp, ods, odt, pdf, png, svg, and webp
-  SVG:\tjpg, odp, ods, odt, pdf, png, and webp
-  HTML:\tjpg, odt, pdf, svg, txt, and webp
-  TXT:\tjpg, html, odt, pdf, svg, and webp
+  PDF:  jpg, odp, ods, odt, png, svg, txt, and webp
+  DOC:  docx, html, jpg, odt, pdf, png, svg, txt, and webp
+  DOCX:  doc, html, jpg, odt, pdf, png, svg, txt, and webp
+  ODT:  doc, docx, html, jpg, pdf, png, svg, txt, and webp
+  XLS:  jpg, pdf, ods, png, svg, xlsx, and webp
+  XLSX:  jpg, pdf, ods, png, svg, xls, and webp
+  ODS:  jpg, pdf, png, xls, svg, xlsx, and webp
+  PPT:  jpg, odp, pdf, png, svg, pptx, and webp
+  PPTX:  jpg, odp, pdf, png, svg, ppt, and webp
+  ODP:  jpg, pdf, png, ppt, svg, pptx, and webp
+  BMP:  jpg, odp, ods, odt, pdf, png, svg, and webp
+  GIF:  jpg, odp, ods, odt, pdf, png, svg, and webp
+  JPG:  jpg, odp, ods, odt, pdf, png, svg, and webp
+  PNG:  jpg, odp, ods, odt, pdf, png, svg, and webp
+  WEBP:  jpg, odp, ods, odt, pdf, png, svg, and webp
+  TIFF:  jpg, odp, ods, odt, pdf, png, svg, and webp
+  AI:      jpg, odp, ods, odt, pdf, png, svg, and webp
+  PSD:  jpg, odp, ods, odt, pdf, png, svg, and webp
+  SVG:  jpg, odp, ods, odt, pdf, png, and webp
+  HTML:  jpg, odt, pdf, svg, txt, and webp
+  TXT:  jpg, html, odt, pdf, svg, and webp
   """
   format: DocumentFileTypes
 }
@@ -1357,369 +2404,74 @@ input ImageTransformationInput {
   resize: ImageResizeInput
 }
 
+"Input for a geolocation point with latitude and longitude"
+input LocationInput {
+  latitude: Float!
+  longitude: Float!
+}
+
+input ProductConnectInput {
+  "Allow to specify document position in list of connected documents, will default to appending at end of list"
+  position: ConnectPositionInput
+  "Document to connect"
+  where: ProductWhereUniqueInput!
+}
+
 input ProductCreateInput {
-  customer: CustomerCreateOneWithoutProductsInput
-  descriptionEN: String
-  descriptionFR: String
-  images: AssetCreateManyWithoutImagesProductInput
-  price: Float
-  status: Status
-  titleEN: String
-  titleFR: String
-}
-
-input ProductCreateManyWithoutCustomerInput {
-  connect: [ProductWhereUniqueInput!]
-  create: [ProductCreateWithoutCustomerInput!]
-}
-
-input ProductCreateManyWithoutImagesInput {
-  connect: [ProductWhereUniqueInput!]
-  create: [ProductCreateWithoutImagesInput!]
-}
-
-input ProductCreateWithoutCustomerInput {
-  descriptionEN: String
-  descriptionFR: String
-  images: AssetCreateManyWithoutImagesProductInput
-  price: Float
-  status: Status
-  titleEN: String
-  titleFR: String
-}
-
-input ProductCreateWithoutImagesInput {
-  customer: CustomerCreateOneWithoutProductsInput
-  descriptionEN: String
-  descriptionFR: String
-  price: Float
-  status: Status
-  titleEN: String
-  titleFR: String
-}
-
-input ProductScalarWhereInput {
-  "Logical AND on all given filters."
-  AND: [ProductScalarWhereInput!]
-  "Logical NOT on all given filters combined by AND."
-  NOT: [ProductScalarWhereInput!]
-  "Logical OR on all given filters."
-  OR: [ProductScalarWhereInput!]
-  _search: String
   createdAt: DateTime
-  "All values greater than the given value."
-  createdAt_gt: DateTime
-  "All values greater than or equal the given value."
-  createdAt_gte: DateTime
-  "All values that are contained in given list."
-  createdAt_in: [DateTime!]
-  "All values less than the given value."
-  createdAt_lt: DateTime
-  "All values less than or equal the given value."
-  createdAt_lte: DateTime
-  "All values that are not equal to given value."
-  createdAt_not: DateTime
-  "All values that are not contained in given list."
-  createdAt_not_in: [DateTime!]
-  descriptionEN: String
-  "All values containing the given string."
-  descriptionEN_contains: String
-  "All values ending with the given string."
-  descriptionEN_ends_with: String
-  "All values greater than the given value."
-  descriptionEN_gt: String
-  "All values greater than or equal the given value."
-  descriptionEN_gte: String
-  "All values that are contained in given list."
-  descriptionEN_in: [String!]
-  "All values less than the given value."
-  descriptionEN_lt: String
-  "All values less than or equal the given value."
-  descriptionEN_lte: String
-  "All values that are not equal to given value."
-  descriptionEN_not: String
-  "All values not containing the given string."
-  descriptionEN_not_contains: String
-  "All values not ending with the given string."
-  descriptionEN_not_ends_with: String
-  "All values that are not contained in given list."
-  descriptionEN_not_in: [String!]
-  "All values not starting with the given string."
-  descriptionEN_not_starts_with: String
-  "All values starting with the given string."
-  descriptionEN_starts_with: String
-  descriptionFR: String
-  "All values containing the given string."
-  descriptionFR_contains: String
-  "All values ending with the given string."
-  descriptionFR_ends_with: String
-  "All values greater than the given value."
-  descriptionFR_gt: String
-  "All values greater than or equal the given value."
-  descriptionFR_gte: String
-  "All values that are contained in given list."
-  descriptionFR_in: [String!]
-  "All values less than the given value."
-  descriptionFR_lt: String
-  "All values less than or equal the given value."
-  descriptionFR_lte: String
-  "All values that are not equal to given value."
-  descriptionFR_not: String
-  "All values not containing the given string."
-  descriptionFR_not_contains: String
-  "All values not ending with the given string."
-  descriptionFR_not_ends_with: String
-  "All values that are not contained in given list."
-  descriptionFR_not_in: [String!]
-  "All values not starting with the given string."
-  descriptionFR_not_starts_with: String
-  "All values starting with the given string."
-  descriptionFR_starts_with: String
-  id: ID
-  "All values containing the given string."
-  id_contains: ID
-  "All values ending with the given string."
-  id_ends_with: ID
-  "All values greater than the given value."
-  id_gt: ID
-  "All values greater than or equal the given value."
-  id_gte: ID
-  "All values that are contained in given list."
-  id_in: [ID!]
-  "All values less than the given value."
-  id_lt: ID
-  "All values less than or equal the given value."
-  id_lte: ID
-  "All values that are not equal to given value."
-  id_not: ID
-  "All values not containing the given string."
-  id_not_contains: ID
-  "All values not ending with the given string."
-  id_not_ends_with: ID
-  "All values that are not contained in given list."
-  id_not_in: [ID!]
-  "All values not starting with the given string."
-  id_not_starts_with: ID
-  "All values starting with the given string."
-  id_starts_with: ID
+  customer: CustomerCreateOneInlineInput
+  "description input for default locale (en)"
+  description: String
+  images: AssetCreateManyInlineInput
+  "Inline mutations for managing document localizations excluding the default locale"
+  localizations: ProductCreateLocalizationsInput
   price: Float
-  "All values greater than the given value."
-  price_gt: Float
-  "All values greater than or equal the given value."
-  price_gte: Float
-  "All values that are contained in given list."
-  price_in: [Float!]
-  "All values less than the given value."
-  price_lt: Float
-  "All values less than or equal the given value."
-  price_lte: Float
-  "All values that are not equal to given value."
-  price_not: Float
-  "All values that are not contained in given list."
-  price_not_in: [Float!]
-  status: Status
-  "All values that are contained in given list."
-  status_in: [Status!]
-  "All values that are not equal to given value."
-  status_not: Status
-  "All values that are not contained in given list."
-  status_not_in: [Status!]
-  titleEN: String
-  "All values containing the given string."
-  titleEN_contains: String
-  "All values ending with the given string."
-  titleEN_ends_with: String
-  "All values greater than the given value."
-  titleEN_gt: String
-  "All values greater than or equal the given value."
-  titleEN_gte: String
-  "All values that are contained in given list."
-  titleEN_in: [String!]
-  "All values less than the given value."
-  titleEN_lt: String
-  "All values less than or equal the given value."
-  titleEN_lte: String
-  "All values that are not equal to given value."
-  titleEN_not: String
-  "All values not containing the given string."
-  titleEN_not_contains: String
-  "All values not ending with the given string."
-  titleEN_not_ends_with: String
-  "All values that are not contained in given list."
-  titleEN_not_in: [String!]
-  "All values not starting with the given string."
-  titleEN_not_starts_with: String
-  "All values starting with the given string."
-  titleEN_starts_with: String
-  titleFR: String
-  "All values containing the given string."
-  titleFR_contains: String
-  "All values ending with the given string."
-  titleFR_ends_with: String
-  "All values greater than the given value."
-  titleFR_gt: String
-  "All values greater than or equal the given value."
-  titleFR_gte: String
-  "All values that are contained in given list."
-  titleFR_in: [String!]
-  "All values less than the given value."
-  titleFR_lt: String
-  "All values less than or equal the given value."
-  titleFR_lte: String
-  "All values that are not equal to given value."
-  titleFR_not: String
-  "All values not containing the given string."
-  titleFR_not_contains: String
-  "All values not ending with the given string."
-  titleFR_not_ends_with: String
-  "All values that are not contained in given list."
-  titleFR_not_in: [String!]
-  "All values not starting with the given string."
-  titleFR_not_starts_with: String
-  "All values starting with the given string."
-  titleFR_starts_with: String
+  "title input for default locale (en)"
+  title: String
   updatedAt: DateTime
-  "All values greater than the given value."
-  updatedAt_gt: DateTime
-  "All values greater than or equal the given value."
-  updatedAt_gte: DateTime
-  "All values that are contained in given list."
-  updatedAt_in: [DateTime!]
-  "All values less than the given value."
-  updatedAt_lt: DateTime
-  "All values less than or equal the given value."
-  updatedAt_lte: DateTime
-  "All values that are not equal to given value."
-  updatedAt_not: DateTime
-  "All values that are not contained in given list."
-  updatedAt_not_in: [DateTime!]
 }
 
-input ProductSubscriptionWhereInput {
-  "Logical AND on all given filters."
-  AND: [ProductSubscriptionWhereInput!]
-  "Logical NOT on all given filters combined by AND."
-  NOT: [ProductSubscriptionWhereInput!]
-  "Logical OR on all given filters."
-  OR: [ProductSubscriptionWhereInput!]
-  "The subscription event gets dispatched when it's listed in mutation_in"
-  mutation_in: [MutationType!]
-  node: ProductWhereInput
-  "The subscription event gets only dispatched when one of the updated fields names is included in this list"
-  updatedFields_contains: String
-  "The subscription event gets only dispatched when all of the field names included in this list have been updated"
-  updatedFields_contains_every: [String!]
-  "The subscription event gets only dispatched when some of the field names included in this list have been updated"
-  updatedFields_contains_some: [String!]
+input ProductCreateLocalizationDataInput {
+  createdAt: DateTime
+  description: String
+  title: String
+  updatedAt: DateTime
 }
 
-input ProductUpdateInput {
-  customer: CustomerUpdateOneWithoutProductsInput
-  descriptionEN: String
-  descriptionFR: String
-  images: AssetUpdateManyWithoutImagesProductInput
-  price: Float
-  status: Status
-  titleEN: String
-  titleFR: String
+input ProductCreateLocalizationInput {
+  "Localization input"
+  data: ProductCreateLocalizationDataInput!
+  locale: Locale!
 }
 
-input ProductUpdateManyDataInput {
-  descriptionEN: String
-  descriptionFR: String
-  price: Float
-  status: Status
-  titleEN: String
-  titleFR: String
+input ProductCreateLocalizationsInput {
+  "Create localizations for the newly-created document"
+  create: [ProductCreateLocalizationInput!]
 }
 
-input ProductUpdateManyMutationInput {
-  descriptionEN: String
-  descriptionFR: String
-  price: Float
-  status: Status
-  titleEN: String
-  titleFR: String
-}
-
-input ProductUpdateManyWithWhereNestedInput {
-  data: ProductUpdateManyDataInput!
-  where: ProductScalarWhereInput!
-}
-
-input ProductUpdateManyWithoutCustomerInput {
+input ProductCreateManyInlineInput {
+  "Connect multiple existing Product documents"
   connect: [ProductWhereUniqueInput!]
-  create: [ProductCreateWithoutCustomerInput!]
-  delete: [ProductWhereUniqueInput!]
-  deleteMany: [ProductScalarWhereInput!]
-  disconnect: [ProductWhereUniqueInput!]
-  set: [ProductWhereUniqueInput!]
-  update: [ProductUpdateWithWhereUniqueWithoutCustomerInput!]
-  updateMany: [ProductUpdateManyWithWhereNestedInput!]
-  upsert: [ProductUpsertWithWhereUniqueWithoutCustomerInput!]
+  "Create and connect multiple existing Product documents"
+  create: [ProductCreateInput!]
 }
 
-input ProductUpdateManyWithoutImagesInput {
-  connect: [ProductWhereUniqueInput!]
-  create: [ProductCreateWithoutImagesInput!]
-  delete: [ProductWhereUniqueInput!]
-  deleteMany: [ProductScalarWhereInput!]
-  disconnect: [ProductWhereUniqueInput!]
-  set: [ProductWhereUniqueInput!]
-  update: [ProductUpdateWithWhereUniqueWithoutImagesInput!]
-  updateMany: [ProductUpdateManyWithWhereNestedInput!]
-  upsert: [ProductUpsertWithWhereUniqueWithoutImagesInput!]
+input ProductCreateOneInlineInput {
+  "Connect one existing Product document"
+  connect: ProductWhereUniqueInput
+  "Create and connect one Product document"
+  create: ProductCreateInput
 }
 
-input ProductUpdateWithWhereUniqueWithoutCustomerInput {
-  data: ProductUpdateWithoutCustomerDataInput!
-  where: ProductWhereUniqueInput!
-}
-
-input ProductUpdateWithWhereUniqueWithoutImagesInput {
-  data: ProductUpdateWithoutImagesDataInput!
-  where: ProductWhereUniqueInput!
-}
-
-input ProductUpdateWithoutCustomerDataInput {
-  descriptionEN: String
-  descriptionFR: String
-  images: AssetUpdateManyWithoutImagesProductInput
-  price: Float
-  status: Status
-  titleEN: String
-  titleFR: String
-}
-
-input ProductUpdateWithoutImagesDataInput {
-  customer: CustomerUpdateOneWithoutProductsInput
-  descriptionEN: String
-  descriptionFR: String
-  price: Float
-  status: Status
-  titleEN: String
-  titleFR: String
-}
-
-input ProductUpsertWithWhereUniqueWithoutCustomerInput {
-  create: ProductCreateWithoutCustomerInput!
-  update: ProductUpdateWithoutCustomerDataInput!
-  where: ProductWhereUniqueInput!
-}
-
-input ProductUpsertWithWhereUniqueWithoutImagesInput {
-  create: ProductCreateWithoutImagesInput!
-  update: ProductUpdateWithoutImagesDataInput!
-  where: ProductWhereUniqueInput!
-}
-
-input ProductWhereInput {
+"Identifies documents"
+input ProductManyWhereInput {
   "Logical AND on all given filters."
   AND: [ProductWhereInput!]
   "Logical NOT on all given filters combined by AND."
   NOT: [ProductWhereInput!]
   "Logical OR on all given filters."
   OR: [ProductWhereInput!]
+  "Contains search across all appropriate fields."
   _search: String
   createdAt: DateTime
   "All values greater than the given value."
@@ -1737,80 +2489,18 @@ input ProductWhereInput {
   "All values that are not contained in given list."
   createdAt_not_in: [DateTime!]
   customer: CustomerWhereInput
-  descriptionEN: String
-  "All values containing the given string."
-  descriptionEN_contains: String
-  "All values ending with the given string."
-  descriptionEN_ends_with: String
-  "All values greater than the given value."
-  descriptionEN_gt: String
-  "All values greater than or equal the given value."
-  descriptionEN_gte: String
-  "All values that are contained in given list."
-  descriptionEN_in: [String!]
-  "All values less than the given value."
-  descriptionEN_lt: String
-  "All values less than or equal the given value."
-  descriptionEN_lte: String
-  "All values that are not equal to given value."
-  descriptionEN_not: String
-  "All values not containing the given string."
-  descriptionEN_not_contains: String
-  "All values not ending with the given string."
-  descriptionEN_not_ends_with: String
-  "All values that are not contained in given list."
-  descriptionEN_not_in: [String!]
-  "All values not starting with the given string."
-  descriptionEN_not_starts_with: String
-  "All values starting with the given string."
-  descriptionEN_starts_with: String
-  descriptionFR: String
-  "All values containing the given string."
-  descriptionFR_contains: String
-  "All values ending with the given string."
-  descriptionFR_ends_with: String
-  "All values greater than the given value."
-  descriptionFR_gt: String
-  "All values greater than or equal the given value."
-  descriptionFR_gte: String
-  "All values that are contained in given list."
-  descriptionFR_in: [String!]
-  "All values less than the given value."
-  descriptionFR_lt: String
-  "All values less than or equal the given value."
-  descriptionFR_lte: String
-  "All values that are not equal to given value."
-  descriptionFR_not: String
-  "All values not containing the given string."
-  descriptionFR_not_contains: String
-  "All values not ending with the given string."
-  descriptionFR_not_ends_with: String
-  "All values that are not contained in given list."
-  descriptionFR_not_in: [String!]
-  "All values not starting with the given string."
-  descriptionFR_not_starts_with: String
-  "All values starting with the given string."
-  descriptionFR_starts_with: String
   id: ID
   "All values containing the given string."
   id_contains: ID
   "All values ending with the given string."
   id_ends_with: ID
-  "All values greater than the given value."
-  id_gt: ID
-  "All values greater than or equal the given value."
-  id_gte: ID
   "All values that are contained in given list."
   id_in: [ID!]
-  "All values less than the given value."
-  id_lt: ID
-  "All values less than or equal the given value."
-  id_lte: ID
   "All values that are not equal to given value."
   id_not: ID
   "All values not containing the given string."
   id_not_contains: ID
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   id_not_ends_with: ID
   "All values that are not contained in given list."
   id_not_in: [ID!]
@@ -1836,67 +2526,21 @@ input ProductWhereInput {
   price_not: Float
   "All values that are not contained in given list."
   price_not_in: [Float!]
-  status: Status
-  "All values that are contained in given list."
-  status_in: [Status!]
-  "All values that are not equal to given value."
-  status_not: Status
-  "All values that are not contained in given list."
-  status_not_in: [Status!]
-  titleEN: String
-  "All values containing the given string."
-  titleEN_contains: String
-  "All values ending with the given string."
-  titleEN_ends_with: String
+  publishedAt: DateTime
   "All values greater than the given value."
-  titleEN_gt: String
+  publishedAt_gt: DateTime
   "All values greater than or equal the given value."
-  titleEN_gte: String
+  publishedAt_gte: DateTime
   "All values that are contained in given list."
-  titleEN_in: [String!]
+  publishedAt_in: [DateTime!]
   "All values less than the given value."
-  titleEN_lt: String
+  publishedAt_lt: DateTime
   "All values less than or equal the given value."
-  titleEN_lte: String
+  publishedAt_lte: DateTime
   "All values that are not equal to given value."
-  titleEN_not: String
-  "All values not containing the given string."
-  titleEN_not_contains: String
-  "All values not ending with the given string."
-  titleEN_not_ends_with: String
+  publishedAt_not: DateTime
   "All values that are not contained in given list."
-  titleEN_not_in: [String!]
-  "All values not starting with the given string."
-  titleEN_not_starts_with: String
-  "All values starting with the given string."
-  titleEN_starts_with: String
-  titleFR: String
-  "All values containing the given string."
-  titleFR_contains: String
-  "All values ending with the given string."
-  titleFR_ends_with: String
-  "All values greater than the given value."
-  titleFR_gt: String
-  "All values greater than or equal the given value."
-  titleFR_gte: String
-  "All values that are contained in given list."
-  titleFR_in: [String!]
-  "All values less than the given value."
-  titleFR_lt: String
-  "All values less than or equal the given value."
-  titleFR_lte: String
-  "All values that are not equal to given value."
-  titleFR_not: String
-  "All values not containing the given string."
-  titleFR_not_contains: String
-  "All values not ending with the given string."
-  titleFR_not_ends_with: String
-  "All values that are not contained in given list."
-  titleFR_not_in: [String!]
-  "All values not starting with the given string."
-  titleFR_not_starts_with: String
-  "All values starting with the given string."
-  titleFR_starts_with: String
+  publishedAt_not_in: [DateTime!]
   updatedAt: DateTime
   "All values greater than the given value."
   updatedAt_gt: DateTime
@@ -1914,48 +2558,138 @@ input ProductWhereInput {
   updatedAt_not_in: [DateTime!]
 }
 
-input ProductWhereUniqueInput {
-  id: ID
-  titleEN: String
-  titleFR: String
+input ProductUpdateInput {
+  customer: CustomerUpdateOneInlineInput
+  "description input for default locale (en)"
+  description: String
+  images: AssetUpdateManyInlineInput
+  "Manage document localizations"
+  localizations: ProductUpdateLocalizationsInput
+  price: Float
+  "title input for default locale (en)"
+  title: String
 }
 
-input ThemeCreateInput {
-  customer: CustomerCreateOneWithoutThemeInput
-  logo: AssetCreateOneWithoutLogoThemeInput
-  primaryColor: String!
-  status: Status
+input ProductUpdateLocalizationDataInput {
+  description: String
+  title: String
 }
 
-input ThemeCreateManyWithoutLogoInput {
-  connect: [ThemeWhereUniqueInput!]
-  create: [ThemeCreateWithoutLogoInput!]
+input ProductUpdateLocalizationInput {
+  data: ProductUpdateLocalizationDataInput!
+  locale: Locale!
 }
 
-input ThemeCreateOneWithoutCustomerInput {
-  connect: ThemeWhereUniqueInput
-  create: ThemeCreateWithoutCustomerInput
+input ProductUpdateLocalizationsInput {
+  "Localizations to create"
+  create: [ProductCreateLocalizationInput!]
+  "Localizations to delete"
+  delete: [Locale!]
+  "Localizations to update"
+  update: [ProductUpdateLocalizationInput!]
+  upsert: [ProductUpsertLocalizationInput!]
 }
 
-input ThemeCreateWithoutCustomerInput {
-  logo: AssetCreateOneWithoutLogoThemeInput
-  primaryColor: String!
-  status: Status
+input ProductUpdateManyInlineInput {
+  "Connect multiple existing Product documents"
+  connect: [ProductConnectInput!]
+  "Create and connect multiple Product documents"
+  create: [ProductCreateInput!]
+  "Delete multiple Product documents"
+  delete: [ProductWhereUniqueInput!]
+  "Disconnect multiple Product documents"
+  disconnect: [ProductWhereUniqueInput!]
+  "Override currently-connected documents with multiple existing Product documents"
+  set: [ProductWhereUniqueInput!]
+  "Update multiple Product documents"
+  update: [ProductUpdateWithNestedWhereUniqueInput!]
+  "Upsert multiple Product documents"
+  upsert: [ProductUpsertWithNestedWhereUniqueInput!]
 }
 
-input ThemeCreateWithoutLogoInput {
-  customer: CustomerCreateOneWithoutThemeInput
-  primaryColor: String!
-  status: Status
+input ProductUpdateManyInput {
+  "description input for default locale (en)"
+  description: String
+  "Optional updates to localizations"
+  localizations: ProductUpdateManyLocalizationsInput
+  price: Float
+  "title input for default locale (en)"
+  title: String
 }
 
-input ThemeScalarWhereInput {
+input ProductUpdateManyLocalizationDataInput {
+  description: String
+  title: String
+}
+
+input ProductUpdateManyLocalizationInput {
+  data: ProductUpdateManyLocalizationDataInput!
+  locale: Locale!
+}
+
+input ProductUpdateManyLocalizationsInput {
+  "Localizations to update"
+  update: [ProductUpdateManyLocalizationInput!]
+}
+
+input ProductUpdateManyWithNestedWhereInput {
+  "Update many input"
+  data: ProductUpdateManyInput!
+  "Document search"
+  where: ProductWhereInput!
+}
+
+input ProductUpdateOneInlineInput {
+  "Connect existing Product document"
+  connect: ProductWhereUniqueInput
+  "Create and connect one Product document"
+  create: ProductCreateInput
+  "Delete currently connected Product document"
+  delete: Boolean
+  "Disconnect currently connected Product document"
+  disconnect: Boolean
+  "Update single Product document"
+  update: ProductUpdateWithNestedWhereUniqueInput
+  "Upsert single Product document"
+  upsert: ProductUpsertWithNestedWhereUniqueInput
+}
+
+input ProductUpdateWithNestedWhereUniqueInput {
+  "Document to update"
+  data: ProductUpdateInput!
+  "Unique document search"
+  where: ProductWhereUniqueInput!
+}
+
+input ProductUpsertInput {
+  "Create document if it didn't exist"
+  create: ProductCreateInput!
+  "Update document if it exists"
+  update: ProductUpdateInput!
+}
+
+input ProductUpsertLocalizationInput {
+  create: ProductCreateLocalizationDataInput!
+  locale: Locale!
+  update: ProductUpdateLocalizationDataInput!
+}
+
+input ProductUpsertWithNestedWhereUniqueInput {
+  "Upsert data"
+  data: ProductUpsertInput!
+  "Unique document search"
+  where: ProductWhereUniqueInput!
+}
+
+"Identifies documents"
+input ProductWhereInput {
   "Logical AND on all given filters."
-  AND: [ThemeScalarWhereInput!]
+  AND: [ProductWhereInput!]
   "Logical NOT on all given filters combined by AND."
-  NOT: [ThemeScalarWhereInput!]
+  NOT: [ProductWhereInput!]
   "Logical OR on all given filters."
-  OR: [ThemeScalarWhereInput!]
+  OR: [ProductWhereInput!]
+  "Contains search across all appropriate fields."
   _search: String
   createdAt: DateTime
   "All values greater than the given value."
@@ -1972,26 +2706,38 @@ input ThemeScalarWhereInput {
   createdAt_not: DateTime
   "All values that are not contained in given list."
   createdAt_not_in: [DateTime!]
+  customer: CustomerWhereInput
+  description: String
+  "All values containing the given string."
+  description_contains: String
+  "All values ending with the given string."
+  description_ends_with: String
+  "All values that are contained in given list."
+  description_in: [String!]
+  "All values that are not equal to given value."
+  description_not: String
+  "All values not containing the given string."
+  description_not_contains: String
+  "All values not ending with the given string"
+  description_not_ends_with: String
+  "All values that are not contained in given list."
+  description_not_in: [String!]
+  "All values not starting with the given string."
+  description_not_starts_with: String
+  "All values starting with the given string."
+  description_starts_with: String
   id: ID
   "All values containing the given string."
   id_contains: ID
   "All values ending with the given string."
   id_ends_with: ID
-  "All values greater than the given value."
-  id_gt: ID
-  "All values greater than or equal the given value."
-  id_gte: ID
   "All values that are contained in given list."
   id_in: [ID!]
-  "All values less than the given value."
-  id_lt: ID
-  "All values less than or equal the given value."
-  id_lte: ID
   "All values that are not equal to given value."
   id_not: ID
   "All values not containing the given string."
   id_not_contains: ID
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   id_not_ends_with: ID
   "All values that are not contained in given list."
   id_not_in: [ID!]
@@ -1999,40 +2745,58 @@ input ThemeScalarWhereInput {
   id_not_starts_with: ID
   "All values starting with the given string."
   id_starts_with: ID
-  primaryColor: String
-  "All values containing the given string."
-  primaryColor_contains: String
-  "All values ending with the given string."
-  primaryColor_ends_with: String
+  images_every: AssetWhereInput
+  images_none: AssetWhereInput
+  images_some: AssetWhereInput
+  price: Float
   "All values greater than the given value."
-  primaryColor_gt: String
+  price_gt: Float
   "All values greater than or equal the given value."
-  primaryColor_gte: String
+  price_gte: Float
   "All values that are contained in given list."
-  primaryColor_in: [String!]
+  price_in: [Float!]
   "All values less than the given value."
-  primaryColor_lt: String
+  price_lt: Float
   "All values less than or equal the given value."
-  primaryColor_lte: String
+  price_lte: Float
   "All values that are not equal to given value."
-  primaryColor_not: String
-  "All values not containing the given string."
-  primaryColor_not_contains: String
-  "All values not ending with the given string."
-  primaryColor_not_ends_with: String
+  price_not: Float
   "All values that are not contained in given list."
-  primaryColor_not_in: [String!]
-  "All values not starting with the given string."
-  primaryColor_not_starts_with: String
-  "All values starting with the given string."
-  primaryColor_starts_with: String
-  status: Status
+  price_not_in: [Float!]
+  publishedAt: DateTime
+  "All values greater than the given value."
+  publishedAt_gt: DateTime
+  "All values greater than or equal the given value."
+  publishedAt_gte: DateTime
   "All values that are contained in given list."
-  status_in: [Status!]
+  publishedAt_in: [DateTime!]
+  "All values less than the given value."
+  publishedAt_lt: DateTime
+  "All values less than or equal the given value."
+  publishedAt_lte: DateTime
   "All values that are not equal to given value."
-  status_not: Status
+  publishedAt_not: DateTime
   "All values that are not contained in given list."
-  status_not_in: [Status!]
+  publishedAt_not_in: [DateTime!]
+  title: String
+  "All values containing the given string."
+  title_contains: String
+  "All values ending with the given string."
+  title_ends_with: String
+  "All values that are contained in given list."
+  title_in: [String!]
+  "All values that are not equal to given value."
+  title_not: String
+  "All values not containing the given string."
+  title_not_contains: String
+  "All values not ending with the given string"
+  title_not_ends_with: String
+  "All values that are not contained in given list."
+  title_not_in: [String!]
+  "All values not starting with the given string."
+  title_not_starts_with: String
+  "All values starting with the given string."
+  title_starts_with: String
   updatedAt: DateTime
   "All values greater than the given value."
   updatedAt_gt: DateTime
@@ -2050,102 +2814,64 @@ input ThemeScalarWhereInput {
   updatedAt_not_in: [DateTime!]
 }
 
-input ThemeSubscriptionWhereInput {
-  "Logical AND on all given filters."
-  AND: [ThemeSubscriptionWhereInput!]
-  "Logical NOT on all given filters combined by AND."
-  NOT: [ThemeSubscriptionWhereInput!]
-  "Logical OR on all given filters."
-  OR: [ThemeSubscriptionWhereInput!]
-  "The subscription event gets dispatched when it's listed in mutation_in"
-  mutation_in: [MutationType!]
-  node: ThemeWhereInput
-  "The subscription event gets only dispatched when one of the updated fields names is included in this list"
-  updatedFields_contains: String
-  "The subscription event gets only dispatched when all of the field names included in this list have been updated"
-  updatedFields_contains_every: [String!]
-  "The subscription event gets only dispatched when some of the field names included in this list have been updated"
-  updatedFields_contains_some: [String!]
+"References Product record uniquely"
+input ProductWhereUniqueInput {
+  id: ID
 }
 
-input ThemeUpdateInput {
-  customer: CustomerUpdateOneWithoutThemeInput
-  logo: AssetUpdateOneWithoutLogoThemeInput
-  primaryColor: String
-  status: Status
+input PublishLocaleInput {
+  "Locales to publish"
+  locale: Locale!
+  "Stages to publish selected locales to"
+  stages: [Stage!]!
 }
 
-input ThemeUpdateManyDataInput {
-  primaryColor: String
-  status: Status
+"Input type representing a RGBA color value: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb()_and_rgba()"
+input RGBAInput {
+  a: RGBATransparency!
+  b: RGBAHue!
+  g: RGBAHue!
+  r: RGBAHue!
 }
 
-input ThemeUpdateManyMutationInput {
-  primaryColor: String
-  status: Status
+input ThemeConnectInput {
+  "Allow to specify document position in list of connected documents, will default to appending at end of list"
+  position: ConnectPositionInput
+  "Document to connect"
+  where: ThemeWhereUniqueInput!
 }
 
-input ThemeUpdateManyWithWhereNestedInput {
-  data: ThemeUpdateManyDataInput!
-  where: ThemeScalarWhereInput!
+input ThemeCreateInput {
+  createdAt: DateTime
+  customer: CustomerCreateOneInlineInput
+  logo: AssetCreateOneInlineInput!
+  primaryColor: String!
+  updatedAt: DateTime
 }
 
-input ThemeUpdateManyWithoutLogoInput {
+input ThemeCreateManyInlineInput {
+  "Connect multiple existing Theme documents"
   connect: [ThemeWhereUniqueInput!]
-  create: [ThemeCreateWithoutLogoInput!]
-  delete: [ThemeWhereUniqueInput!]
-  deleteMany: [ThemeScalarWhereInput!]
-  disconnect: [ThemeWhereUniqueInput!]
-  set: [ThemeWhereUniqueInput!]
-  update: [ThemeUpdateWithWhereUniqueWithoutLogoInput!]
-  updateMany: [ThemeUpdateManyWithWhereNestedInput!]
-  upsert: [ThemeUpsertWithWhereUniqueWithoutLogoInput!]
+  "Create and connect multiple existing Theme documents"
+  create: [ThemeCreateInput!]
 }
 
-input ThemeUpdateOneWithoutCustomerInput {
+input ThemeCreateOneInlineInput {
+  "Connect one existing Theme document"
   connect: ThemeWhereUniqueInput
-  create: ThemeCreateWithoutCustomerInput
-  delete: Boolean
-  disconnect: Boolean
-  update: ThemeUpdateWithoutCustomerDataInput
-  upsert: ThemeUpsertWithoutCustomerInput
+  "Create and connect one Theme document"
+  create: ThemeCreateInput
 }
 
-input ThemeUpdateWithWhereUniqueWithoutLogoInput {
-  data: ThemeUpdateWithoutLogoDataInput!
-  where: ThemeWhereUniqueInput!
-}
-
-input ThemeUpdateWithoutCustomerDataInput {
-  logo: AssetUpdateOneWithoutLogoThemeInput
-  primaryColor: String
-  status: Status
-}
-
-input ThemeUpdateWithoutLogoDataInput {
-  customer: CustomerUpdateOneWithoutThemeInput
-  primaryColor: String
-  status: Status
-}
-
-input ThemeUpsertWithWhereUniqueWithoutLogoInput {
-  create: ThemeCreateWithoutLogoInput!
-  update: ThemeUpdateWithoutLogoDataInput!
-  where: ThemeWhereUniqueInput!
-}
-
-input ThemeUpsertWithoutCustomerInput {
-  create: ThemeCreateWithoutCustomerInput!
-  update: ThemeUpdateWithoutCustomerDataInput!
-}
-
-input ThemeWhereInput {
+"Identifies documents"
+input ThemeManyWhereInput {
   "Logical AND on all given filters."
   AND: [ThemeWhereInput!]
   "Logical NOT on all given filters combined by AND."
   NOT: [ThemeWhereInput!]
   "Logical OR on all given filters."
   OR: [ThemeWhereInput!]
+  "Contains search across all appropriate fields."
   _search: String
   createdAt: DateTime
   "All values greater than the given value."
@@ -2168,21 +2894,13 @@ input ThemeWhereInput {
   id_contains: ID
   "All values ending with the given string."
   id_ends_with: ID
-  "All values greater than the given value."
-  id_gt: ID
-  "All values greater than or equal the given value."
-  id_gte: ID
   "All values that are contained in given list."
   id_in: [ID!]
-  "All values less than the given value."
-  id_lt: ID
-  "All values less than or equal the given value."
-  id_lte: ID
   "All values that are not equal to given value."
   id_not: ID
   "All values not containing the given string."
   id_not_contains: ID
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   id_not_ends_with: ID
   "All values that are not contained in given list."
   id_not_in: [ID!]
@@ -2196,21 +2914,13 @@ input ThemeWhereInput {
   primaryColor_contains: String
   "All values ending with the given string."
   primaryColor_ends_with: String
-  "All values greater than the given value."
-  primaryColor_gt: String
-  "All values greater than or equal the given value."
-  primaryColor_gte: String
   "All values that are contained in given list."
   primaryColor_in: [String!]
-  "All values less than the given value."
-  primaryColor_lt: String
-  "All values less than or equal the given value."
-  primaryColor_lte: String
   "All values that are not equal to given value."
   primaryColor_not: String
   "All values not containing the given string."
   primaryColor_not_contains: String
-  "All values not ending with the given string."
+  "All values not ending with the given string"
   primaryColor_not_ends_with: String
   "All values that are not contained in given list."
   primaryColor_not_in: [String!]
@@ -2218,13 +2928,21 @@ input ThemeWhereInput {
   primaryColor_not_starts_with: String
   "All values starting with the given string."
   primaryColor_starts_with: String
-  status: Status
+  publishedAt: DateTime
+  "All values greater than the given value."
+  publishedAt_gt: DateTime
+  "All values greater than or equal the given value."
+  publishedAt_gte: DateTime
   "All values that are contained in given list."
-  status_in: [Status!]
+  publishedAt_in: [DateTime!]
+  "All values less than the given value."
+  publishedAt_lt: DateTime
+  "All values less than or equal the given value."
+  publishedAt_lte: DateTime
   "All values that are not equal to given value."
-  status_not: Status
+  publishedAt_not: DateTime
   "All values that are not contained in given list."
-  status_not_in: [Status!]
+  publishedAt_not_in: [DateTime!]
   updatedAt: DateTime
   "All values greater than the given value."
   updatedAt_gt: DateTime
@@ -2242,21 +2960,209 @@ input ThemeWhereInput {
   updatedAt_not_in: [DateTime!]
 }
 
+input ThemeUpdateInput {
+  customer: CustomerUpdateOneInlineInput
+  logo: AssetUpdateOneInlineInput
+  primaryColor: String
+}
+
+input ThemeUpdateManyInlineInput {
+  "Connect multiple existing Theme documents"
+  connect: [ThemeConnectInput!]
+  "Create and connect multiple Theme documents"
+  create: [ThemeCreateInput!]
+  "Delete multiple Theme documents"
+  delete: [ThemeWhereUniqueInput!]
+  "Disconnect multiple Theme documents"
+  disconnect: [ThemeWhereUniqueInput!]
+  "Override currently-connected documents with multiple existing Theme documents"
+  set: [ThemeWhereUniqueInput!]
+  "Update multiple Theme documents"
+  update: [ThemeUpdateWithNestedWhereUniqueInput!]
+  "Upsert multiple Theme documents"
+  upsert: [ThemeUpsertWithNestedWhereUniqueInput!]
+}
+
+input ThemeUpdateManyInput {
+  primaryColor: String
+}
+
+input ThemeUpdateManyWithNestedWhereInput {
+  "Update many input"
+  data: ThemeUpdateManyInput!
+  "Document search"
+  where: ThemeWhereInput!
+}
+
+input ThemeUpdateOneInlineInput {
+  "Connect existing Theme document"
+  connect: ThemeWhereUniqueInput
+  "Create and connect one Theme document"
+  create: ThemeCreateInput
+  "Delete currently connected Theme document"
+  delete: Boolean
+  "Disconnect currently connected Theme document"
+  disconnect: Boolean
+  "Update single Theme document"
+  update: ThemeUpdateWithNestedWhereUniqueInput
+  "Upsert single Theme document"
+  upsert: ThemeUpsertWithNestedWhereUniqueInput
+}
+
+input ThemeUpdateWithNestedWhereUniqueInput {
+  "Document to update"
+  data: ThemeUpdateInput!
+  "Unique document search"
+  where: ThemeWhereUniqueInput!
+}
+
+input ThemeUpsertInput {
+  "Create document if it didn't exist"
+  create: ThemeCreateInput!
+  "Update document if it exists"
+  update: ThemeUpdateInput!
+}
+
+input ThemeUpsertWithNestedWhereUniqueInput {
+  "Upsert data"
+  data: ThemeUpsertInput!
+  "Unique document search"
+  where: ThemeWhereUniqueInput!
+}
+
+"Identifies documents"
+input ThemeWhereInput {
+  "Logical AND on all given filters."
+  AND: [ThemeWhereInput!]
+  "Logical NOT on all given filters combined by AND."
+  NOT: [ThemeWhereInput!]
+  "Logical OR on all given filters."
+  OR: [ThemeWhereInput!]
+  "Contains search across all appropriate fields."
+  _search: String
+  createdAt: DateTime
+  "All values greater than the given value."
+  createdAt_gt: DateTime
+  "All values greater than or equal the given value."
+  createdAt_gte: DateTime
+  "All values that are contained in given list."
+  createdAt_in: [DateTime!]
+  "All values less than the given value."
+  createdAt_lt: DateTime
+  "All values less than or equal the given value."
+  createdAt_lte: DateTime
+  "All values that are not equal to given value."
+  createdAt_not: DateTime
+  "All values that are not contained in given list."
+  createdAt_not_in: [DateTime!]
+  customer: CustomerWhereInput
+  id: ID
+  "All values containing the given string."
+  id_contains: ID
+  "All values ending with the given string."
+  id_ends_with: ID
+  "All values that are contained in given list."
+  id_in: [ID!]
+  "All values that are not equal to given value."
+  id_not: ID
+  "All values not containing the given string."
+  id_not_contains: ID
+  "All values not ending with the given string"
+  id_not_ends_with: ID
+  "All values that are not contained in given list."
+  id_not_in: [ID!]
+  "All values not starting with the given string."
+  id_not_starts_with: ID
+  "All values starting with the given string."
+  id_starts_with: ID
+  logo: AssetWhereInput
+  primaryColor: String
+  "All values containing the given string."
+  primaryColor_contains: String
+  "All values ending with the given string."
+  primaryColor_ends_with: String
+  "All values that are contained in given list."
+  primaryColor_in: [String!]
+  "All values that are not equal to given value."
+  primaryColor_not: String
+  "All values not containing the given string."
+  primaryColor_not_contains: String
+  "All values not ending with the given string"
+  primaryColor_not_ends_with: String
+  "All values that are not contained in given list."
+  primaryColor_not_in: [String!]
+  "All values not starting with the given string."
+  primaryColor_not_starts_with: String
+  "All values starting with the given string."
+  primaryColor_starts_with: String
+  publishedAt: DateTime
+  "All values greater than the given value."
+  publishedAt_gt: DateTime
+  "All values greater than or equal the given value."
+  publishedAt_gte: DateTime
+  "All values that are contained in given list."
+  publishedAt_in: [DateTime!]
+  "All values less than the given value."
+  publishedAt_lt: DateTime
+  "All values less than or equal the given value."
+  publishedAt_lte: DateTime
+  "All values that are not equal to given value."
+  publishedAt_not: DateTime
+  "All values that are not contained in given list."
+  publishedAt_not_in: [DateTime!]
+  updatedAt: DateTime
+  "All values greater than the given value."
+  updatedAt_gt: DateTime
+  "All values greater than or equal the given value."
+  updatedAt_gte: DateTime
+  "All values that are contained in given list."
+  updatedAt_in: [DateTime!]
+  "All values less than the given value."
+  updatedAt_lt: DateTime
+  "All values less than or equal the given value."
+  updatedAt_lte: DateTime
+  "All values that are not equal to given value."
+  updatedAt_not: DateTime
+  "All values that are not contained in given list."
+  updatedAt_not_in: [DateTime!]
+}
+
+"References Theme record uniquely"
 input ThemeWhereUniqueInput {
   id: ID
 }
 
+input UnpublishLocaleInput {
+  "Locales to unpublish"
+  locale: Locale!
+  "Stages to unpublish selected locales from"
+  stages: [Stage!]!
+}
 
-scalar DateTime
+input VersionWhereInput {
+  id: ID!
+  revision: Int!
+  stage: Stage!
+}
 
-"Custom scalar representing a Slate rich text AST"
+
+scalar RGBAHue
+
+"Slate-compatible RichText AST"
 scalar RichTextAST
 
-"""
-The `Long` scalar type represents non-fractional signed whole numeric values.
-Long can represent values between -(2^63) and 2^63 - 1.
-"""
+scalar RGBATransparency
+
+scalar Hex
+
+"A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the date-timeformat outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representationof dates and times using the Gregorian calendar."
+scalar DateTime
+
+"The Long scalar type represents non-fractional signed whole numeric values. Long can represent values between -(2^63) and 2^63 - 1."
 scalar Long
 
 "Raw JSON value"
 scalar Json
+
+"A date string, such as 2007-12-03 (YYYY-MM-DD), compliant with ISO 8601 standard for representation of dates using the Gregorian calendar."
+scalar Date

--- a/src/components/appBootstrap/MultiversalAppBootstrap.tsx
+++ b/src/components/appBootstrap/MultiversalAppBootstrap.tsx
@@ -110,25 +110,39 @@ const MultiversalAppBootstrap: React.FunctionComponent<Props> = (props): JSX.Ele
     }
 
     if (!customer || !i18nTranslations || !lang || !locale) {
+      let error = props.err || null;
+
       // Unrecoverable error, we can't even display the layout because we don't have the minimal required information to properly do so
       // This most likely means something went wrong, and we must display the error page in such case
-      if (!props.err) {
-        // If the error wasn't detected by Next, then we log it to Sentry to make sure we'll be notified
+      if (!error) {
+        // The most-likely issue could be that we failed to fetch the customer related to "process.env.NEXT_PUBLIC_CUSTOMER_REF"
+        // E.g: This will happens when an instance was deployed for a customer, but the customer.ref was changed since then.
+        if (process.env.NEXT_PUBLIC_CUSTOMER_REF !== customer?.ref) {
+          error = new Error(process.env.NEXT_PUBLIC_APP_STAGE === 'production' ?
+            `An error happened, the app cannot start. (customer doesn't match)` :
+            `Fatal error when bootstraping the app. The "customer.ref" doesn't match (expected: "${process.env.NEXT_PUBLIC_CUSTOMER_REF}", received: "${customer?.ref}".`,
+          );
+        } else {
+          error = new Error(process.env.NEXT_PUBLIC_APP_STAGE === 'production' ?
+            `An error happened, the app cannot start.` :
+            `Fatal error when bootstraping the app. It might happen when lang/locale/translations couldn't be resolved.`,
+          );
+        }
 
+        // If the error wasn't detected by Next, then we log it to Sentry to make sure we'll be notified
         Sentry.withScope((scope): void => {
           scope.setContext('props', props);
-          Sentry.captureMessage(`Unexpected fatal error happened, the app cannot render properly, fallback to the Error page. Check props.`, Sentry.Severity.Warning);
+          Sentry.captureException(error);
         });
-
       } else {
         // If an error was detected by Next, then it means the current state is due to a top-level that was caught before
         // We don't have anything to do, as it's automatically logged into Sentry
       }
 
       return (
-        <ErrorPage err={props.err} statusCode={500} isReadyToRender={true}>
+        <ErrorPage err={error} statusCode={500} isReadyToRender={true}>
           <DefaultErrorLayout
-            error={props.err}
+            error={error}
           />
         </ErrorPage>
       );

--- a/src/components/data/AllProducts.tsx
+++ b/src/components/data/AllProducts.tsx
@@ -10,8 +10,8 @@ type Props = {
 
 const AllProducts: React.FunctionComponent<Props> = (props) => {
   const { products } = props;
-  const productsPublished = filter(products, { status: 'PUBLISHED' });
-  const productsDraft = filter(products, { status: 'DRAFT' });
+  const productsPublished = filter(products, { stage: 'PUBLISHED' });
+  const productsDraft = filter(products, { stage: 'DRAFT' });
 
   return (
     <>

--- a/src/components/data/AllProducts.tsx
+++ b/src/components/data/AllProducts.tsx
@@ -1,4 +1,5 @@
 import filter from 'lodash.filter';
+import map from 'lodash.map';
 import React from 'react';
 
 import { Product } from '../../types/data/Product';
@@ -10,9 +11,16 @@ type Props = {
 
 const AllProducts: React.FunctionComponent<Props> = (props) => {
   const { products } = props;
-  const productsPublished = filter(products, { stage: 'PUBLISHED' });
+  const productsPublished = [];
+  map(products, (productInStage: { documentInStages: Product[] } & Product) => {
+    const productsInStage: Product[] = productInStage?.documentInStages; // Contains an array of 1 element, when there is a PUBLISHED record (otherwise is empty)
+    map(productsInStage, (product: Product) => {
+      if(product?.stage === 'PUBLISHED'){
+        productsPublished.push(product);
+      }
+    });
+  });
   const productsDraft = filter(products, { stage: 'DRAFT' });
-  console.log('products', products)
 
   return (
     <>

--- a/src/components/data/AllProducts.tsx
+++ b/src/components/data/AllProducts.tsx
@@ -12,6 +12,7 @@ const AllProducts: React.FunctionComponent<Props> = (props) => {
   const { products } = props;
   const productsPublished = filter(products, { stage: 'PUBLISHED' });
   const productsDraft = filter(products, { stage: 'DRAFT' });
+  console.log('products', products)
 
   return (
     <>

--- a/src/components/doc/ExternalFeaturesSection.tsx
+++ b/src/components/doc/ExternalFeaturesSection.tsx
@@ -34,31 +34,24 @@ const ExternalFeaturesSection: React.FunctionComponent<Props> = (props): JSX.Ele
         <Card>
           <CardBody>
             <CardTitle><h3 style={{textDecoration: 'strikethrough'}}>Backoffice/Admin site</h3></CardTitle>
-            <CardSubtitle>&ldquo;Update NRN demo using NRN-Admin CMS&rdquo;</CardSubtitle>
+            <CardSubtitle>&ldquo;Update NRN demo using GraphCMS&rdquo;</CardSubtitle>
             <CardText tag={'div'}>
 
-              <Alert color={'error'}>
-                This experimental feature isn't available anymore, because the GraphQL provider (GraphCMS) used for this demo has changed its API (from v1 to v2) with several breaking changes.<br />
-                <br />
-                The NRN-Admin hasn't been updated to the new GraphCMS v2 API and thus is now unusable and changes made on NRN-Admin won't reflect here.<br />
-                <br />
-                This section has been kept through, to showcase what could be done. <i>(this was working properly in 2020)</i><br />
-                <br />
-                The NRN-Admin demo will stop working on February 1st, 2021.
-              </Alert>
-
               <Alert color={'info'}>
-                Edit this demo using NRN-Admin CMS!<br />
+                Edit this demo using GraphCMS!<br />
                 <br />
-                You can edit the <code>customer</code> theme, play with its primary color to see how the demo is affected depending on the various rendering modes (SSG, SSR, etc.)<br />
+                <b>Email</b>: <code style={{fontSize: 18}}>unly-nrn+contributor@unly.org</code><br />
+                <b>Password</b>: <code style={{fontSize: 18}}>bbU#Ec2m6FpqU7&</code><br />
                 <br />
-                It's basically an admin site (POC/experimental), for managing content, based on
-                <ExternalLink href={'https://github.com/marmelab/react-admin'} suffix={null}><code>react-admin</code></ExternalLink>, built with NRN.
+                You can edit anything and play with the various rendering modes (SSG, SSR, etc.), the GraphCMS API is configured to use <code>DRAFT</code> content in priority.<br />
+                This mean that your changes on any published content will be reflected (because changing a published content creates a draft, and that draft is being used).<br />
+                This has been done on purpose, to allow visitors to manipulate the content of the demo and see their changes being reflected immediately.<br />
+                <b>N.B: Please do not change the <code>customer.ref</code> values, as it would break the associated demo, if the <code>ref</code> doesn't match.</b><br />
               </Alert>
 
               <div className={'buttons'}>
-                <ExternalLink href={'https://nrn-admin.now.sh/'}>
-                  <Button color={'link'}>Go to NRN-Admin CMS</Button>
+                <ExternalLink href={'https://app.graphcms.com/b767f8ab435746e2909249461e2f1eb7/master'}>
+                  <Button color={'link'}>Go to GraphCMS</Button>
                 </ExternalLink>
               </div>
             </CardText>

--- a/src/components/doc/ExternalFeaturesSection.tsx
+++ b/src/components/doc/ExternalFeaturesSection.tsx
@@ -49,6 +49,12 @@ const ExternalFeaturesSection: React.FunctionComponent<Props> = (props): JSX.Ele
                 <b>N.B: Please do not change the <code>customer.ref</code> values, as it would break the associated demo, if the <code>ref</code> doesn't match.</b><br />
               </Alert>
 
+              <Alert color={'warning'}>
+                Changes will be immediately be reflected on SSG pages, when the preview mode is enabled (staging environment).<br />
+                But, they won't be applied on the production demo (for SSG pages), because those pages have been generated at build-time and aren't updated dynamically.<br />
+                On the other hand, SSR pages will always reflect the latest version of the content.
+              </Alert>
+
               <div className={'buttons'}>
                 <ExternalLink href={'https://app.graphcms.com/b767f8ab435746e2909249461e2f1eb7/master'}>
                   <Button color={'link'}>Go to GraphCMS</Button>

--- a/src/components/doc/ExternalFeaturesSection.tsx
+++ b/src/components/doc/ExternalFeaturesSection.tsx
@@ -33,9 +33,20 @@ const ExternalFeaturesSection: React.FunctionComponent<Props> = (props): JSX.Ele
       <Cards maxCards={1}>
         <Card>
           <CardBody>
-            <CardTitle><h3>Backoffice/Admin site</h3></CardTitle>
+            <CardTitle><h3 style={{textDecoration: 'strikethrough'}}>Backoffice/Admin site</h3></CardTitle>
             <CardSubtitle>&ldquo;Update NRN demo using NRN-Admin CMS&rdquo;</CardSubtitle>
             <CardText tag={'div'}>
+
+              <Alert color={'error'}>
+                This experimental feature isn't available anymore, because the GraphQL provider (GraphCMS) used for this demo has changed its API (from v1 to v2) with several breaking changes.<br />
+                <br />
+                The NRN-Admin hasn't been updated to the new GraphCMS v2 API and thus is now unusable and changes made on NRN-Admin won't reflect here.<br />
+                <br />
+                This section has been kept through, to showcase what could be done. <i>(this was working properly in 2020)</i><br />
+                <br />
+                The NRN-Admin demo will stop working on February 1st, 2021.
+              </Alert>
+
               <Alert color={'info'}>
                 Edit this demo using NRN-Admin CMS!<br />
                 <br />

--- a/src/components/pageLayouts/Nav.tsx
+++ b/src/components/pageLayouts/Nav.tsx
@@ -292,28 +292,32 @@ const Nav: React.FunctionComponent<Props> = () => {
             <NavItem>
               <Col className={'navItemsMenu'}>
                 <Row className={'justify-content-center'}>
-                  {/*<Tooltip*/}
-                  {/*  overlay={<span>*/}
-                  {/*    Edit this demo using NRN-Admin CMS!<br />*/}
-                  {/*    <br />*/}
-                  {/*    You can edit the <code>customer</code> theme, play with its primary color to see how the demo is affected depending on the various rendering modes (SSG, SSR, etc.)<br />*/}
-                  {/*    <br />*/}
-                  {/*    You can also edit the products, and play around, as if you were using the NRN-Admin CMS from a customer/editor standpoint!*/}
-                  {/*  </span>}*/}
-                  {/*>*/}
-                  {/*  <NavLink*/}
-                  {/*    id={'nav-link-admin-site'}*/}
-                  {/*    href={`https://nrn-admin.now.sh`}*/}
-                  {/*    target={'_blank'}*/}
-                  {/*    rel={'noopener'}*/}
-                  {/*    onClick={(): void => {*/}
-                  {/*      logEvent('open-admin-site');*/}
-                  {/*    }}*/}
-                  {/*  >*/}
-                  {/*    <FontAwesomeIcon icon={['fas', 'user-cog']} />*/}
-                  {/*    {t('nav.adminSite.link', 'Go to CMS')}*/}
-                  {/*  </NavLink>*/}
-                  {/*</Tooltip>*/}
+                  <Tooltip
+                    overlay={<span>
+                      Edit this demo using GraphCMS!<br />
+                      <br />
+                      <b>Email</b>: <code style={{ fontSize: 18 }}>unly-nrn+contributor@unly.org</code><br />
+                      <b>Password</b>: <code style={{ fontSize: 18 }}>bbU#Ec2m6FpqU7&</code><br />
+                      <br />
+                      You can edit anything and play with the various rendering modes (SSG, SSR, etc.), the GraphCMS API is configured to use <code>DRAFT</code> content in priority.<br />
+                      This mean that your changes on any published content will be reflected (because changing a published content creates a draft, and that draft is being used).<br />
+                      This has been done on purpose, to allow visitors to manipulate the content of the demo and see their changes being reflected immediately.<br />
+                      <b>N.B: Please do not change the <code>customer.ref</code> values, as it would break the associated demo, if the <code>ref</code> doesn't match.</b><br />
+                    </span>}
+                  >
+                    <NavLink
+                      id={'nav-link-admin-site'}
+                      href={`https://app.graphcms.com/b767f8ab435746e2909249461e2f1eb7/master`}
+                      target={'_blank'}
+                      rel={'noopener'}
+                      onClick={(): void => {
+                        logEvent('open-admin-site');
+                      }}
+                    >
+                      <FontAwesomeIcon icon={['fas', 'user-cog']} />
+                      {t('nav.adminSite.link', 'Go to CMS')}
+                    </NavLink>
+                  </Tooltip>
                 </Row>
               </Col>
             </NavItem>

--- a/src/components/pageLayouts/Nav.tsx
+++ b/src/components/pageLayouts/Nav.tsx
@@ -292,28 +292,28 @@ const Nav: React.FunctionComponent<Props> = () => {
             <NavItem>
               <Col className={'navItemsMenu'}>
                 <Row className={'justify-content-center'}>
-                  <Tooltip
-                    overlay={<span>
-                      Edit this demo using NRN-Admin CMS!<br />
-                      <br />
-                      You can edit the <code>customer</code> theme, play with its primary color to see how the demo is affected depending on the various rendering modes (SSG, SSR, etc.)<br />
-                      <br />
-                      You can also edit the products, and play around, as if you were using the NRN-Admin CMS from a customer/editor standpoint!
-                    </span>}
-                  >
-                    <NavLink
-                      id={'nav-link-admin-site'}
-                      href={`https://nrn-admin.now.sh`}
-                      target={'_blank'}
-                      rel={'noopener'}
-                      onClick={(): void => {
-                        logEvent('open-admin-site');
-                      }}
-                    >
-                      <FontAwesomeIcon icon={['fas', 'user-cog']} />
-                      {t('nav.adminSite.link', 'Go to CMS')}
-                    </NavLink>
-                  </Tooltip>
+                  {/*<Tooltip*/}
+                  {/*  overlay={<span>*/}
+                  {/*    Edit this demo using NRN-Admin CMS!<br />*/}
+                  {/*    <br />*/}
+                  {/*    You can edit the <code>customer</code> theme, play with its primary color to see how the demo is affected depending on the various rendering modes (SSG, SSR, etc.)<br />*/}
+                  {/*    <br />*/}
+                  {/*    You can also edit the products, and play around, as if you were using the NRN-Admin CMS from a customer/editor standpoint!*/}
+                  {/*  </span>}*/}
+                  {/*>*/}
+                  {/*  <NavLink*/}
+                  {/*    id={'nav-link-admin-site'}*/}
+                  {/*    href={`https://nrn-admin.now.sh`}*/}
+                  {/*    target={'_blank'}*/}
+                  {/*    rel={'noopener'}*/}
+                  {/*    onClick={(): void => {*/}
+                  {/*      logEvent('open-admin-site');*/}
+                  {/*    }}*/}
+                  {/*  >*/}
+                  {/*    <FontAwesomeIcon icon={['fas', 'user-cog']} />*/}
+                  {/*    {t('nav.adminSite.link', 'Go to CMS')}*/}
+                  {/*  </NavLink>*/}
+                  {/*</Tooltip>*/}
                 </Row>
               </Col>
             </NavItem>

--- a/src/gql/common/layoutQuery.ts
+++ b/src/gql/common/layoutQuery.ts
@@ -10,6 +10,14 @@ export const LAYOUT_QUERY = gql`
     customer(where: {
       ref: $customerRef,
     }){
+      stage
+      documentInStages(includeCurrent: true){
+        id
+        label
+        theme {
+          ...themeFields
+        }
+      }
       id
       label
       theme {

--- a/src/gql/common/layoutQuery.ts
+++ b/src/gql/common/layoutQuery.ts
@@ -11,13 +11,6 @@ export const LAYOUT_QUERY = gql`
       ref: $customerRef,
     }){
       stage
-      documentInStages(includeCurrent: true){
-        id
-        label
-        theme {
-          ...themeFields
-        }
-      }
       id
       label
       theme {

--- a/src/gql/fragments/asset.ts
+++ b/src/gql/fragments/asset.ts
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 export const asset = {
   assetFields: gql`
     fragment assetFields on Asset {
+      stage
       id
       url
       mimeType

--- a/src/gql/fragments/product.ts
+++ b/src/gql/fragments/product.ts
@@ -6,6 +6,7 @@ import { asset } from './asset';
 export const product = {
   productFields: gql`
     fragment productFields on Product {
+      stage
       id
       title
       description

--- a/src/gql/fragments/product.ts
+++ b/src/gql/fragments/product.ts
@@ -7,7 +7,6 @@ export const product = {
   productFields: gql`
     fragment productFields on Product {
       id
-      status
       title
       description
       images {

--- a/src/gql/fragments/product.ts
+++ b/src/gql/fragments/product.ts
@@ -6,7 +6,7 @@ import { asset } from './asset';
 export const product = {
   productFields: gql`
     fragment productFields on Product {
-      documentInStages(includeCurrent: true, stages: [DRAFT, PUBLISHED]){
+      documentInStages(includeCurrent: false, stages: [PUBLISHED]){
         stage
         id
         title

--- a/src/gql/fragments/product.ts
+++ b/src/gql/fragments/product.ts
@@ -6,6 +6,16 @@ import { asset } from './asset';
 export const product = {
   productFields: gql`
     fragment productFields on Product {
+      documentInStages(includeCurrent: false, stages: [PUBLISHED]){
+        stage
+        id
+        title
+        description
+        images {
+          ...assetFields
+        }
+        price
+      }
       stage
       id
       title

--- a/src/gql/fragments/product.ts
+++ b/src/gql/fragments/product.ts
@@ -6,7 +6,7 @@ import { asset } from './asset';
 export const product = {
   productFields: gql`
     fragment productFields on Product {
-      documentInStages(includeCurrent: false, stages: [PUBLISHED]){
+      documentInStages(includeCurrent: true, stages: [DRAFT, PUBLISHED]){
         stage
         id
         title

--- a/src/gql/fragments/theme.ts
+++ b/src/gql/fragments/theme.ts
@@ -6,6 +6,7 @@ import { asset } from './asset';
 export const theme = {
   themeFields: gql`
     fragment themeFields on Theme {
+      stage
       primaryColor
       logo {
         ...assetFields

--- a/src/gql/pages/examples/native-features/example-with-ssg.ts
+++ b/src/gql/pages/examples/native-features/example-with-ssg.ts
@@ -1,5 +1,4 @@
 import gql from 'graphql-tag';
-import { product } from '../../../fragments/product';
 
 /**
  * Used by /src/pages/[locale]/examples/native-features/example-with-ssg page
@@ -11,8 +10,30 @@ export const EXAMPLE_WITH_SSG_QUERY = gql`
         ref: $customerRef
       }
     }){
-      ...productFields
+      documentInStages(includeCurrent: true, stages: [DRAFT, PUBLISHED]){
+        stage
+        id
+        title
+        description
+        images {
+          stage
+          id
+          url
+          mimeType
+        }
+        price
+      }
+      stage
+      id
+      title
+      description
+      images {
+        stage
+        id
+        url
+        mimeType
+      }
+      price
     }
   }
-  ${product.productFields}
 `;

--- a/src/gql/pages/examples/native-features/example-with-ssg.ts
+++ b/src/gql/pages/examples/native-features/example-with-ssg.ts
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { product } from '../../../fragments/product';
 
 /**
  * Used by /src/pages/[locale]/examples/native-features/example-with-ssg page
@@ -10,30 +11,8 @@ export const EXAMPLE_WITH_SSG_QUERY = gql`
         ref: $customerRef
       }
     }){
-      documentInStages(includeCurrent: true, stages: [DRAFT, PUBLISHED]){
-        stage
-        id
-        title
-        description
-        images {
-          stage
-          id
-          url
-          mimeType
-        }
-        price
-      }
-      stage
-      id
-      title
-      description
-      images {
-        stage
-        id
-        url
-        mimeType
-      }
-      price
+      ...productFields
     }
   }
+  ${product.productFields}
 `;

--- a/src/gql/pages/examples/native-features/example-with-ssr.ts
+++ b/src/gql/pages/examples/native-features/example-with-ssr.ts
@@ -23,7 +23,6 @@ export const EXAMPLE_WITH_SSR_QUERY = gql`
         ref: $customerRef
       }
     }
-      orderBy: title_ASC
     ){
       ...productFields
     }

--- a/src/gql/pages/examples/native-features/example-with-ssr.ts
+++ b/src/gql/pages/examples/native-features/example-with-ssr.ts
@@ -23,7 +23,7 @@ export const EXAMPLE_WITH_SSR_QUERY = gql`
         ref: $customerRef
       }
     }
-      orderBy: status_DESC
+      orderBy: title_ASC
     ){
       ...productFields
     }

--- a/src/pages/[locale]/examples/built-in-features/graphql.tsx
+++ b/src/pages/[locale]/examples/built-in-features/graphql.tsx
@@ -91,7 +91,7 @@ const ExampleGraphQLPage: NextPage<Props> = (props): JSX.Element => {
                 headers: {
                   // This is how we handle "Dynamic i18n", by only fetching content for one language
                   // With languages fallback if content isn't available (e.g: ['FR', 'DE', 'EN']
-                  'gcms-locale': gcmsLocales,
+                  'gcms-locales': gcmsLocales,
                 },
               },
             };

--- a/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
@@ -76,6 +76,7 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
         },
       },
     };
+    console.log('queryOptions', queryOptions)
 
     const {
       data,

--- a/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
@@ -72,7 +72,7 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
       variables,
       context: {
         headers: {
-          'gcms-locale': gcmsLocales,
+          'gcms-locales': gcmsLocales,
         },
       },
     };

--- a/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
@@ -1,5 +1,5 @@
 import { createLogger } from '@unly/utils-simple-logger';
-import { ApolloQueryResult } from 'apollo-client';
+import { ApolloQueryResult, QueryOptions } from 'apollo-client';
 import deepmerge from 'deepmerge';
 import size from 'lodash.size';
 import {
@@ -66,7 +66,7 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
     const variables = {
       customerRef,
     };
-    const queryOptions = {
+    const queryOptions: QueryOptions = {
       displayName: 'EXAMPLE_WITH_SSG_QUERY',
       query: EXAMPLE_WITH_SSG_QUERY,
       variables,
@@ -75,7 +75,19 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
           'gcms-locales': gcmsLocales,
         },
       },
-    };
+
+      // XXX When you use the "documentInStages" special GraphCMS feature,
+      //  you must disable the ApolloClient cache for it to function properly,
+      //  otherwise ApolloClient internal caching messes up with the results returned by GraphCMS,
+      //  because it gets 2 different records that have the same "id",
+      //  and it doesn't understand those are 2 different records but treats them as one.
+      //  If you don't disable the cache, then "documentInStages" will only contain DRAFT records and not PUBLISHED records,
+      //  because ApolloClient will replace the PUBLISHED record by the draft record, by mistakenly thinking they're the same
+      //  This is because ApolloClient doesn't known about the concept of "stage".
+      //  I haven't reported this issue to the ApolloClient team,
+      //  you'll need to look into it yourself if you want to benefit from both content from multiple stages and client-side caching
+      fetchPolicy: 'no-cache',
+    } as QueryOptions;
 
     const {
       data,

--- a/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg-and-revalidate.tsx
@@ -76,7 +76,6 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
         },
       },
     };
-    console.log('queryOptions', queryOptions)
 
     const {
       data,

--- a/src/pages/[locale]/examples/native-features/example-with-ssg.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg.tsx
@@ -71,7 +71,7 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
       variables,
       context: {
         headers: {
-          'gcms-locale': gcmsLocales,
+          'gcms-locales': gcmsLocales,
         },
       },
     };

--- a/src/pages/[locale]/examples/native-features/example-with-ssg.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssg.tsx
@@ -75,6 +75,7 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
         },
       },
     };
+    console.log('queryOptions', queryOptions)
 
     const {
       data,

--- a/src/pages/[locale]/examples/native-features/example-with-ssr.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssr.tsx
@@ -193,7 +193,7 @@ const ProductsWithSSRPage: NextPage<Props> = (props): JSX.Element => {
 //     variables,
 //     context: {
 //       headers: {
-//         'gcms-locale': gcmsLocales,
+//         'gcms-locales': gcmsLocales,
 //       },
 //     },
 //   };

--- a/src/pages/[locale]/examples/native-features/example-with-ssr.tsx
+++ b/src/pages/[locale]/examples/native-features/example-with-ssr.tsx
@@ -1,5 +1,5 @@
 import { createLogger } from '@unly/utils-simple-logger';
-import { ApolloQueryResult } from 'apollo-client';
+import { ApolloQueryResult, QueryOptions } from 'apollo-client';
 import size from 'lodash.size';
 import {
   GetServerSideProps,
@@ -64,11 +64,23 @@ export const getServerSideProps: GetServerSideProps<GetServerSidePageProps> = as
         ...pageData
       },
     } = commonServerSideProps;
-    const queryOptions = { // Override query (keep existing variables and headers)
+    const queryOptions: QueryOptions = { // Override query (keep existing variables and headers)
       ...layoutQueryOptions,
       displayName: 'EXAMPLE_WITH_SSR_QUERY',
       query: EXAMPLE_WITH_SSR_QUERY,
-    };
+
+      // XXX When you use the "documentInStages" special GraphCMS feature,
+      //  you must disable the ApolloClient cache for it to function properly,
+      //  otherwise ApolloClient internal caching messes up with the results returned by GraphCMS,
+      //  because it gets 2 different records that have the same "id",
+      //  and it doesn't understand those are 2 different records but treats them as one.
+      //  If you don't disable the cache, then "documentInStages" will only contain DRAFT records and not PUBLISHED records,
+      //  because ApolloClient will replace the PUBLISHED record by the draft record, by mistakenly thinking they're the same
+      //  This is because ApolloClient doesn't known about the concept of "stage".
+      //  I haven't reported this issue to the ApolloClient team,
+      //  you'll need to look into it yourself if you want to benefit from both content from multiple stages and client-side caching
+      fetchPolicy: 'no-cache',
+    } as QueryOptions;
 
     const {
       data,

--- a/src/pages/[locale]/pageTemplateSSR.tsx
+++ b/src/pages/[locale]/pageTemplateSSR.tsx
@@ -60,6 +60,7 @@ export const getServerSideProps: GetServerSideProps<GetServerSidePageProps> = as
       displayName: 'LAYOUT_QUERY',
       query: LAYOUT_QUERY,
     };
+    console.log('queryOptions', queryOptions)
 
     const {
       data,

--- a/src/pages/[locale]/pageTemplateSSR.tsx
+++ b/src/pages/[locale]/pageTemplateSSR.tsx
@@ -60,7 +60,6 @@ export const getServerSideProps: GetServerSideProps<GetServerSidePageProps> = as
       displayName: 'LAYOUT_QUERY',
       query: LAYOUT_QUERY,
     };
-    console.log('queryOptions', queryOptions)
 
     const {
       data,

--- a/src/pages/[locale]/terms.tsx
+++ b/src/pages/[locale]/terms.tsx
@@ -70,6 +70,7 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
       },
     };
     console.log('queryOptions', queryOptions)
+
     const {
       data,
       errors,

--- a/src/pages/[locale]/terms.tsx
+++ b/src/pages/[locale]/terms.tsx
@@ -69,7 +69,6 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
         },
       },
     };
-    console.log('queryOptions', queryOptions)
 
     const {
       data,

--- a/src/pages/[locale]/terms.tsx
+++ b/src/pages/[locale]/terms.tsx
@@ -65,11 +65,11 @@ export const getStaticProps: GetStaticProps<SSGPageProps, CommonServerSideParams
       variables,
       context: {
         headers: {
-          'gcms-locale': gcmsLocales,
+          'gcms-locales': gcmsLocales,
         },
       },
     };
-
+    console.log('queryOptions', queryOptions)
     const {
       data,
       errors,

--- a/src/types/data/GraphCMSSystemFields.ts
+++ b/src/types/data/GraphCMSSystemFields.ts
@@ -7,7 +7,6 @@
 export type GraphCMSSystemFields = {
   // id: string; // XXX Should specified in sub-types if required - See https://github.com/microsoft/TypeScript/issues/36286
   createdAt?: string;
-  status?: string;
-  updatedAt?: string;
+  stage?: 'DRAFT' | 'PUBLISHED';
   __typename?: string;
 }

--- a/src/types/data/Product.ts
+++ b/src/types/data/Product.ts
@@ -2,6 +2,7 @@ import { Asset } from './Asset';
 import { GraphCMSSystemFields } from './GraphCMSSystemFields';
 
 export type Product = {
+  stage?: string;
   id?: string;
   title?: string;
   description?: string;

--- a/src/utils/gql/graphcms.test.ts
+++ b/src/utils/gql/graphcms.test.ts
@@ -4,15 +4,18 @@ describe(`utils/graphcms.ts`, () => {
   describe(`prepareGraphCMSLocaleHeader`, () => {
     describe(`should clean properly the header locale`, () => {
       test(`when using 1 language`, async () => {
-        expect(prepareGraphCMSLocaleHeader(['fr'])).toEqual(`FR`);
+        expect(prepareGraphCMSLocaleHeader(['fr'])).toEqual(`fr`);
+        expect(prepareGraphCMSLocaleHeader(['FR'])).toEqual(`fr`);
       });
 
       test(`when using 2 languages`, async () => {
-        expect(prepareGraphCMSLocaleHeader(['fr', 'en'])).toEqual(`FR, EN`);
+        expect(prepareGraphCMSLocaleHeader(['fr', 'en'])).toEqual(`fr, en`);
+        expect(prepareGraphCMSLocaleHeader(['FR', 'EN'])).toEqual(`fr, en`);
       });
 
       test(`when using 3 languages`, async () => {
-        expect(prepareGraphCMSLocaleHeader(['fr', 'en', 'es'])).toEqual(`FR, EN, ES`);
+        expect(prepareGraphCMSLocaleHeader(['fr', 'en', 'es'])).toEqual(`fr, en, es`);
+        expect(prepareGraphCMSLocaleHeader(['FR', 'EN', 'ES'])).toEqual(`fr, en, es`);
       });
     });
   });

--- a/src/utils/gql/graphcms.ts
+++ b/src/utils/gql/graphcms.ts
@@ -1,20 +1,20 @@
 /**
  * GraphCMS country codes separator expected in the header
  *
- * @see https://docs.graphcms.com/docs/api/content-api/#passing-a-header-flag
+ * @see https://graphcms.com/docs/content-api/localization#http-header
  * @type {string}
  */
 export const LANGUAGES_SEP = ', ';
 
 /**
  * Convert an array of languages into a GraphCMS-compatible locale header
- * @see https://docs.graphcms.com/docs/api/content-api/#passing-a-header-flag
+ * @see https://graphcms.com/docs/content-api/localization#http-header
  *
- * XXX Beware, uppercase is very important as it won't work properly if not upper-cased!
+ * XXX Beware, lowercase is very important as it will completely crash if not lower-cased! (e.g: "ApolloError: Network error: Response not successful: Received status code 500")
  *
  * @param {string[]} languages
  * @return {string}
  */
 export const prepareGraphCMSLocaleHeader = (languages: string[]): string => {
-  return languages.join(LANGUAGES_SEP).toUpperCase();
+  return languages.join(LANGUAGES_SEP).toLowerCase();
 };

--- a/src/utils/gql/graphql.ts
+++ b/src/utils/gql/graphql.ts
@@ -15,8 +15,7 @@ export const createApolloClient = (initialState = {}, ctx = undefined): ApolloCl
       // Headers applied here will be applied for all requests
       // See the use of the "options" when running a graphQL query to specify options per-request at https://www.apollographql.com/docs/react/api/react-hooks/#options
       headers: {
-        'gcms-locale-no-default': false,
-        'authorization': `Bearer ${process.env.GRAPHQL_API_KEY}`,
+        authorization: `Bearer ${process.env.GRAPHQL_API_KEY}`,
       },
       credentials: 'same-origin', // XXX See https://www.apollographql.com/docs/react/recipes/authentication#cookie
       fetch, // Switches between unfetch & node-fetch for client & server.

--- a/src/utils/nextjs/SSG.ts
+++ b/src/utils/nextjs/SSG.ts
@@ -149,6 +149,7 @@ export const getExamplesCommonStaticProps: GetStaticProps<SSGPageProps, CommonSe
       },
     },
   };
+  console.log('queryOptions', queryOptions)
 
   const {
     data,

--- a/src/utils/nextjs/SSG.ts
+++ b/src/utils/nextjs/SSG.ts
@@ -149,7 +149,6 @@ export const getExamplesCommonStaticProps: GetStaticProps<SSGPageProps, CommonSe
       },
     },
   };
-  console.log('queryOptions', queryOptions)
 
   const {
     data,

--- a/src/utils/nextjs/SSG.ts
+++ b/src/utils/nextjs/SSG.ts
@@ -145,7 +145,7 @@ export const getExamplesCommonStaticProps: GetStaticProps<SSGPageProps, CommonSe
     variables,
     context: {
       headers: {
-        'gcms-locale': gcmsLocales,
+        'gcms-locales': gcmsLocales,
       },
     },
   };

--- a/src/utils/nextjs/SSR.ts
+++ b/src/utils/nextjs/SSR.ts
@@ -126,7 +126,7 @@ export const getExamplesCommonServerSideProps: GetServerSideProps<GetCommonServe
     variables,
     context: {
       headers: {
-        'gcms-locale': gcmsLocales,
+        'gcms-locales': gcmsLocales,
       },
     },
   };

--- a/vercel.customer1.production.json
+++ b/vercel.customer1.production.json
@@ -10,8 +10,8 @@
       "NEXT_PUBLIC_CUSTOMER_REF": "customer1",
       "NEXT_PUBLIC_LOCIZE_PROJECT_ID": "@nrn-locize-project-id",
       "NEXT_PUBLIC_AMPLITUDE_API_KEY": "@nrn-amplitude-api-key-production",
-      "GRAPHQL_API_ENDPOINT": "https://api-euwest.graphcms.com/v1/ck73ixhlv09yt01dv2ga1bkbp/master",
-      "GRAPHQL_API_KEY": "@nrn-graphql-api-key",
+      "GRAPHQL_API_ENDPOINT": "https://api-eu-central-1.graphcms.com/v2/ck73ixhlv09yt01dv2ga1bkbp/master",
+      "GRAPHQL_API_KEY": "@nrn-graphql-api-key-v2",
       "LOCIZE_API_KEY": "The Locize API Key shouldn't be used in production (see https://github.com/locize/i18next-locize-backend#backend-options) because it's related to development-only features, and it's sensitive.",
       "SENTRY_DSN": "@nrn-sentry-dsn"
     }

--- a/vercel.customer1.staging.json
+++ b/vercel.customer1.staging.json
@@ -10,8 +10,8 @@
       "NEXT_PUBLIC_CUSTOMER_REF": "customer1",
       "NEXT_PUBLIC_LOCIZE_PROJECT_ID": "@nrn-locize-project-id",
       "NEXT_PUBLIC_AMPLITUDE_API_KEY": "@nrn-amplitude-api-key-staging",
-      "GRAPHQL_API_ENDPOINT": "https://api-euwest.graphcms.com/v1/ck73ixhlv09yt01dv2ga1bkbp/master",
-      "GRAPHQL_API_KEY": "@nrn-graphql-api-key",
+      "GRAPHQL_API_ENDPOINT": "https://api-eu-central-1.graphcms.com/v2/ck73ixhlv09yt01dv2ga1bkbp/master",
+      "GRAPHQL_API_KEY": "@nrn-graphql-api-key-v2",
       "LOCIZE_API_KEY": "@nrn-locize-api-key-staging",
       "SENTRY_DSN": "@nrn-sentry-dsn"
     }

--- a/vercel.customer2.production.json
+++ b/vercel.customer2.production.json
@@ -10,8 +10,8 @@
       "NEXT_PUBLIC_CUSTOMER_REF": "customer2",
       "NEXT_PUBLIC_LOCIZE_PROJECT_ID": "@nrn-locize-project-id",
       "NEXT_PUBLIC_AMPLITUDE_API_KEY": "@nrn-amplitude-api-key-production",
-      "GRAPHQL_API_ENDPOINT": "https://api-euwest.graphcms.com/v1/ck73ixhlv09yt01dv2ga1bkbp/master",
-      "GRAPHQL_API_KEY": "@nrn-graphql-api-key",
+      "GRAPHQL_API_ENDPOINT": "https://api-eu-central-1.graphcms.com/v2/ck73ixhlv09yt01dv2ga1bkbp/master",
+      "GRAPHQL_API_KEY": "@nrn-graphql-api-key-v2",
       "LOCIZE_API_KEY": "The Locize API Key shouldn't be used in production (see https://github.com/locize/i18next-locize-backend#backend-options) because it's related to development-only features, and it's sensitive.",
       "SENTRY_DSN": "@nrn-sentry-dsn"
     }

--- a/vercel.customer2.staging.json
+++ b/vercel.customer2.staging.json
@@ -10,8 +10,8 @@
       "NEXT_PUBLIC_CUSTOMER_REF": "customer2",
       "NEXT_PUBLIC_LOCIZE_PROJECT_ID": "@nrn-locize-project-id",
       "NEXT_PUBLIC_AMPLITUDE_API_KEY": "@nrn-amplitude-api-key-staging",
-      "GRAPHQL_API_ENDPOINT": "https://api-euwest.graphcms.com/v1/ck73ixhlv09yt01dv2ga1bkbp/master",
-      "GRAPHQL_API_KEY": "@nrn-graphql-api-key",
+      "GRAPHQL_API_ENDPOINT": "https://api-eu-central-1.graphcms.com/v2/ck73ixhlv09yt01dv2ga1bkbp/master",
+      "GRAPHQL_API_KEY": "@nrn-graphql-api-key-v2",
       "LOCIZE_API_KEY": "@nrn-locize-api-key-staging",
       "SENTRY_DSN": "@nrn-sentry-dsn"
     }


### PR DESCRIPTION
Use GraphCMS v2 API.

- Change how i18n is configured (breaking change)
- Use Content Stages instead of status (breaking change)
	- ⚠️ I had to disable ApolloClient caching when fetching "products" for this to work properly, see `XXX` in code
- Remove mentions of `NRN Admin` and replace them by GraphCMS - Use GraphCMS as CMS for the demo from now on (instead of NRN Admin, which will be unusable on Feb, 1st 2021)
- Better handle edge case when/if someone breaks the demo by modifying `customer.ref` so that the error is made obvious (was blank error before)
	- This commit will be ported to other v2 presets `408e41f766f7264480efc7afe0b147bf73be81a8`
