### PR TITLE
DevOps - Resolve app version from git tags, instead of package.json

### DIFF
--- a/.github/workflows/auto-git-release.yml
+++ b/.github/workflows/auto-git-release.yml
@@ -51,7 +51,8 @@ jobs:
 
       # Auto-release (as pre-release) when a commit hit another branch
       - uses: marvinpinto/action-automatic-releases@10bdce64abdb4558a2ee6983192242be40d631d8 # Pin "latest" https://github.com/marvinpinto/action-automatic-releases/commit/10bdce64abdb4558a2ee6983192242be40d631d8 necessary to avoid "The `set-env` command is disabled."
-        if: startsWith(env.GITHUB_REF_SLUG, 'v2-') || env.GITHUB_REF_SLUG == 'master' || env.GITHUB_REF_SLUG == 'main' # If master, mark release as official release
+        # When using "!", mut use expression syntax - See https://github.community/t/if-not-startswith-mutually-exclusive-steps/141841/2?u=vadorequest
+        if: ${{ !startsWith(env.GITHUB_REF_SLUG, 'v2-') && env.GITHUB_REF_SLUG != 'master' && env.GITHUB_REF_SLUG != 'main' }} # If not master, mark release as pre-release and include branch name to avoid tagging conflicts
         with: # See https://github.com/marvinpinto/action-automatic-releases/tree/v1.1.0#supported-parameters
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: v${{steps.next_semantic_version.outputs.version}}

--- a/.github/workflows/auto-git-release.yml
+++ b/.github/workflows/auto-git-release.yml
@@ -36,7 +36,6 @@ jobs:
           echo "Next version: ${{steps.next_semantic_version.outputs.version}}"
           echo "Next version tag: ${{steps.next_semantic_version.outputs.version_tag}}"
 
-      # Auto-release when a commit hit "master"
       - uses: marvinpinto/action-automatic-releases@10bdce64abdb4558a2ee6983192242be40d631d8 # Pin "latest" https://github.com/marvinpinto/action-automatic-releases/commit/10bdce64abdb4558a2ee6983192242be40d631d8 necessary to avoid "The `set-env` command is disabled."
         if: startsWith(env.GITHUB_REF_SLUG, 'v2-') || env.GITHUB_REF_SLUG == 'master' || env.GITHUB_REF_SLUG == 'main' # If master, mark release as official release
         with: # See https://github.com/marvinpinto/action-automatic-releases/tree/v1.1.0#supported-parameters
@@ -49,7 +48,6 @@ jobs:
             CHANGELOG.md
             LICENSE
 
-      # Auto-release (as pre-release) when a commit hit another branch
       - uses: marvinpinto/action-automatic-releases@10bdce64abdb4558a2ee6983192242be40d631d8 # Pin "latest" https://github.com/marvinpinto/action-automatic-releases/commit/10bdce64abdb4558a2ee6983192242be40d631d8 necessary to avoid "The `set-env` command is disabled."
         if: !startsWith(env.GITHUB_REF_SLUG, 'v2-') && env.GITHUB_REF_SLUG != 'master' && env.GITHUB_REF_SLUG != 'main' # If not master, mark release as pre-release and include branch name to avoid tagging conflicts
         with: # See https://github.com/marvinpinto/action-automatic-releases/tree/v1.1.0#supported-parameters

--- a/.github/workflows/auto-git-release.yml
+++ b/.github/workflows/auto-git-release.yml
@@ -36,6 +36,7 @@ jobs:
           echo "Next version: ${{steps.next_semantic_version.outputs.version}}"
           echo "Next version tag: ${{steps.next_semantic_version.outputs.version_tag}}"
 
+      # Auto-release when a commit hit "master"
       - uses: marvinpinto/action-automatic-releases@10bdce64abdb4558a2ee6983192242be40d631d8 # Pin "latest" https://github.com/marvinpinto/action-automatic-releases/commit/10bdce64abdb4558a2ee6983192242be40d631d8 necessary to avoid "The `set-env` command is disabled."
         if: startsWith(env.GITHUB_REF_SLUG, 'v2-') || env.GITHUB_REF_SLUG == 'master' || env.GITHUB_REF_SLUG == 'main' # If master, mark release as official release
         with: # See https://github.com/marvinpinto/action-automatic-releases/tree/v1.1.0#supported-parameters
@@ -48,8 +49,9 @@ jobs:
             CHANGELOG.md
             LICENSE
 
+      # Auto-release (as pre-release) when a commit hit another branch
       - uses: marvinpinto/action-automatic-releases@10bdce64abdb4558a2ee6983192242be40d631d8 # Pin "latest" https://github.com/marvinpinto/action-automatic-releases/commit/10bdce64abdb4558a2ee6983192242be40d631d8 necessary to avoid "The `set-env` command is disabled."
-        if: !startsWith(env.GITHUB_REF_SLUG, 'v2-') && env.GITHUB_REF_SLUG != 'master' && env.GITHUB_REF_SLUG != 'main' # If not master, mark release as pre-release and include branch name to avoid tagging conflicts
+        if: startsWith(env.GITHUB_REF_SLUG, 'v2-') || env.GITHUB_REF_SLUG == 'master' || env.GITHUB_REF_SLUG == 'main' # If master, mark release as official release
         with: # See https://github.com/marvinpinto/action-automatic-releases/tree/v1.1.0#supported-parameters
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: v${{steps.next_semantic_version.outputs.version}}

--- a/.github/workflows/auto-git-release.yml
+++ b/.github/workflows/auto-git-release.yml
@@ -8,10 +8,8 @@
 name: 'Auto release'
 on:
   push:
-    branches: # You'll likely want to release on either main or master
-      - main
-      - master
-      - 'v2-*' # XXX NRN releases on v2 branches
+    branches:
+      - '*'
 
 jobs:
   tag-and-release:
@@ -37,12 +35,28 @@ jobs:
           echo ${{join(steps.next_semantic_version.outputs.*, ' - ')}}
           echo "Next version: ${{steps.next_semantic_version.outputs.version}}"
           echo "Next version tag: ${{steps.next_semantic_version.outputs.version_tag}}"
+
+      # Auto-release when a commit hit "master"
       - uses: marvinpinto/action-automatic-releases@10bdce64abdb4558a2ee6983192242be40d631d8 # Pin "latest" https://github.com/marvinpinto/action-automatic-releases/commit/10bdce64abdb4558a2ee6983192242be40d631d8 necessary to avoid "The `set-env` command is disabled."
+        if: startsWith(env.GITHUB_REF_SLUG, 'v2-') || env.GITHUB_REF_SLUG == 'master' || env.GITHUB_REF_SLUG == 'main' # If master, mark release as official release
         with: # See https://github.com/marvinpinto/action-automatic-releases/tree/v1.1.0#supported-parameters
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: v${{steps.next_semantic_version.outputs.version}}
           prerelease: false
           title: "Automatic release ${{steps.next_semantic_version.outputs.version_tag}} (`${{ env.GITHUB_REF_SLUG }}`)"
+          files: |
+            README.md
+            CHANGELOG.md
+            LICENSE
+
+      # Auto-release (as pre-release) when a commit hit another branch
+      - uses: marvinpinto/action-automatic-releases@10bdce64abdb4558a2ee6983192242be40d631d8 # Pin "latest" https://github.com/marvinpinto/action-automatic-releases/commit/10bdce64abdb4558a2ee6983192242be40d631d8 necessary to avoid "The `set-env` command is disabled."
+        if: !startsWith(env.GITHUB_REF_SLUG, 'v2-') && env.GITHUB_REF_SLUG != 'master' && env.GITHUB_REF_SLUG != 'main' # If not master, mark release as pre-release and include branch name to avoid tagging conflicts
+        with: # See https://github.com/marvinpinto/action-automatic-releases/tree/v1.1.0#supported-parameters
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: v${{steps.next_semantic_version.outputs.version}}
+          prerelease: true
+          title: "Automatic pre-release ${{steps.next_semantic_version.outputs.version_tag}} (`${{ env.GITHUB_REF_SLUG }}`)"
           files: |
             README.md
             CHANGELOG.md

--- a/process.env.d.ts
+++ b/process.env.d.ts
@@ -20,7 +20,6 @@ declare global {
       NEXT_PUBLIC_AMPLITUDE_API_KEY: string;
       NEXT_PUBLIC_APP_BUILD_ID: string;
       NEXT_PUBLIC_APP_NAME: string;
-      NEXT_PUBLIC_APP_VERSION: string;
       NEXT_PUBLIC_APP_NAME_VERSION: string;
       NEXT_PUBLIC_APP_VERSION_RELEASE: string;
       NEXT_PUBLIC_APP_STAGE: 'test' | 'development' | 'staging' | 'production';

--- a/src/components/appBootstrap/BrowserPageBootstrap.tsx
+++ b/src/components/appBootstrap/BrowserPageBootstrap.tsx
@@ -149,7 +149,7 @@ const BrowserPageBootstrap = (props: BrowserPageBootstrapProps): JSX.Element => 
         eventProperties={{
           app: {
             name: process.env.NEXT_PUBLIC_APP_NAME,
-            version: process.env.NEXT_PUBLIC_APP_VERSION,
+            release: process.env.NEXT_PUBLIC_APP_VERSION_RELEASE,
             stage: process.env.NEXT_PUBLIC_APP_STAGE,
             preset: process.env.NEXT_PUBLIC_NRN_PRESET,
           },

--- a/src/pages/[locale]/examples/built-in-features/analytics.tsx
+++ b/src/pages/[locale]/examples/built-in-features/analytics.tsx
@@ -122,7 +122,7 @@ const ExampleAnalyticsPage: NextPage<Props> = (props): JSX.Element => {
                     eventProperties={{
                       app: {
                         name: process.env.NEXT_PUBLIC_APP_NAME,
-                        version: process.env.NEXT_PUBLIC_APP_VERSION,
+                        release: process.env.NEXT_PUBLIC_APP_VERSION_RELEASE,
                         stage: process.env.NEXT_PUBLIC_APP_STAGE,
                         preset: process.env.NEXT_PUBLIC_NRN_PRESET,
                       },
@@ -160,7 +160,7 @@ const ExampleAnalyticsPage: NextPage<Props> = (props): JSX.Element => {
                   sameSite: 'Strict', // 'Strict' | 'Lax' | 'None' - See https://web.dev/samesite-cookies-explained/
                 });
 
-                amplitudeInstance.setVersionName(process.env.NEXT_PUBLIC_APP_VERSION); // e.g: 1.0.0
+                amplitudeInstance.setVersionName(process.env.NEXT_PUBLIC_APP_VERSION_RELEASE); // e.g: v1.0.0
 
                 // We're only doing this when detecting a new session, as it won't be executed multiple times for the same session anyway, and it avoids noise
                 if (amplitudeInstance.isNewSession()) {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -102,7 +102,7 @@ class AppDocument extends Document<DocumentRenderProps> {
             // For customer/stage/version based styles, could be handy in rare cases
             `${process.env.NEXT_PUBLIC_CUSTOMER_REF}`,
             `stage-${process.env.NEXT_PUBLIC_APP_STAGE}`,
-            `v${process.env.NEXT_PUBLIC_APP_VERSION}`, // From package.json:version
+            `v${process.env.NEXT_PUBLIC_APP_VERSION_RELEASE}`,
           )}
         >
           <Main />

--- a/src/pages/api/status.ts
+++ b/src/pages/api/status.ts
@@ -29,7 +29,6 @@ export const status = async (req: NextApiRequest, res: NextApiResponse): Promise
     res.json({
       appStage: process.env.NEXT_PUBLIC_APP_STAGE,
       appName: process.env.NEXT_PUBLIC_APP_NAME,
-      appVersion: process.env.NEXT_PUBLIC_APP_VERSION,
       appRelease: process.env.NEXT_PUBLIC_APP_VERSION_RELEASE,
       appBuildTime: process.env.NEXT_PUBLIC_APP_BUILD_TIME,
       appBuildTimestamp: process.env.NEXT_PUBLIC_APP_BUILD_TIMESTAMP,

--- a/src/utils/analytics/amplitude.ts
+++ b/src/utils/analytics/amplitude.ts
@@ -101,7 +101,7 @@ export const getAmplitudeInstance = (props: GetAmplitudeInstanceProps): Amplitud
       console.info(`User has opted-in into analytics tracking. (Thank you! This helps us make our product better, and we don't track any personal/identifiable data.`); // eslint-disable-line no-console
     }
 
-    amplitudeInstance.setVersionName(process.env.NEXT_PUBLIC_APP_VERSION); // e.g: 1.0.0
+    amplitudeInstance.setVersionName(process.env.NEXT_PUBLIC_APP_VERSION_RELEASE); // e.g: v1.0.0
 
     // We're only doing this when detecting a new session, as it won't be executed multiple times for the same session anyway, and it avoids noise
     if (amplitudeInstance.isNewSession()) {
@@ -166,13 +166,13 @@ export const sendWebVitals = (report: NextWebVitalsMetricsReport): void => {
       cookieExpiration: 365, // Expires in 1 year (would fallback to 10 years by default, which isn't GDPR compliant)
     });
 
-    amplitudeInstance.setVersionName(process.env.NEXT_PUBLIC_APP_VERSION); // e.g: 1.0.0
+    amplitudeInstance.setVersionName(process.env.NEXT_PUBLIC_APP_VERSION_RELEASE); // e.g: v1.0.0
 
     // Sen metrics to our analytics service
     amplitudeInstance.logEvent(`report-web-vitals`, {
       app: {
         name: process.env.NEXT_PUBLIC_APP_NAME,
-        version: process.env.NEXT_PUBLIC_APP_VERSION,
+        release: process.env.NEXT_PUBLIC_APP_VERSION_RELEASE,
         stage: process.env.NEXT_PUBLIC_APP_STAGE,
         preset: process.env.NEXT_PUBLIC_NRN_PRESET,
       },

--- a/src/utils/env/env.test.ts
+++ b/src/utils/env/env.test.ts
@@ -41,15 +41,6 @@ describe(`utils/env/env.ts`, () => {
       }
     });
 
-    test(`NEXT_PUBLIC_APP_VERSION`, async () => {
-      // This ENV var is injected by Webpack and not available when running the tests suite when building a local build (because webpack hasn't been executed yet)
-      if (process.env.NODE_ENV === 'production') {
-        expect(process.env.NEXT_PUBLIC_APP_VERSION, 'NEXT_PUBLIC_APP_VERSION must be defined but is not').toBeDefined();
-      } else {
-        expect(process.env.NEXT_PUBLIC_APP_VERSION, 'NEXT_PUBLIC_APP_VERSION should not be defined when building a non-production release').not.toBeDefined();
-      }
-    });
-
     test(`NEXT_PUBLIC_APP_VERSION_RELEASE`, async () => {
       // This ENV var is injected by Webpack and not available when running the tests suite when building a local build (because webpack hasn't been executed yet)
       if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
Previously resolved from package.json, support for this was dropped recently, because it's not a great way to know about the version in an automated system. Also, the package.json:version is meant for NPM packages in the first place, not apps outside the NPM environment.

Since we recently provided support for Git tags as ENV var, a new way using git tags has been implemented to resolve the release version.