### PR TITLE
Use Caching for Cypress (reduces CI build time)

### DIFF
--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -150,6 +150,7 @@ jobs:
       - name: Run E2E tests (Cypress)
         uses: cypress-io/github-action@v2 # XXX See https://github.com/cypress-io/github-action
         with:
+          cache-key: ${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }} # Using a custom key for cache because default is not workking. See https://github.com/cypress-io/github-action#custom-cache-key
           wait-on: ${{ env.VERCEL_DEPLOYMENT_URL }} # Be sure that the endpoint is ready by pinging it before starting tests, it has a timeout of 60seconds
           config-file: cypress/config-${{ env.CUSTOMER_REF_TO_DEPLOY }}.json # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
           config: baseUrl=${{ env.VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment

--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -148,7 +148,7 @@ jobs:
 
       # Run the E2E tests against the new Vercel deployment
       - name: Run E2E tests (Cypress)
-        uses: cypress-io/github-action@v2 # XXX See https://github.com/cypress-io/github-action
+        uses: cypress-io/github-action@47c5d1dc17e3f4a28680fe65494bf28607e405bf # Pin v2.7.1 XXX See https://github.com/cypress-io/github-action
         with:
           cache-key: ${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }} # Using a custom key for cache because the default key is not working. See https://github.com/cypress-io/github-action#custom-cache-key
           wait-on: ${{ env.VERCEL_DEPLOYMENT_URL }} # Be sure that the endpoint is ready by pinging it before starting tests, it has a timeout of 60seconds

--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Run E2E tests (Cypress)
         uses: cypress-io/github-action@v2 # XXX See https://github.com/cypress-io/github-action
         with:
-          cache-key: ${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }} # Using a custom key for cache because default is not workking. See https://github.com/cypress-io/github-action#custom-cache-key
+          cache-key: ${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }} # Using a custom key for cache because the default key is not working. See https://github.com/cypress-io/github-action#custom-cache-key
           wait-on: ${{ env.VERCEL_DEPLOYMENT_URL }} # Be sure that the endpoint is ready by pinging it before starting tests, it has a timeout of 60seconds
           config-file: cypress/config-${{ env.CUSTOMER_REF_TO_DEPLOY }}.json # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
           config: baseUrl=${{ env.VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -33,18 +33,6 @@ jobs:
         uses: actions/setup-node@v1 # Used to install node environment - XXX https://github.com/actions/setup-node
         with:
           node-version: '12.x' # Use the same node.js version as the one Vercel's uses (currently node12.x)
-      # Caching node_modules to use it in others workflow (e.g: E2E tests)
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Save yarn cache for other jobs
-        uses: actions/cache@v2 # Used to cache dependencies XXX https://github.com/actions/cache
-        id: yarn-cache # Use this id to check what did the cache  (e.g: `steps.yarn-cache.outputs.cache-hit`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-
 
   # Starts a Vercel deployment, using the staging configuration file of the default institution
   # The default institution is the one defined in the `vercel.json` file (which is a symlink to the actual file)
@@ -245,31 +233,11 @@ jobs:
           echo "Url where to run E2E tests (VERCEL_DEPLOYMENT_URL): " $VERCEL_DEPLOYMENT_URL
           echo "VERCEL_DEPLOYMENT_URL=$VERCEL_DEPLOYMENT_URL" >> $GITHUB_ENV
 
-      # Caching node_modules to use it in others workflow (e.g: E2E tests)
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Restoring cache for Cypress
-        uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Debug cache
-        run: |
-          echo "Cache returned: $CACHE_STATUS"
-          ls $(yarn cache dir)
-        env:
-          CACHE_STATUS: ${{ steps.cache-primes.outputs.cache-hit }}
-
       # Run the E2E tests against the new Vercel deployment
       - name: Run E2E tests (Cypress)
         uses: cypress-io/github-action@v2 # XXX See https://github.com/cypress-io/github-action
         with:
+          cache-key: ${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }}
           wait-on: ${{ env.VERCEL_DEPLOYMENT_URL }} # Be sure that the endpoint is ready by pinging it before starting tests, it has a timeout of 60seconds
           config-file: cypress/config-customer-ci-cd.json # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
           config: baseUrl=${{ env.VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -33,6 +33,18 @@ jobs:
         uses: actions/setup-node@v1 # Used to install node environment - XXX https://github.com/actions/setup-node
         with:
           node-version: '12.x' # Use the same node.js version as the one Vercel's uses (currently node12.x)
+      # Caching node_modules to use it in others workflow (e.g: E2E tests)
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Save yarn cache for other jobs
+        uses: actions/cache@v2 # Used to cache dependencies XXX https://github.com/actions/cache
+        id: yarn-cache # Use this id to check what did the cache  (e.g: `steps.yarn-cache.outputs.cache-hit`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+
 
   # Starts a Vercel deployment, using the staging configuration file of the default institution
   # The default institution is the one defined in the `vercel.json` file (which is a symlink to the actual file)
@@ -175,7 +187,10 @@ jobs:
     runs-on: ubuntu-18.04
     # Docker image with Cypress pre-installed
     # https://github.com/cypress-io/cypress-docker-images/tree/master/included
-    container: cypress/included:3.8.3
+    container:
+      image: cypress/included:3.8.3
+      #volumes:
+      #  - my_docker_volume:/volume_mount
     needs: start-staging-deployment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
@@ -189,6 +204,10 @@ jobs:
         # We need to set env the url for next step, formatted as `https://${$VERCEL_DEPLOYMENT}`
         # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
+          echo "------------------------------------------"
+          ls
+          pwd
+          echo "------------------------------------------"
           apt update -y >/dev/null && apt install -y jq >/dev/null
 
           MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
@@ -223,6 +242,20 @@ jobs:
           VERCEL_DEPLOYMENT_URL="https://$VERCEL_DEPLOYMENT"
           echo "Url where to run E2E tests (VERCEL_DEPLOYMENT_URL): " $VERCEL_DEPLOYMENT_URL
           echo "VERCEL_DEPLOYMENT_URL=$VERCEL_DEPLOYMENT_URL" >> $GITHUB_ENV
+
+      - name: Restoring cache for Cypress
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Debug cache
+        run: |
+          echo "Cache returned: $CACHE_STATUS"
+          ls $(yarn cache dir)
+        env:
+          - CACHE_STATUS: ${{ steps.cache-primes.outputs.cache-hit }}
 
       # Run the E2E tests against the new Vercel deployment
       - name: Run E2E tests (Cypress)

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -64,6 +64,9 @@ jobs:
         #   - Create a deployment alias based on the branch name, and link it to the deployment (so that each branch has its own domain automatically aliased to the latest commit)
         # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
+          echo "------------------------------------------"
+          pwd
+          echo "------------------------------------------"
           # Print the version of the "vercel" CLI being used (helps debugging)
           vercel --version
 
@@ -190,7 +193,7 @@ jobs:
     container:
       image: cypress/included:3.8.3
       #volumes:
-      #  - my_docker_volume:/volume_mount
+        #- ./node_modules:./node_modules
     needs: start-staging-deployment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
@@ -205,7 +208,6 @@ jobs:
         # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
           echo "------------------------------------------"
-          ls
           pwd
           echo "------------------------------------------"
           apt update -y >/dev/null && apt install -y jq >/dev/null
@@ -247,6 +249,7 @@ jobs:
         uses: actions/cache@v2
         id: yarn-cache
         with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Run E2E tests (Cypress)
         uses: cypress-io/github-action@v2 # XXX See https://github.com/cypress-io/github-action
         with:
-          cache-key: ${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }} # Using a custom key for cache because default is not workking. See https://github.com/cypress-io/github-action#custom-cache-key
+          cache-key: ${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }} # Using a custom key for cache because the default key is not working. See https://github.com/cypress-io/github-action#custom-cache-key
           wait-on: ${{ env.VERCEL_DEPLOYMENT_URL }} # Be sure that the endpoint is ready by pinging it before starting tests, it has a timeout of 60seconds
           config-file: cypress/config-customer-ci-cd.json # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
           config: baseUrl=${{ env.VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -52,9 +52,6 @@ jobs:
         #   - Create a deployment alias based on the branch name, and link it to the deployment (so that each branch has its own domain automatically aliased to the latest commit)
         # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
-          echo "------------------------------------------"
-          pwd
-          echo "------------------------------------------"
           # Print the version of the "vercel" CLI being used (helps debugging)
           vercel --version
 
@@ -178,10 +175,7 @@ jobs:
     runs-on: ubuntu-18.04
     # Docker image with Cypress pre-installed
     # https://github.com/cypress-io/cypress-docker-images/tree/master/included
-    container:
-      image: cypress/included:3.8.3
-      #volumes:
-        #- /home/runner/work/next-right-now/next-right-now/:./node_modules
+    container: cypress/included:3.8.3
     needs: start-staging-deployment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
@@ -195,9 +189,6 @@ jobs:
         # We need to set env the url for next step, formatted as `https://${$VERCEL_DEPLOYMENT}`
         # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |
-          echo "------------------------------------------"
-          pwd
-          echo "------------------------------------------"
           apt update -y >/dev/null && apt install -y jq >/dev/null
 
           MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
@@ -237,7 +228,7 @@ jobs:
       - name: Run E2E tests (Cypress)
         uses: cypress-io/github-action@v2 # XXX See https://github.com/cypress-io/github-action
         with:
-          cache-key: ${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }}
+          cache-key: ${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }} # Using a custom key for cache because default is not workking. See https://github.com/cypress-io/github-action#custom-cache-key
           wait-on: ${{ env.VERCEL_DEPLOYMENT_URL }} # Be sure that the endpoint is ready by pinging it before starting tests, it has a timeout of 60seconds
           config-file: cypress/config-customer-ci-cd.json # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
           config: baseUrl=${{ env.VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -226,7 +226,7 @@ jobs:
 
       # Run the E2E tests against the new Vercel deployment
       - name: Run E2E tests (Cypress)
-        uses: cypress-io/github-action@v2 # XXX See https://github.com/cypress-io/github-action
+        uses: cypress-io/github-action@47c5d1dc17e3f4a28680fe65494bf28607e405bf # XXX See https://github.com/cypress-io/github-action
         with:
           cache-key: ${{ runner.os }}-hash-${{ hashFiles('yarn.lock') }} # Using a custom key for cache because the default key is not working. See https://github.com/cypress-io/github-action#custom-cache-key
           wait-on: ${{ env.VERCEL_DEPLOYMENT_URL }} # Be sure that the endpoint is ready by pinging it before starting tests, it has a timeout of 60seconds

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -255,7 +255,7 @@ jobs:
           echo "Cache returned: $CACHE_STATUS"
           ls $(yarn cache dir)
         env:
-          - CACHE_STATUS: ${{ steps.cache-primes.outputs.cache-hit }}
+          CACHE_STATUS: ${{ steps.cache-primes.outputs.cache-hit }}
 
       # Run the E2E tests against the new Vercel deployment
       - name: Run E2E tests (Cypress)

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -193,7 +193,7 @@ jobs:
     container:
       image: cypress/included:3.8.3
       #volumes:
-        #- ./node_modules:./node_modules
+        #- /home/runner/work/next-right-now/next-right-now/:./node_modules
     needs: start-staging-deployment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - XXX See https://github.com/actions/checkout
@@ -245,11 +245,17 @@ jobs:
           echo "Url where to run E2E tests (VERCEL_DEPLOYMENT_URL): " $VERCEL_DEPLOYMENT_URL
           echo "VERCEL_DEPLOYMENT_URL=$VERCEL_DEPLOYMENT_URL" >> $GITHUB_ENV
 
+      # Caching node_modules to use it in others workflow (e.g: E2E tests)
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: Restoring cache for Cypress
         uses: actions/cache@v2
         id: yarn-cache
         with:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 


### PR DESCRIPTION
https://app.asana.com/0/inbox/584852631485915/1199618883018786/1199640693848660

Reduce time Cypress takes on CI/CD by using a cache.

Analysis has shown that Cypress takes 2mn to prepare, this improvement reduces it to ~1mn.
So, it's a 1mn gain on a single deployment.

# Status
No improvement whatsoever, PR has been closed.