### PR TITLE
Only keep one test for smaller reproduction - See https://github.com/facebook/react/issues/20568

### DIFF
--- a/src/components/i18n/I18nLink.test.tsx
+++ b/src/components/i18n/I18nLink.test.tsx
@@ -36,86 +36,86 @@ describe('I18nLink', () => {
       expect(link).toMatchSnapshot();
     });
 
-    test('when using custom CSS class', () => {
-      const renderer = TestRenderer.create(<I18nLinkTest href={'/'} className="customClassName" />);
-      const link: any = renderer.toJSON();
-
-      expect(link.type).toEqual('a');
-      expect(link.children).toEqual(['Text']);
-      expect(link.props.href).toEqual('/en');
-      expect(link.props.className).toEqual('customClassName');
-      expect(link).toMatchSnapshot();
-    });
-
-    test('when forcing the locale to use', () => {
-      const renderer = TestRenderer.create(<I18nLinkTest href={'/'} locale={'fr-FR'} />);
-      const link: any = renderer.toJSON();
-
-      expect(link.type).toEqual('a');
-      expect(link.children).toEqual(['Text']);
-      expect(link.props.href).toEqual('/fr-FR');
-      expect(link).toMatchSnapshot();
-    });
-
-    test('when using wrapChildrenAsLink manually using a <a> element', () => {
-      const renderer = TestRenderer.create(<I18nLinkTest href={'/'} wrapChildrenAsLink={false} text={<a>Page</a>} />);
-      const link: any = renderer.toJSON();
-
-      expect(link.type).toEqual('a');
-      expect(link.children).toEqual(['Page']);
-      expect(link.props.href).toEqual('/en');
-      expect(link).toMatchSnapshot();
-    });
-
-    test('when using wrapChildrenAsLink manually using a <NavLink> element', () => {
-      const renderer = TestRenderer.create(<I18nLinkTest href={'/'} wrapChildrenAsLink={false} text={<NavLink>Page</NavLink>} />);
-      const link: any = renderer.toJSON();
-
-      expect(link.type).toEqual('a');
-      expect(link.children).toEqual(['Page']);
-      expect(link.props.href).toEqual('/en');
-      expect(link.props.className).toEqual('nav-link');
-      expect(link).toMatchSnapshot();
-    });
-
-    test('when using route params', () => {
-      const renderer = TestRenderer.create(<I18nLinkTest href={'/products/[id]'} params={{ id: 5 }} />);
-      const link: any = renderer.toJSON();
-
-      expect(link.type).toEqual('a');
-      expect(link.children).toEqual(['Text']);
-      expect(link.props.href).toEqual('/en/products/5');
-      expect(link).toMatchSnapshot();
-    });
-
-    test('when using route params and query route params', () => {
-      const renderer = TestRenderer.create(<I18nLinkTest href={'/products/[id]'} params={{ id: 5 }} query={{ userId: 1 }} />);
-      const link: any = renderer.toJSON();
-
-      expect(link.type).toEqual('a');
-      expect(link.children).toEqual(['Text']);
-      expect(link.props.href).toEqual('/en/products/5?userId=1');
-      expect(link).toMatchSnapshot();
-    });
-
-    test('when using route params and query route params using nested paths', () => {
-      const renderer = TestRenderer.create(<I18nLinkTest href={'/products/favourites/[id]'} params={{ id: 5 }} query={{ userId: 1 }} />);
-      const link: any = renderer.toJSON();
-
-      expect(link.type).toEqual('a');
-      expect(link.children).toEqual(['Text']);
-      expect(link.props.href).toEqual('/en/products/favourites/5?userId=1');
-      expect(link).toMatchSnapshot();
-    });
-
-    test('when using route params and query route params using nested paths and forcing locale', () => {
-      const renderer = TestRenderer.create(<I18nLinkTest href={'/products/favourites/[id]'} params={{ id: 5 }} query={{ userId: 1 }} locale={'fr'} />);
-      const link: any = renderer.toJSON();
-
-      expect(link.type).toEqual('a');
-      expect(link.children).toEqual(['Text']);
-      expect(link.props.href).toEqual('/fr/products/favourites/5?userId=1');
-      expect(link).toMatchSnapshot();
-    });
+  //   test('when using custom CSS class', () => {
+  //     const renderer = TestRenderer.create(<I18nLinkTest href={'/'} className="customClassName" />);
+  //     const link: any = renderer.toJSON();
+  //
+  //     expect(link.type).toEqual('a');
+  //     expect(link.children).toEqual(['Text']);
+  //     expect(link.props.href).toEqual('/en');
+  //     expect(link.props.className).toEqual('customClassName');
+  //     expect(link).toMatchSnapshot();
+  //   });
+  //
+  //   test('when forcing the locale to use', () => {
+  //     const renderer = TestRenderer.create(<I18nLinkTest href={'/'} locale={'fr-FR'} />);
+  //     const link: any = renderer.toJSON();
+  //
+  //     expect(link.type).toEqual('a');
+  //     expect(link.children).toEqual(['Text']);
+  //     expect(link.props.href).toEqual('/fr-FR');
+  //     expect(link).toMatchSnapshot();
+  //   });
+  //
+  //   test('when using wrapChildrenAsLink manually using a <a> element', () => {
+  //     const renderer = TestRenderer.create(<I18nLinkTest href={'/'} wrapChildrenAsLink={false} text={<a>Page</a>} />);
+  //     const link: any = renderer.toJSON();
+  //
+  //     expect(link.type).toEqual('a');
+  //     expect(link.children).toEqual(['Page']);
+  //     expect(link.props.href).toEqual('/en');
+  //     expect(link).toMatchSnapshot();
+  //   });
+  //
+  //   test('when using wrapChildrenAsLink manually using a <NavLink> element', () => {
+  //     const renderer = TestRenderer.create(<I18nLinkTest href={'/'} wrapChildrenAsLink={false} text={<NavLink>Page</NavLink>} />);
+  //     const link: any = renderer.toJSON();
+  //
+  //     expect(link.type).toEqual('a');
+  //     expect(link.children).toEqual(['Page']);
+  //     expect(link.props.href).toEqual('/en');
+  //     expect(link.props.className).toEqual('nav-link');
+  //     expect(link).toMatchSnapshot();
+  //   });
+  //
+  //   test('when using route params', () => {
+  //     const renderer = TestRenderer.create(<I18nLinkTest href={'/products/[id]'} params={{ id: 5 }} />);
+  //     const link: any = renderer.toJSON();
+  //
+  //     expect(link.type).toEqual('a');
+  //     expect(link.children).toEqual(['Text']);
+  //     expect(link.props.href).toEqual('/en/products/5');
+  //     expect(link).toMatchSnapshot();
+  //   });
+  //
+  //   test('when using route params and query route params', () => {
+  //     const renderer = TestRenderer.create(<I18nLinkTest href={'/products/[id]'} params={{ id: 5 }} query={{ userId: 1 }} />);
+  //     const link: any = renderer.toJSON();
+  //
+  //     expect(link.type).toEqual('a');
+  //     expect(link.children).toEqual(['Text']);
+  //     expect(link.props.href).toEqual('/en/products/5?userId=1');
+  //     expect(link).toMatchSnapshot();
+  //   });
+  //
+  //   test('when using route params and query route params using nested paths', () => {
+  //     const renderer = TestRenderer.create(<I18nLinkTest href={'/products/favourites/[id]'} params={{ id: 5 }} query={{ userId: 1 }} />);
+  //     const link: any = renderer.toJSON();
+  //
+  //     expect(link.type).toEqual('a');
+  //     expect(link.children).toEqual(['Text']);
+  //     expect(link.props.href).toEqual('/en/products/favourites/5?userId=1');
+  //     expect(link).toMatchSnapshot();
+  //   });
+  //
+  //   test('when using route params and query route params using nested paths and forcing locale', () => {
+  //     const renderer = TestRenderer.create(<I18nLinkTest href={'/products/favourites/[id]'} params={{ id: 5 }} query={{ userId: 1 }} locale={'fr'} />);
+  //     const link: any = renderer.toJSON();
+  //
+  //     expect(link.type).toEqual('a');
+  //     expect(link.children).toEqual(['Text']);
+  //     expect(link.props.href).toEqual('/fr/products/favourites/5?userId=1');
+  //     expect(link).toMatchSnapshot();
+  //   });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,15 +219,6 @@
     "@babel/helper-explode-assignable-expression" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helper-builder-react-jsx-experimental@^7.12.1":
-  version "7.12.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.4.tgz#55fc1ead5242caa0ca2875dcb8eed6d311e50f48"
-  integrity sha512-AjEa0jrQqNk7eDQOo0pTfUOwQBMF+xVqrausQwT9/rTKy0g04ggFNaJpaE09IQMn9yExluigWMJcj0WC7bq+Og==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.10.4"
-    "@babel/helper-module-imports" "^7.12.1"
-    "@babel/types" "^7.12.1"
-
 "@babel/helper-builder-react-jsx-experimental@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.11.tgz#a39616d7e4cf8f9da1f82b5fc3ee1f7406beeb11"
@@ -894,14 +885,15 @@
     "@babel/plugin-syntax-jsx" "^7.12.1"
 
 "@babel/plugin-transform-react-jsx@^7.3.0":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.1.tgz#c2d96c77c2b0e4362cc4e77a43ce7c2539d478cb"
-  integrity sha512-RmKejwnT0T0QzQUzcbP5p1VWlpnP8QHtdhEtLG55ZDQnJNalbF3eeDyu3dnGKvGzFIQiBzFhBYTwvv435p9Xpw==
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.12.tgz#b0da51ffe5f34b9a900e9f1f5fb814f9e512d25e"
+  integrity sha512-JDWGuzGNWscYcq8oJVCtSE61a5+XAOos+V0HrxnDieUus4UMnBEosDnY1VJqU5iZ4pA04QY7l0+JvHL1hZEfsw==
   dependencies:
-    "@babel/helper-builder-react-jsx" "^7.10.4"
-    "@babel/helper-builder-react-jsx-experimental" "^7.12.1"
+    "@babel/helper-annotate-as-pure" "^7.12.10"
+    "@babel/helper-module-imports" "^7.12.5"
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-jsx" "^7.12.1"
+    "@babel/types" "^7.12.12"
 
 "@babel/plugin-transform-regenerator@^7.4.5":
   version "7.12.1"
@@ -1196,7 +1188,7 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.12.6":
+"@babel/types@^7.12.12", "@babel/types@^7.12.6":
   version "7.12.12"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
   integrity sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
@@ -1360,9 +1352,9 @@
     babel-plugin-emotion "^10.0.27"
 
 "@emotion/cache@^10.0.27":
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.27.tgz#7895db204e2c1a991ae33d51262a3a44f6737303"
-  integrity sha512-Zp8BEpbMunFsTcqAK4D7YTm3MvCp1SekflSLJH8lze2fCcSZ/yMkXHo8kb3t1/1Tdd3hAqf3Fb7z9VZ+FMiC9w==
+  version "10.0.29"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
+  integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
   dependencies:
     "@emotion/sheet" "0.9.4"
     "@emotion/stylis" "0.8.5"
@@ -1390,19 +1382,12 @@
     "@emotion/utils" "0.11.3"
     babel-plugin-emotion "^10.0.27"
 
-"@emotion/hash@0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.4.tgz#f14932887422c9056b15a8d222a9074a7dfa2831"
-  integrity sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==
+"@emotion/hash@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.6":
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.6.tgz#4757646f0a58e9dec614c47c838e7147d88c263c"
-  integrity sha512-mnZMho3Sq8BfzkYYRVc8ilQTnc8U02Ytp6J1AwM6taQStZ3AhsEJBX2LzhA/LJirNCwM2VtHL3VFIZ+sNJUgUQ==
-  dependencies:
-    "@emotion/memoize" "0.7.4"
-
-"@emotion/is-prop-valid@^0.8.8":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1414,12 +1399,12 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
-"@emotion/serialize@^0.11.15":
-  version "0.11.15"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.15.tgz#9a0f5873fb458d87d4f23e034413c12ed60a705a"
-  integrity sha512-YE+qnrmGwyR+XB5j7Bi+0GT1JWsdcjM/d4POu+TXkcnrRs4RFCCsi3d/Ebf+wSStHqAlTT2+dfd+b9N9EO2KBg==
+"@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
+  version "0.11.16"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.16.tgz#dee05f9e96ad2fb25a5206b6d759b2d1ed3379ad"
+  integrity sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==
   dependencies:
-    "@emotion/hash" "0.7.4"
+    "@emotion/hash" "0.8.0"
     "@emotion/memoize" "0.7.4"
     "@emotion/unitless" "0.7.5"
     "@emotion/utils" "0.11.3"
@@ -1431,12 +1416,12 @@
   integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
 
 "@emotion/styled-base@^10.0.27":
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.0.27.tgz#d9efa307ae4e938fcc4d0596b40b7e8bc10f7c7c"
-  integrity sha512-ufHM/HhE3nr309hJG9jxuFt71r6aHn7p+bwXduFxcwPFEfBIqvmZUMtZ9YxIsY61PVwK3bp4G1XhaCzy9smVvw==
+  version "10.0.31"
+  resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.0.31.tgz#940957ee0aa15c6974adc7d494ff19765a2f742a"
+  integrity sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==
   dependencies:
     "@babel/runtime" "^7.5.5"
-    "@emotion/is-prop-valid" "0.8.6"
+    "@emotion/is-prop-valid" "0.8.8"
     "@emotion/serialize" "^0.11.15"
     "@emotion/utils" "0.11.3"
 
@@ -3502,14 +3487,14 @@ babel-plugin-dynamic-import-node@^2.3.3:
     object.assign "^4.1.0"
 
 babel-plugin-emotion@^10.0.27:
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.27.tgz#59001cf5de847c1d61f2079cd906a90a00d3184f"
-  integrity sha512-SUNYcT4FqhOqvwv0z1oeYhqgheU8qrceLojuHyX17ngo7WtWqN5I9l3IGHzf21Xraj465CVzF4IvOlAF+3ed0A==
+  version "10.0.33"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz#ce1155dcd1783bbb9286051efee53f4e2be63e03"
+  integrity sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
-    "@emotion/hash" "0.7.4"
+    "@emotion/hash" "0.8.0"
     "@emotion/memoize" "0.7.4"
-    "@emotion/serialize" "^0.11.15"
+    "@emotion/serialize" "^0.11.16"
     babel-plugin-macros "^2.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
     convert-source-map "^1.5.0"
@@ -5081,10 +5066,15 @@ csstype@3.0.6:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.6.tgz#865d0b5833d7d8d40f4e5b8a6d76aea3de4725ef"
   integrity sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
 
-csstype@^2.2.0, csstype@^2.5.7:
+csstype@^2.2.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
   integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+
+csstype@^2.5.7:
+  version "2.6.14"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.14.tgz#004822a4050345b55ad4dcc00be1d9cf2f4296de"
+  integrity sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A==
 
 csstype@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
Reproduction for: https://github.com/facebook/react/issues/20568

---

Failed Vercel deployment due to non-passing tests:
https://vercel.com/unly-oss/nrn-v2-mst-aptd-at-lcz-sty-c1/3ahe154cv

Vercel logs:
```

11:26:47.234 | Running "yarn run build"
-- | --
11:26:47.497 | yarn run v1.22.4
11:26:47.521 | $ yarn test:once:group:no-integration && next build
11:26:47.816 | $ NODE_ENV=test jest --group=-integration
11:26:59.357 | PASS src/utils/data/record.test.ts (10.34 s)
11:27:00.171 | PASS src/components/i18n/I18nLink.test.tsx
11:27:00.171 | › 8 snapshots obsolete.
11:27:00.171 | • I18nLink should properly render when forcing the locale to use 1
11:27:00.171 | • I18nLink should properly render when using custom CSS class 1
11:27:00.171 | • I18nLink should properly render when using route params 1
11:27:00.171 | • I18nLink should properly render when using route params and query route params 1
11:27:00.172 | • I18nLink should properly render when using route params and query route params using nested paths 1
11:27:00.172 | • I18nLink should properly render when using route params and query route params using nested paths and forcing locale 1
11:27:00.172 | • I18nLink should properly render when using wrapChildrenAsLink manually using a <NavLink> element 1
11:27:00.172 | • I18nLink should properly render when using wrapChildrenAsLink manually using a <a> element 1
11:27:00.405 | PASS src/components/assets/AirtableAsset.test.tsx (11.365 s)
11:27:01.134 | PASS src/utils/js/url.test.ts
11:27:01.597 | PASS src/utils/cookies/UniversalCookiesManager.browser.test.ts
11:27:01.630 | ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
11:27:01.630 | Attempted to log "Warning: An update to Link inside a test was not wrapped in act(...).
11:27:01.630 | When testing, code that causes React state updates should be wrapped into act(...):
11:27:01.630 | act(() => {
11:27:01.630 | /* fire events that update state */
11:27:01.630 | });
11:27:01.630 | /* assert on the output */
11:27:01.631 | This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
11:27:01.631 | at Link (/vercel/workpath0/node_modules/next/client/link.tsx:134:19)
11:27:01.631 | at I18nLink (/vercel/workpath0/src/components/i18n/I18nLink.tsx:63:56)
11:27:01.631 | at I18nLinkTest (/vercel/workpath0/src/components/i18n/I18nLink.test.tsx:14:13)".
11:27:01.631 | 61 \|  *   >
11:27:01.631 | 62 \|  *      Go to product 5
11:27:01.631 | > 63 \|  *   </I18nLink>
11:27:01.631 | \|                 ^
11:27:01.631 | 64 \|  *
11:27:01.631 | 65 \|  * @example When using route query params. Ex: /products/5?userId=1
11:27:01.631 | 66 \|  *   <I18nLink
11:27:01.631 | at Link (node_modules/next/client/link.tsx:134:19)
11:27:01.631 | at I18nLink (src/components/i18n/I18nLink.tsx:63:56)
11:27:01.631 | at I18nLinkTest (src/components/i18n/I18nLink.test.tsx:14:13)".
11:27:01.631 | at BufferedConsole.error (node_modules/@jest/console/build/BufferedConsole.js:161:10)
11:27:01.632 | at printWarning (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:68:30)
11:27:01.632 | at error (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:44:5)
11:27:01.632 | at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15034:9)
11:27:01.632 | at dispatchAction (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7129:9)
11:27:01.632 | at node_modules/next/client/use-intersection.tsx:48:1
11:27:01.632 | at Timeout._onTimeout (node_modules/next/client/request-idle-callback.ts:24:9)
11:27:01.656 | PASS src/utils/data/airtableField.test.ts
11:27:01.786 | PASS src/utils/caching/hybridCache.test.ts (12.789 s)
11:27:02.241 | PASS src/utils/airtableDataset/applyRecordFallback.test.ts
11:27:02.351 | PASS src/utils/js/string.test.ts
11:27:02.620 | PASS src/utils/js/array.test.ts
11:27:03.021 | PASS src/utils/css.test.ts
11:27:03.251 | PASS src/utils/assets/logo.test.ts
11:27:03.523 | PASS src/utils/cookies/UniversalCookiesManager.server.test.ts
11:27:03.573 | PASS src/utils/api/fetchJSON.test.ts
11:27:03.618 | Snapshot Summary
11:27:03.619 | › 8 snapshots obsolete from 1 test suite. To remove them all, run `yarn run test:once:group:no-integration -u`.
11:27:03.619 | ↳ src/components/i18n/I18nLink.test.tsx
11:27:03.619 | • I18nLink should properly render when forcing the locale to use 1
11:27:03.619 | • I18nLink should properly render when using custom CSS class 1
11:27:03.619 | • I18nLink should properly render when using route params 1
11:27:03.619 | • I18nLink should properly render when using route params and query route params 1
11:27:03.619 | • I18nLink should properly render when using route params and query route params using nested paths 1
11:27:03.619 | • I18nLink should properly render when using route params and query route params using nested paths and forcing locale 1
11:27:03.619 | • I18nLink should properly render when using wrapChildrenAsLink manually using a <NavLink> element 1
11:27:03.619 | • I18nLink should properly render when using wrapChildrenAsLink manually using a <a> element 1
11:27:03.619 | Test Suites: 14 passed, 14 of 16 total
11:27:03.619 | Tests:       72 passed, 72 total
11:27:03.619 | Snapshots:   8 obsolete, 17 passed, 17 total
11:27:03.619 | Time:        14.908 s
11:27:03.619 | Ran all test suites.
11:27:03.637 | error Command failed with exit code 1.
11:27:03.637 | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
11:27:03.655 | error Command failed with exit code 1.
11:27:03.655 | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
11:27:03.665 | Error: Command "yarn run build" exited with 1
11:27:07.745 | Done with "package.json"


```