### PR TITLE
Implement restore-variable to clean our actions

### DIFF
--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -265,7 +265,7 @@ jobs:
           echo "Vercel deployment webhook url: " $VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK
 
           # Checking if a webhook url is defined
-          if [ -n  "$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK" ]; then
+          if [ -n "$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK" ]; then
             # Run script that populates git-related variables as ENV variables
             echo "Running script populate-git-env.sh"
             . ./scripts/populate-git-env.sh
@@ -374,7 +374,7 @@ jobs:
           config: baseUrl=${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
         env:
           # Enables Cypress debugging logs, very useful if Cypress crashes, like out-of-memory issues.
-          #          DEBUG: "cypress:*" # Enable all logs. See https://docs.cypress.io/guides/references/troubleshooting.html#Print-DEBUG-logs
+          # DEBUG: "cypress:*" # Enable all logs. See https://docs.cypress.io/guides/references/troubleshooting.html#Print-DEBUG-logs
           DEBUG: "cypress:server:util:process_profiler" # Enable logs for "memory and CPU usage". See https://docs.cypress.io/guides/references/troubleshooting.html#Log-memory-and-CPU-usage
 
       # On E2E failure, upload screenshots

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -215,7 +215,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
 
-      # Restore variables stored in previous jobs
+      # Restore variables stored by previous jobs
       - name: Restore variables
         uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
@@ -246,7 +246,7 @@ jobs:
       - name: Expose GitHub slug/short variables # See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
         uses: rlespinasse/github-slug-action@v3.x # See https://github.com/rlespinasse/github-slug-action
 
-      # Restore variables stored in previous jobs
+      # Restore variables stored by previous jobs
       - name: Restore variables
         uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
@@ -355,7 +355,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
 
-      # Restore variables stored in previous jobs
+      # Restore variables stored by previous jobs
       - name: Restore variables
         uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
@@ -428,7 +428,7 @@ jobs:
       - name: Create temporary folder for artifacts storage
         run: mkdir /tmp/lighthouse-artifacts
 
-      # Restore variables stored in previous jobs
+      # Restore variables stored by previous jobs
       - name: Restore variables
         uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -21,6 +21,7 @@
 # - See https://github.com/jwalton/gh-find-current-pr https://github.com/jwalton/gh-find-current-pr/tree/v1
 # - See https://github.com/peter-evans/create-or-update-comment https://github.com/peter-evans/create-or-update-comment/tree/v1
 # - See https://github.com/UnlyEd/github-action-await-vercel https://github.com/UnlyEd/github-action-await-vercel/tree/v1.1.1
+# - See https://github.com/UnlyEd/github-action-store-variable https://github.com/UnlyEd/github-action-store-variable/tree/v1.0.1
 # - See https://github.com/rlespinasse/github-slug-action https://github.com/rlespinasse/github-slug-action/tree/v3.x
 # - See https://github.com/cypress-io/github-action https://github.com/cypress-io/github-action/tree/v2
 # - See https://github.com/foo-software/lighthouse-check-action https://github.com/foo-software/lighthouse-check-action/tree/v1.0.1
@@ -195,8 +196,10 @@ jobs:
             Commit ${{ github.sha }} successfully deployed to [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
             Deployment aliased as [${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }}](https://${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }})
 
+      # At the end of the job, store all variables we will need in the following jobs
+      # The variables will be stored in and retrieved from a GitHub Artifact (each variable is stored in a different file)
       - name: Store variables for next jobs
-        uses: UnlyEd/github-action-store-variable@v1.0.1
+        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         with:
           variables: |
             CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
@@ -211,11 +214,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
 
+      # Restore variables stored in previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1
+        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
-          variables: VERCEL_DEPLOYMENT_DOMAIN
+          variables: |
+            VERCEL_DEPLOYMENT_DOMAIN
 
       # Wait for deployment to be ready, before running E2E (otherwise Cypress might start testing too early, and gets redirected to Vercel's "Login page", and tests fail)
       - name: Awaiting Vercel deployment to be ready
@@ -240,19 +245,23 @@ jobs:
       - name: Expose GitHub slug/short variables # See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
         uses: rlespinasse/github-slug-action@v3.x # See https://github.com/rlespinasse/github-slug-action
 
-      - name: Restore CUSTOMER_REF_TO_DEPLOY
-        uses: UnlyEd/github-action-store-variable@v1.0.1
+      # Restore variables stored in previous jobs
+      - name: Restore variables
+        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
-          variables: CUSTOMER_REF_TO_DEPLOY
+          variables: |
+            CUSTOMER_REF_TO_DEPLOY
 
       - name: Expose git environment variables and call webhook (if provided)
         # Workflow overview:
         #  - Resolves webhook url from customer config file
         #  - If a webhook url was defined in the customer config file, send an HTTP request, as POST request, with a JSON request body dynamically generated
         #  - Prints the headers of the POST HTTP request (curl)
+        # TODO Convert this into an external bash script if possible, to simplify this step as much as possible
         run: |
           VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')
+          echo "Vercel deployment webhook url: " $VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK
 
           # Checking if a webhook url is defined
           if [ -n  "$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK" ]; then
@@ -318,6 +327,7 @@ jobs:
             echo "No webhook url defined in 'vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json:.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK' (found '$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')"
           fi
         env:
+          CUSTOMER_REF_TO_DEPLOY: ${{ fromJson(steps.restore-variable.outputs.variables).CUSTOMER_REF_TO_DEPLOY }}
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker
           GIT_COMMIT_SHA: ${{ github.sha }} # Passing current commit SHA to the worker
           # Passing exposed GitHub environment variables - See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
@@ -332,7 +342,6 @@ jobs:
           GITHUB_EVENT_REF_SLUG_URL: ${{ env.GITHUB_EVENT_REF_SLUG_URL }}
           GITHUB_REPOSITORY_SLUG_URL: ${{ env.GITHUB_REPOSITORY_SLUG_URL }}
           GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
-          CUSTOMER_REF_TO_DEPLOY: ${{ fromJson(steps.restore-variable.outputs.variables).CUSTOMER_REF_TO_DEPLOY }}
 
   # Runs E2E tests against the Vercel deployment
   run-2e2-tests:
@@ -344,11 +353,15 @@ jobs:
     needs: await-for-vercel-deployment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
-      - name: Restore VERCEL_DEPLOYMENT_URL
-        uses: UnlyEd/github-action-store-variable@v1.0.1
+
+      # Restore variables stored in previous jobs
+      - name: Restore variables
+        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
-          variables: VERCEL_DEPLOYMENT_URL
+          variables: |
+            VERCEL_DEPLOYMENT_URL
+
       # Runs the E2E tests against the new Vercel deployment
       - name: Run E2E tests (Cypress)
         uses: cypress-io/github-action@v2 # See https://github.com/cypress-io/github-action
@@ -416,14 +429,18 @@ jobs:
     needs: await-for-vercel-deployment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
+
       # To store reports and then upload them, we must create the folder beforehand
       - name: Create temporary folder for artifacts storage
         run: mkdir /tmp/lighthouse-artifacts
-      - name: Restore VERCEL_DEPLOYMENT_URL
-        uses: UnlyEd/github-action-store-variable@v1.0.1
+
+      # Restore variables stored in previous jobs
+      - name: Restore variables
+        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           variables: VERCEL_DEPLOYMENT_URL
+
       # Runs LightHouse for a given url and create HTML reports in the specified directory (outputDirectory)
       # Action documentation: https://github.com/marketplace/actions/lighthouse-check#usage-standard-example
       - name: Run Lighthouse

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -196,7 +196,7 @@ jobs:
             Deployment aliased as [${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }}](https://${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }})
 
       - name: Store variables for next jobs
-        uses: UnlyEd/github-action-store-variable@v1.0.0
+        uses: UnlyEd/github-action-store-variable@v1.0.1
         with:
           variables: |
             MANUAL_TRIGGER_CUSTOMER=${{ env.MANUAL_TRIGGER_CUSTOMER }}
@@ -215,7 +215,7 @@ jobs:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
 
       - name: Restore VERCEL_DEPLOYMENT
-        uses: UnlyEd/github-action-store-variable@v1.0.0
+        uses: UnlyEd/github-action-store-variable@v1.0.1
         id: restore-variable
         with:
           variables: VERCEL_DEPLOYMENT
@@ -244,7 +244,7 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x # See https://github.com/rlespinasse/github-slug-action
 
       - name: Restore VERCEL_DEPLOYMENT
-        uses: UnlyEd/github-action-store-variable@v1.0.0
+        uses: UnlyEd/github-action-store-variable@v1.0.1
         id: restore-variable
         with:
           variables: CUSTOMER_REF_TO_DEPLOY
@@ -258,7 +258,7 @@ jobs:
           VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')
 
           # Checking if a webhook url is defined
-          if [ -n "$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK" ]; then
+          if [ -n  "$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK" ]; then
             # Run script that populates git-related variables as ENV variables
             echo "Running script populate-git-env.sh"
             . ./scripts/populate-git-env.sh
@@ -348,7 +348,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
       - name: Restore VERCEL_DEPLOYMENT_URL
-        uses: UnlyEd/github-action-store-variable@v1.0.0
+        uses: UnlyEd/github-action-store-variable@v1.0.1
         id: restore-variable
         with:
           variables: VERCEL_DEPLOYMENT_URL
@@ -423,7 +423,7 @@ jobs:
       - name: Create temporary folder for artifacts storage
         run: mkdir /tmp/lighthouse-artifacts
       - name: Restore VERCEL_DEPLOYMENT_URL
-        uses: UnlyEd/github-action-store-variable@v1.0.0
+        uses: UnlyEd/github-action-store-variable@v1.0.1
         id: restore-variable
         with:
           variables: VERCEL_DEPLOYMENT_URL

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -195,15 +195,15 @@ jobs:
             Commit ${{ github.sha }} successfully deployed to [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
             Deployment aliased as [${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }}](https://${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }})
 
-        - name: Store variables for next jobs
-          uses: UnlyEd/github-action-store-variable@v1.0.0
-          with:
-            variables: |
-              MANUAL_TRIGGER_CUSTOMER=${{ env.MANUAL_TRIGGER_CUSTOMER }}
-              CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
-              VERCEL_DEPLOYMENT_URL=${{ env.VERCEL_DEPLOYMENT_URL }}
-              VERCEL_DEPLOYMENT=${{ env.VERCEL_DEPLOYMENT }}
-              VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS=${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }}
+      - name: Store variables for next jobs
+        uses: UnlyEd/github-action-store-variable@v1.0.0
+        with:
+          variables: |
+            MANUAL_TRIGGER_CUSTOMER=${{ env.MANUAL_TRIGGER_CUSTOMER }}
+            CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
+            VERCEL_DEPLOYMENT_URL=${{ env.VERCEL_DEPLOYMENT_URL }}
+            VERCEL_DEPLOYMENT=${{ env.VERCEL_DEPLOYMENT }}
+            VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS=${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }}
 
 
   # Waits for the Vercel deployment to reach "READY" state, so that other actions will be applied on a domain that is really online

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -97,6 +97,7 @@ jobs:
           VERCEL_DEPLOYMENT_URL=`echo $VERCEL_DEPLOYMENT_OUTPUT | egrep -o 'https?://[^ ]+.vercel.app'`
           echo "Deployment url: " $VERCEL_DEPLOYMENT_URL
           echo "VERCEL_DEPLOYMENT_URL=$VERCEL_DEPLOYMENT_URL" >> $GITHUB_ENV
+          echo "VERCEL_DEPLOYMENT=${VERCEL_DEPLOYMENT_URL#https://}" >> $GITHUB_ENV
 
           # Build the alias domain based on our own rules (NRN own rules)
           # Basically, if a branch starts with "v[0-9]" then we consider it to be a "preset branch" and we use the branch name as alias (e.g: "v2-mst-xxx")
@@ -179,7 +180,7 @@ jobs:
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             :x:&nbsp; Deployment **FAILED**
-            Commit ${{ github.sha }} failed to deploy to [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
+            Commit ${{ github.sha }} failed to deploy to [${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}](${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }})
             [click to see logs](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks)
 
       # On deployment success, add a comment to the PR, if there is an open PR for the current branch
@@ -194,6 +195,17 @@ jobs:
             Commit ${{ github.sha }} successfully deployed to [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
             Deployment aliased as [${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }}](https://${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }})
 
+        - name: Store variables for next jobs
+          uses: UnlyEd/github-action-store-variable@v1.0.0
+          with:
+            variables: |
+              MANUAL_TRIGGER_CUSTOMER=${{ env.MANUAL_TRIGGER_CUSTOMER }}
+              CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
+              VERCEL_DEPLOYMENT_URL=${{ env.VERCEL_DEPLOYMENT_URL }}
+              VERCEL_DEPLOYMENT=${{ env.VERCEL_DEPLOYMENT }}
+              VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS=${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }}
+
+
   # Waits for the Vercel deployment to reach "READY" state, so that other actions will be applied on a domain that is really online
   await-for-vercel-deployment:
     name: Await current deployment to be ready (Ubuntu 18.04)
@@ -201,51 +213,12 @@ jobs:
     needs: start-staging-deployment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
-      - name: Resolving deployment url from Vercel
-        # Workflow overview:
-        #   - Resolve customer to deploy from github event input (falls back to resolving it from vercel.json file)
-        #   - Resolve $VERCEL_DEPLOYMENT_URL
-        #     - Fetch all deployments data (by using the scope in `vercel.json`)
-        #     - Resolve the last url (from `response.deployments[0].url`)
-        #     - Remove the `"` character to pre-format url
-        # We need to set env the url for next step, formatted as `https://${$VERCEL_DEPLOYMENT}`
-        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
-        run: |
-          apt update -y >/dev/null && apt install -y jq >/dev/null
 
-          MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
-          echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
-          echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
-
-          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat vercel.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-          echo "Customer that was deployed: " $CUSTOMER_REF_TO_DEPLOY
-          echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
-
-          # Resolve Vercel team ID
-          VERCEL_TEAM_ID=`cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.scope'`
-          echo "Vercel team ID: " $VERCEL_TEAM_ID
-          echo "VERCEL_TEAM_ID=$VERCEL_TEAM_ID" >> $GITHUB_ENV
-
-          # Resolve Vercel project name
-          VERCEL_PROJECT_NAME=`cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.name'`
-          echo "Vercel project name: " $VERCEL_PROJECT_NAME
-          echo "VERCEL_PROJECT_NAME=$VERCEL_PROJECT_NAME" >> $GITHUB_ENV
-
-          # Build Vercel API endpoint used to fetch deployments
-          VERCEL_FETCH_DEPLOYMENTS_API_ENDPOINT="https://api.zeit.co/v5/now/deployments?teamId=$VERCEL_TEAM_ID"
-          echo "Fetching Vercel deployments using API endpoint: " $VERCEL_FETCH_DEPLOYMENTS_API_ENDPOINT
-
-          # Fetch all Vercel deployment from this project
-          ALL_VERCEL_DEPLOYMENTS=`curl -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}' $VERCEL_FETCH_DEPLOYMENTS_API_ENDPOINT`
-          echo "Vercel deployments for current team: " $ALL_VERCEL_DEPLOYMENTS
-
-          # Parse the deployments (as json) to find the latest deployment url, while stripping the double quotes
-          # TODO Do not use '.deployments [0].url' blindly, but filter the deployments array first to make sure to consider only the deployments where "name" is equal to $VERCEL_PROJECT_NAME
-          VERCEL_DEPLOYMENT=`echo $ALL_VERCEL_DEPLOYMENTS | jq '.deployments [0].url' | tr -d \"`
-          VERCEL_DEPLOYMENT_URL="https://$VERCEL_DEPLOYMENT"
-          echo "Url where to run E2E tests (VERCEL_DEPLOYMENT_URL): " $VERCEL_DEPLOYMENT_URL
-          echo "VERCEL_DEPLOYMENT_URL=$VERCEL_DEPLOYMENT_URL" >> $GITHUB_ENV
-          echo "VERCEL_DEPLOYMENT=$VERCEL_DEPLOYMENT" >> $GITHUB_ENV
+      - name: Restore VERCEL_DEPLOYMENT
+        uses: UnlyEd/github-action-store-variable@v1.0.0
+        id: restore-variable
+        with:
+          variables: VERCEL_DEPLOYMENT
 
       # Wait for deployment to be ready, before running E2E (otherwise Cypress might start testing too early, and gets redirected to Vercel's "Login page", and tests fail)
       - name: Awaiting Vercel deployment to be ready
@@ -254,7 +227,7 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEl_TOKEN }}
         with:
-          deployment-url: ${{ env.VERCEL_DEPLOYMENT }} # Must only contain the domain name (no http prefix, etc.)
+          deployment-url: ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT }} # Must only contain the domain name (no http prefix, etc.)
           timeout: 90 # Wait for 90 seconds before failing
 
       - name: Display deployment status
@@ -269,15 +242,19 @@ jobs:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
       - name: Expose GitHub slug/short variables # See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
         uses: rlespinasse/github-slug-action@v3.x # See https://github.com/rlespinasse/github-slug-action
+
+      - name: Restore VERCEL_DEPLOYMENT
+        uses: UnlyEd/github-action-store-variable@v1.0.0
+        id: restore-variable
+        with:
+          variables: CUSTOMER_REF_TO_DEPLOY
+
       - name: Expose git environment variables and call webhook (if provided)
         # Workflow overview:
         #  - Resolves webhook url from customer config file
         #  - If a webhook url was defined in the customer config file, send an HTTP request, as POST request, with a JSON request body dynamically generated
         #  - Prints the headers of the POST HTTP request (curl)
         run: |
-          MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
-          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat vercel.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-
           VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')
 
           # Checking if a webhook url is defined
@@ -358,6 +335,7 @@ jobs:
           GITHUB_EVENT_REF_SLUG_URL: ${{ env.GITHUB_EVENT_REF_SLUG_URL }}
           GITHUB_REPOSITORY_SLUG_URL: ${{ env.GITHUB_REPOSITORY_SLUG_URL }}
           GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
+          CUSTOMER_REF_TO_DEPLOY: ${{ fromJson(steps.restore-variable.outputs.variables).CUSTOMER_REF_TO_DEPLOY }}
 
   # Runs E2E tests against the Vercel deployment
   run-2e2-tests:
@@ -369,51 +347,19 @@ jobs:
     needs: await-for-vercel-deployment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
-      - name: Resolving deployment url from Vercel
-        run: |
-          apt update -y >/dev/null && apt install -y jq >/dev/null
-
-          MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
-          echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
-          echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
-
-          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat vercel.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-          echo "Customer that was deployed: " $CUSTOMER_REF_TO_DEPLOY
-          echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
-
-          # Resolve Vercel team ID
-          VERCEL_TEAM_ID=`cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.scope'`
-          echo "Vercel team ID: " $VERCEL_TEAM_ID
-          echo "VERCEL_TEAM_ID=$VERCEL_TEAM_ID" >> $GITHUB_ENV
-
-          # Resolve Vercel project name
-          VERCEL_PROJECT_NAME=`cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.name'`
-          echo "Vercel project name: " $VERCEL_PROJECT_NAME
-          echo "VERCEL_PROJECT_NAME=$VERCEL_PROJECT_NAME" >> $GITHUB_ENV
-
-          # Build Vercel API endpoint used to fetch deployments
-          VERCEL_FETCH_DEPLOYMENTS_API_ENDPOINT="https://api.zeit.co/v5/now/deployments?teamId=$VERCEL_TEAM_ID"
-          echo "Fetching Vercel deployments using API endpoint: " $VERCEL_FETCH_DEPLOYMENTS_API_ENDPOINT
-
-          # Fetch all Vercel deployment from this project
-          ALL_VERCEL_DEPLOYMENTS=`curl -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}' $VERCEL_FETCH_DEPLOYMENTS_API_ENDPOINT`
-          echo "Vercel deployments for current team: " $ALL_VERCEL_DEPLOYMENTS
-
-          # Parse the deployments (as json) to find the latest deployment url, while stripping the double quotes
-          # TODO Do not use '.deployments [0].url' blindly, but filter the deployments array first to make sure to consider only the deployments where "name" is equal to $VERCEL_PROJECT_NAME
-          VERCEL_DEPLOYMENT=`echo $ALL_VERCEL_DEPLOYMENTS | jq '.deployments [0].url' | tr -d \"`
-          VERCEL_DEPLOYMENT_URL="https://$VERCEL_DEPLOYMENT"
-          echo "Url where to run E2E tests (VERCEL_DEPLOYMENT_URL): " $VERCEL_DEPLOYMENT_URL
-          echo "VERCEL_DEPLOYMENT_URL=$VERCEL_DEPLOYMENT_URL" >> $GITHUB_ENV
-
+      - name: Restore VERCEL_DEPLOYMENT_URL
+        uses: UnlyEd/github-action-store-variable@v1.0.0
+        id: restore-variable
+        with:
+          variables: VERCEL_DEPLOYMENT_URL
       # Runs the E2E tests against the new Vercel deployment
       - name: Run E2E tests (Cypress)
         uses: cypress-io/github-action@v2 # See https://github.com/cypress-io/github-action
         with:
           # XXX We disabled "wait-on" option, because it's useless. Cypress will fail anyway, because it gets redirected to some internal Vercel URL if the domain isn't yet available - See https://github.com/cypress-io/github-action/issues/270
-          # wait-on: '${{ env.VERCEL_DEPLOYMENT_URL }}' # Be sure that the endpoint is ready by pinging it before starting tests, using a default timeout of 60 seconds
+          # wait-on: '${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}' # Be sure that the endpoint is ready by pinging it before starting tests, using a default timeout of 60 seconds
           config-file: 'cypress/config-customer-ci-cd.json' # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
-          config: baseUrl=${{ env.VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
+          config: baseUrl=${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
         env:
           # Enables Cypress debugging logs, very useful if Cypress crashes, like out-of-memory issues.
           #          DEBUG: "cypress:*" # Enable all logs. See https://docs.cypress.io/guides/references/troubleshooting.html#Print-DEBUG-logs
@@ -451,7 +397,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
-            :x:&nbsp; E2E tests **FAILED** for commit ${{ github.sha }} previously deployed at [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
+            :x:&nbsp; E2E tests **FAILED** for commit ${{ github.sha }} previously deployed at [${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}](${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }})
             Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks) section
 
       # On E2E success, add a comment to the PR, if there is an open PR for the current branch
@@ -462,7 +408,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
-            :white_check_mark:&nbsp; E2E tests **SUCCESS** for commit ${{ github.sha }} previously deployed at [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
+            :white_check_mark:&nbsp; E2E tests **SUCCESS** for commit ${{ github.sha }} previously deployed at [${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}](${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }})
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -473,56 +419,14 @@ jobs:
     needs: await-for-vercel-deployment
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
-      - name: Resolving deployment url from Vercel
-        # Workflow overview:
-        #   - Resolve customer to deploy from github event input (falls back to resolving it from vercel.json file)
-        #   - Resolve $VERCEL_DEPLOYMENT_URL
-        #     - Fetch all deployments data (by using the scope in `vercel.json`)
-        #     - Resolve the last url (from `response.deployments[0].url`)
-        #     - Remove the `"` character to pre-format url
-        # We need to set env the url for next step, formatted as `https://${$VERCEL_DEPLOYMENT}/en` using /en endpoint to improve perfs by avoiding the url redirect on /
-        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
-        run: |
-          apt update -y >/dev/null && apt install -y jq >/dev/null
-
-          MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
-          echo "MANUAL_TRIGGER_CUSTOMER: " $MANUAL_TRIGGER_CUSTOMER
-          echo "MANUAL_TRIGGER_CUSTOMER=$MANUAL_TRIGGER_CUSTOMER" >> $GITHUB_ENV
-
-          CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat vercel.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
-          echo "Customer that was deployed: " $CUSTOMER_REF_TO_DEPLOY
-          echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
-
-          # Resolve Vercel team ID
-          VERCEL_TEAM_ID=`cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.scope'`
-          echo "Vercel team ID: " $VERCEL_TEAM_ID
-          echo "VERCEL_TEAM_ID=$VERCEL_TEAM_ID" >> $GITHUB_ENV
-
-          # Resolve Vercel project name
-          VERCEL_PROJECT_NAME=`cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.name'`
-          echo "Vercel project name: " $VERCEL_PROJECT_NAME
-          echo "VERCEL_PROJECT_NAME=$VERCEL_PROJECT_NAME" >> $GITHUB_ENV
-
-          # Build Vercel API endpoint used to fetch deployments
-          VERCEL_FETCH_DEPLOYMENTS_API_ENDPOINT="https://api.zeit.co/v5/now/deployments?teamId=$VERCEL_TEAM_ID"
-          echo "Fetching Vercel deployments using API endpoint: " $VERCEL_FETCH_DEPLOYMENTS_API_ENDPOINT
-
-          # Fetch all Vercel deployment from this project
-          ALL_VERCEL_DEPLOYMENTS=`curl -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}' $VERCEL_FETCH_DEPLOYMENTS_API_ENDPOINT`
-          echo "Vercel deployments for current team: " $ALL_VERCEL_DEPLOYMENTS
-
-          # Parse the deployments (as json) to find the latest deployment url, while stripping the double quotes
-          # TODO Do not use '.deployments [0].url' blindly, but filter the deployments array first to make sure to consider only the deployments where "name" is equal to $VERCEL_PROJECT_NAME
-          VERCEL_DEPLOYMENT=`echo $ALL_VERCEL_DEPLOYMENTS | jq '.deployments [0].url' | tr -d \"`
-          VERCEL_DEPLOYMENT_URL="https://$VERCEL_DEPLOYMENT"
-          echo "Url where to run LightHouse tests (VERCEL_DEPLOYMENT_URL): " $VERCEL_DEPLOYMENT_URL
-          echo "VERCEL_DEPLOYMENT_URL=$VERCEL_DEPLOYMENT_URL" >> $GITHUB_ENV
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }} # Passing github's secret to the worker
       # To store reports and then upload them, we must create the folder beforehand
       - name: Create temporary folder for artifacts storage
         run: mkdir /tmp/lighthouse-artifacts
-
+      - name: Restore VERCEL_DEPLOYMENT_URL
+        uses: UnlyEd/github-action-store-variable@v1.0.0
+        id: restore-variable
+        with:
+          variables: VERCEL_DEPLOYMENT_URL
       # Runs LightHouse for a given url and create HTML reports in the specified directory (outputDirectory)
       # Action documentation: https://github.com/marketplace/actions/lighthouse-check#usage-standard-example
       - name: Run Lighthouse
@@ -535,7 +439,7 @@ jobs:
           prCommentSaveOld: true # If true, then add a new comment for each commit. Otherwise, update the latest comment (default: false).
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           emulatedFormFactor: all # Run LightHouse against "mobile", "desktop", or "all" devices
-          urls: ${{ env.VERCEL_DEPLOYMENT_URL }}, ${{ env.VERCEL_DEPLOYMENT_URL }}/en, ${{ env.VERCEL_DEPLOYMENT_URL }}/fr
+          urls: ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}, ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}/en, ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}/fr
           locale: en
 
       # Upload HTML report created by lighthouse as an artifact.

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -252,6 +252,7 @@ jobs:
         id: restore-variable
         with:
           variables: |
+            MANUAL_TRIGGER_CUSTOMER
             CUSTOMER_REF_TO_DEPLOY
 
       - name: Expose git environment variables and call webhook (if provided)

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -97,7 +97,7 @@ jobs:
           VERCEL_DEPLOYMENT_URL=`echo $VERCEL_DEPLOYMENT_OUTPUT | egrep -o 'https?://[^ ]+.vercel.app'`
           echo "Deployment url: " $VERCEL_DEPLOYMENT_URL
           echo "VERCEL_DEPLOYMENT_URL=$VERCEL_DEPLOYMENT_URL" >> $GITHUB_ENV
-          echo "VERCEL_DEPLOYMENT=${VERCEL_DEPLOYMENT_URL#https://}" >> $GITHUB_ENV
+          echo "VERCEL_DEPLOYMENT_DOMAIN=${VERCEL_DEPLOYMENT_URL#https://}" >> $GITHUB_ENV
 
           # Build the alias domain based on our own rules (NRN own rules)
           # Basically, if a branch starts with "v[0-9]" then we consider it to be a "preset branch" and we use the branch name as alias (e.g: "v2-mst-xxx")
@@ -201,8 +201,7 @@ jobs:
           variables: |
             CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
             VERCEL_DEPLOYMENT_URL=${{ env.VERCEL_DEPLOYMENT_URL }}
-            VERCEL_DEPLOYMENT=${{ env.VERCEL_DEPLOYMENT }}
-
+            VERCEL_DEPLOYMENT_DOMAIN=${{ env.VERCEL_DEPLOYMENT_DOMAIN }}
 
   # Waits for the Vercel deployment to reach "READY" state, so that other actions will be applied on a domain that is really online
   await-for-vercel-deployment:
@@ -212,11 +211,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
 
-      - name: Restore VERCEL_DEPLOYMENT
+      - name: Restore variables
         uses: UnlyEd/github-action-store-variable@v1.0.1
         id: restore-variable
         with:
-          variables: VERCEL_DEPLOYMENT
+          variables: VERCEL_DEPLOYMENT_DOMAIN
 
       # Wait for deployment to be ready, before running E2E (otherwise Cypress might start testing too early, and gets redirected to Vercel's "Login page", and tests fail)
       - name: Awaiting Vercel deployment to be ready
@@ -225,7 +224,7 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEl_TOKEN }}
         with:
-          deployment-url: ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT }} # Must only contain the domain name (no http prefix, etc.)
+          deployment-url: ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_DOMAIN }} # Must only contain the domain name (no http prefix, etc.)
           timeout: 90 # Wait for 90 seconds before failing
 
       - name: Display deployment status

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -205,6 +205,7 @@ jobs:
             CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
             VERCEL_DEPLOYMENT_URL=${{ env.VERCEL_DEPLOYMENT_URL }}
             VERCEL_DEPLOYMENT_DOMAIN=${{ env.VERCEL_DEPLOYMENT_DOMAIN }}
+            GITHUB_PULL_REQUEST_ID=${{ steps.pr_id_finder.outputs.number }}
 
   # Waits for the Vercel deployment to reach "READY" state, so that other actions will be applied on a domain that is really online
   await-for-vercel-deployment:
@@ -361,6 +362,7 @@ jobs:
         with:
           variables: |
             VERCEL_DEPLOYMENT_URL
+            GITHUB_PULL_REQUEST_ID
 
       # Runs the E2E tests against the new Vercel deployment
       - name: Run E2E tests (Cypress)
@@ -391,32 +393,24 @@ jobs:
           name: videos
           path: cypress/videos/
 
-      # We need to find the PR id. Will be used later to comment on that PR.
-      - name: Finding Pull Request ID
-        uses: jwalton/gh-find-current-pr@v1 # See https://github.com/jwalton/gh-find-current-pr
-        id: pr_id_finder
-        if: always() # Forces the job to be always executed, even if a previous job fail.
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       # On E2E failure, add a comment to the PR with additional information, if there is an open PR for the current branch
       - name: Comment PR (E2E failure)
         uses: peter-evans/create-or-update-comment@v1 # See https://github.com/peter-evans/create-or-update-comment
-        if: steps.pr_id_finder.outputs.number && failure()
+        if: fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID && success()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ steps.pr_id_finder.outputs.number }}
+          issue-number: ${{ fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID }}
           body: |
             :x:&nbsp; E2E tests **FAILED** for commit ${{ github.sha }} previously deployed at [${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}](${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }})
-            Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks) section
+            Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID }}/checks) section
 
       # On E2E success, add a comment to the PR, if there is an open PR for the current branch
       - name: Comment PR (E2E success)
         uses: peter-evans/create-or-update-comment@v1 # See https://github.com/peter-evans/create-or-update-comment
-        if: steps.pr_id_finder.outputs.number && success()
+        if: fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID && success()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ steps.pr_id_finder.outputs.number }}
+          issue-number: ${{ fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID }}
           body: |
             :white_check_mark:&nbsp; E2E tests **SUCCESS** for commit ${{ github.sha }} previously deployed at [${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}](${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }})
         env:

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -199,11 +199,9 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v1.0.1
         with:
           variables: |
-            MANUAL_TRIGGER_CUSTOMER=${{ env.MANUAL_TRIGGER_CUSTOMER }}
             CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
             VERCEL_DEPLOYMENT_URL=${{ env.VERCEL_DEPLOYMENT_URL }}
             VERCEL_DEPLOYMENT=${{ env.VERCEL_DEPLOYMENT }}
-            VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS=${{ env.VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS }}
 
 
   # Waits for the Vercel deployment to reach "READY" state, so that other actions will be applied on a domain that is really online
@@ -243,7 +241,7 @@ jobs:
       - name: Expose GitHub slug/short variables # See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
         uses: rlespinasse/github-slug-action@v3.x # See https://github.com/rlespinasse/github-slug-action
 
-      - name: Restore VERCEL_DEPLOYMENT
+      - name: Restore CUSTOMER_REF_TO_DEPLOY
         uses: UnlyEd/github-action-store-variable@v1.0.1
         id: restore-variable
         with:

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -180,7 +180,7 @@ jobs:
           issue-number: ${{ steps.pr_id_finder.outputs.number }}
           body: |
             :x:&nbsp; Deployment **FAILED**
-            Commit ${{ github.sha }} failed to deploy to [${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}](${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }})
+            Commit ${{ github.sha }} failed to deploy to [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
             [click to see logs](https://github.com/UnlyEd/next-right-now/pull/${{ steps.pr_id_finder.outputs.number }}/checks)
 
       # On deployment success, add a comment to the PR, if there is an open PR for the current branch
@@ -357,7 +357,7 @@ jobs:
         uses: cypress-io/github-action@v2 # See https://github.com/cypress-io/github-action
         with:
           # XXX We disabled "wait-on" option, because it's useless. Cypress will fail anyway, because it gets redirected to some internal Vercel URL if the domain isn't yet available - See https://github.com/cypress-io/github-action/issues/270
-          # wait-on: '${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}' # Be sure that the endpoint is ready by pinging it before starting tests, using a default timeout of 60 seconds
+          # wait-on: '${{ env.VERCEL_DEPLOYMENT_URL }}' # Be sure that the endpoint is ready by pinging it before starting tests, using a default timeout of 60 seconds
           config-file: 'cypress/config-customer-ci-cd.json' # The config file itself doesn't matter because we will override most settings anyway. We just need `projectId` to run the tests.
           config: baseUrl=${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
         env:


### PR DESCRIPTION
Use https://github.com/UnlyEd/github-action-store-variable to share our variables across different jobs, thus reducing the code needed and avoiding code duplication as much as possible.

Also, it fixes an issue with E2E tests when deploying multiple commits in parallel, because we don't mistakenly await for the latest Vercel deployment, but await for the correct deployment instead.

# Status
This PR only affects "staging" for now, we'll make another one that changes the "production" script.

Also, we'll change the github action implementation to restore variables as ENV variables for use of writing/DX. (later)