### PR TITLE
Optimize Storybook CI/CD, by avoiding unnecessary runs

### DIFF
--- a/.github/workflows/deploy-vercel-storybook.yml
+++ b/.github/workflows/deploy-vercel-storybook.yml
@@ -33,7 +33,8 @@ on:
       - 'cypress/integration-storybook/**'
       - 'src/stories/**'
       - 'src/components/**'
-#      - 'src/*/components/**' # For later?
+      #      - 'src/*/components/**' # For later?
+      - 'package.json'
 
 jobs:
   # Configures the deployment environment, install dependencies (like node, npm, etc.) that are requirements for the upcoming jobs

--- a/.github/workflows/deploy-vercel-storybook.yml
+++ b/.github/workflows/deploy-vercel-storybook.yml
@@ -25,6 +25,15 @@ on:
   push: # Triggers on each pushed commit
     branches:
       - '*'
+    # Only run the workflow when there are changes made to files, in any of the below paths
+    # Optimize our CI/CD by not running Storybook needlessly (faster deploy, lower cost)
+    paths:
+      - '.github/workflows/deploy-vercel-storybook.yml'
+      - '.storybook/**'
+      - 'cypress/integration-storybook/**'
+      - 'src/stories/**'
+      - 'src/components/**'
+#      - 'src/*/components/**' # For later?
 
 jobs:
   # Configures the deployment environment, install dependencies (like node, npm, etc.) that are requirements for the upcoming jobs

--- a/scripts/test sb.sh
+++ b/scripts/test sb.sh
@@ -1,0 +1,1 @@
+## test sb run


### PR DESCRIPTION
Only build Storybook static site when files under "whitelisted" paths have changed.

Helps avoid unnecessary runs, fasten developer feedback, and reduce costs and load on Vercel and GitHub Actions.