### PR TITLE
Fix "await-for-vercel-deployment" step

### DIFF
--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -123,6 +123,7 @@ jobs:
     runs-on: ubuntu-18.04
     needs: start-production-deployment
     steps:
+      - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
       - name: Resolving deployment url from Vercel
         # Workflow overview:
         #   - Resolve customer to deploy from github event input (falls back to resolving it from vercel.json file)

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -200,6 +200,7 @@ jobs:
     runs-on: ubuntu-18.04
     needs: start-staging-deployment
     steps:
+      - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
       - name: Resolving deployment url from Vercel
         # Workflow overview:
         #   - Resolve customer to deploy from github event input (falls back to resolving it from vercel.json file)


### PR DESCRIPTION
We had forgotten to pull our git commits prior to resolve the `CUSTOMER_REF`, which led to providing the wrong `TEAMD_ID` when fetching the Vercel deployments.