### PR TITLE
Feature - Automatically release Vercel deployments as GitHub deployments

### DIFF
--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -24,6 +24,7 @@
 # - See https://github.com/UnlyEd/github-action-store-variable https://github.com/UnlyEd/github-action-store-variable/tree/v1.0.1
 # - See https://github.com/cypress-io/github-action https://github.com/cypress-io/github-action/tree/v2
 # - See https://github.com/foo-software/lighthouse-check-action https://github.com/foo-software/lighthouse-check-action/tree/v1.0.1
+# - See https://github.com/bobheadxi/deployments https://github.com/bobheadxi/deployments/tree/v0.4.3
 
 name: Deploy to Vercel (production)
 
@@ -69,17 +70,10 @@ jobs:
     timeout-minutes: 40 # Limit current job timeout https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
-      - name: Deploying on Vercel (production)
-        # Workflow overview:
-        #   - Resolve customer to deploy from github event input (falls back to resolving it from vercel.json file)
-        #   - Deploy the customer in production
-        #   - Creates multiple deployment aliases based on the "alias" property defined in the vercel.json file, and link them to the deployment
-        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
-        run: |
-          # Print the version of the "vercel" CLI being used (helps debugging)
-          vercel --version
-          echo "Deploying using git commit SHA: $GIT_COMMIT_SHA and branch/tag: $GIT_COMMIT_REF"
 
+      #  Resolves customer to deploy from github event input (falls back to resolving it from vercel.json file)
+      - name: Resolve customer to deploy
+        run: |
           # Resolving customer to deploy based on the github event input, when using manual deployment triggerer through "workflow_dispatch" event
           # Falls back to the customer specified in the vercel.json file, which is most useful when deployment is triggered through "push" event
           MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
@@ -89,6 +83,25 @@ jobs:
           CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat vercel.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
           echo "Customer to deploy: " $CUSTOMER_REF_TO_DEPLOY
           echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
+
+      # Create a GitHub deployment (within a GitHub environment), useful to keep a public track of all deployments directly in GitHub
+      - name: Start GitHub deployment
+        uses: bobheadxi/deployments@v0.4.3 # See https://github.com/bobheadxi/deployments
+        id: start-github-deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ env.CUSTOMER_REF_TO_DEPLOY }}-production
+
+      - name: Deploying on Vercel (production)
+        # Workflow overview:
+        #   - Deploys the customer and resolves the $VERCEL_DEPLOYMENT_URL from Vercel deployment output
+        #   - Creates multiple deployment aliases based on the "alias" property defined in the vercel.json file, and link them to the deployment
+        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
+        run: |
+          # Print the version of the "vercel" CLI being used (helps debugging)
+          vercel --version
+          echo "Deploying using git commit SHA: $GIT_COMMIT_SHA and branch/tag: $GIT_COMMIT_REF"
 
           # Deploy the customer on Vercel using the customer ref
           # Store the output in a variable so we can extract metadata from it
@@ -132,6 +145,18 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }} # Passing github's secret to the worker
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker
           GIT_COMMIT_SHA: ${{ github.sha }} # Passing current commit SHA to the worker
+
+      # Update the previously created GitHub deployment, and link it to our Vercel deployment
+      - name: Link GitHub deployment to Vercel
+        uses: bobheadxi/deployments@v0.4.3 # See https://github.com/bobheadxi/deployments
+        id: link-github-deployment-to-vercel
+        if: always()
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.start-github-deployment.outputs.deployment_id }}
+          env_url: ${{ env.VERCEL_DEPLOYMENT_URL }} # Link the Vercel deployment url to the GitHub environment
 
       # At the end of the job, store all variables we will need in the following jobs
       # The variables will be stored in and retrieved from a GitHub Artifact (each variable is stored in a different file)

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -192,6 +192,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.start-github-deployment.outputs.deployment_id }}
+          env_url: ${{ env.VERCEL_DEPLOYMENT_URL }} # Link the Vercel deployment url to the GitHub environment
 
       # We need to find the PR id. Will be used later to comment on that PR.
       - name: Finding Pull Request ID

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -70,29 +70,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
 
-      # Create a GitHub deployment (within a GitHub environment), useful to keep a public track of all deployments directly in GitHub
-      - name: Start GitHub deployment
-        uses: bobheadxi/deployments@v0.4.3 # See https://github.com/bobheadxi/deployments
-        id: start-github-deployment
-        with:
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: staging
-
-      - name: Deploying on Vercel (staging)
-        # Workflow overview:
-        #   - Resolve customer to deploy from github event input (falls back to resolving it from vercel.json file)
-        #   - Resolve $VERCEL_DEPLOYMENT_URL
-        #   - Get stdout from deploy command (stderr prints build steps and stdout prints deployment url, which is what we are really looking for)
-        #   - Set the deployment url that will be included in the eventual PR comment
-        #   - Create a deployment alias based on the branch name, and link it to the deployment (so that each branch has its own domain automatically aliased to the latest commit)
-        #   - Creates multiple deployment aliases based on the "alias" property defined in the vercel.json file, and link them to the deployment
-        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
+      #  Resolve customer to deploy from github event input (falls back to resolving it from vercel.json file)
+      - name: Resolve customer to deploy
         run: |
-          # Print the version of the "vercel" CLI being used (helps debugging)
-          vercel --version
-          echo "Deploying using git commit SHA: $GIT_COMMIT_SHA and branch/tag: $GIT_COMMIT_REF"
-
           # Resolving customer to deploy based on the github event input, when using manual deployment triggerer through "workflow_dispatch" event
           # Falls back to the customer specified in the vercel.json file, which is most useful when deployment is triggered through "push" event
           MANUAL_TRIGGER_CUSTOMER="${{ github.event.inputs.customer}}"
@@ -102,6 +82,28 @@ jobs:
           CUSTOMER_REF_TO_DEPLOY="${MANUAL_TRIGGER_CUSTOMER:-$(cat vercel.json | jq --raw-output '.build.env.NEXT_PUBLIC_CUSTOMER_REF')}"
           echo "Customer to deploy: " $CUSTOMER_REF_TO_DEPLOY
           echo "CUSTOMER_REF_TO_DEPLOY=$CUSTOMER_REF_TO_DEPLOY" >> $GITHUB_ENV
+
+      # Create a GitHub deployment (within a GitHub environment), useful to keep a public track of all deployments directly in GitHub
+      - name: Start GitHub deployment
+        uses: bobheadxi/deployments@v0.4.3 # See https://github.com/bobheadxi/deployments
+        id: start-github-deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ env.CUSTOMER_REF_TO_DEPLOY }}-staging
+
+      - name: Deploying on Vercel (staging)
+        # Workflow overview:
+        #   - Resolve $VERCEL_DEPLOYMENT_URL from Vercel deployment output
+        #   - Get stdout from deploy command (stderr prints build steps and stdout prints deployment url, which is what we are really looking for)
+        #   - Set the deployment url that will be included in the eventual PR comment
+        #   - Create a deployment alias based on the branch name, and link it to the deployment (so that each branch has its own domain automatically aliased to the latest commit)
+        #   - Creates multiple deployment aliases based on the "alias" property defined in the vercel.json file, and link them to the deployment
+        # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
+        run: |
+          # Print the version of the "vercel" CLI being used (helps debugging)
+          vercel --version
+          echo "Deploying using git commit SHA: $GIT_COMMIT_SHA and branch/tag: $GIT_COMMIT_REF"
 
           # Deploy the customer on Vercel using the customer ref
           # Store the output in a variable so we can extract metadata from it
@@ -180,7 +182,6 @@ jobs:
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker
           GIT_COMMIT_SHA: ${{ github.sha }} # Passing current commit SHA to the worker
 
-
       # Update the previously created GitHub deployment, and link it to our Vercel deployment
       - name: Link GitHub deployment to Vercel
         uses: bobheadxi/deployments@v0.4.3 # See https://github.com/bobheadxi/deployments
@@ -191,7 +192,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.start-github-deployment.outputs.deployment_id }}
-          desc: "Deployed **'${{ env.CUSTOMER_REF_TO_DEPLOY }}'** to [Vercel](${{ env.VERCEL_DEPLOYMENT_URL }})"
 
       # We need to find the PR id. Will be used later to comment on that PR.
       - name: Finding Pull Request ID

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -69,6 +69,16 @@ jobs:
     timeout-minutes: 40 # Limit current job timeout https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
+
+      # Create a GitHub deployment (within a GitHub environment), useful to keep a public track of all deployments directly in GitHub
+      - name: Start GitHub deployment
+        uses: bobheadxi/deployments@v0.4.3 # See https://github.com/bobheadxi/deployments
+        id: start-github-deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: staging
+
       - name: Deploying on Vercel (staging)
         # Workflow overview:
         #   - Resolve customer to deploy from github event input (falls back to resolving it from vercel.json file)
@@ -169,6 +179,19 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }} # Passing github's secret to the worker
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker
           GIT_COMMIT_SHA: ${{ github.sha }} # Passing current commit SHA to the worker
+
+
+      # Update the previously created GitHub deployment, and link it to our Vercel deployment
+      - name: Link GitHub deployment to Vercel
+        uses: bobheadxi/deployments@v0.4.3 # See https://github.com/bobheadxi/deployments
+        id: link-github-deployment-to-vercel
+        if: always()
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.start-github-deployment.outputs.deployment_id }}
+          desc: "Deployed **'${{ env.CUSTOMER_REF_TO_DEPLOY }}'** to [Vercel](${{ env.VERCEL_DEPLOYMENT_URL }})"
 
       # We need to find the PR id. Will be used later to comment on that PR.
       - name: Finding Pull Request ID

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -24,6 +24,7 @@
 # - See https://github.com/UnlyEd/github-action-store-variable https://github.com/UnlyEd/github-action-store-variable/tree/v1.0.1
 # - See https://github.com/cypress-io/github-action https://github.com/cypress-io/github-action/tree/v2
 # - See https://github.com/foo-software/lighthouse-check-action https://github.com/foo-software/lighthouse-check-action/tree/v1.0.1
+# - See https://github.com/bobheadxi/deployments https://github.com/bobheadxi/deployments/tree/v0.4.3
 
 name: Deploy to Vercel (staging)
 
@@ -70,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
 
-      #  Resolve customer to deploy from github event input (falls back to resolving it from vercel.json file)
+      #  Resolves customer to deploy from github event input (falls back to resolving it from vercel.json file)
       - name: Resolve customer to deploy
         run: |
           # Resolving customer to deploy based on the github event input, when using manual deployment triggerer through "workflow_dispatch" event
@@ -94,10 +95,8 @@ jobs:
 
       - name: Deploying on Vercel (staging)
         # Workflow overview:
-        #   - Resolve $VERCEL_DEPLOYMENT_URL from Vercel deployment output
-        #   - Get stdout from deploy command (stderr prints build steps and stdout prints deployment url, which is what we are really looking for)
-        #   - Set the deployment url that will be included in the eventual PR comment
-        #   - Create a deployment alias based on the branch name, and link it to the deployment (so that each branch has its own domain automatically aliased to the latest commit)
+        #   - Deploys the customer and resolves the $VERCEL_DEPLOYMENT_URL from Vercel deployment output
+        #   - Creates a deployment alias based on the branch name, and link it to the deployment (so that each branch has its own domain automatically aliased to the latest commit)
         #   - Creates multiple deployment aliases based on the "alias" property defined in the vercel.json file, and link them to the deployment
         # XXX You can use https://jqplay.org/ if you want to play around with "jq" to manipulate JSON
         run: |

--- a/.github/workflows/deploy-vercel-storybook.yml
+++ b/.github/workflows/deploy-vercel-storybook.yml
@@ -61,6 +61,15 @@ jobs:
       - name: Expose GitHub slug/short variables # See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
         uses: rlespinasse/github-slug-action@v3.x # See https://github.com/rlespinasse/github-slug-action
 
+      # Create a GitHub deployment (within a GitHub environment), useful to keep a public track of all deployments directly in GitHub
+      - name: Start GitHub deployment
+        uses: bobheadxi/deployments@v0.4.3 # See https://github.com/bobheadxi/deployments
+        id: start-github-deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: storybook
+
       - name: Deploying on Vercel
         # Workflow overview:
         #   - Install yarn dependencies (necessary to build the Storybook static site)
@@ -76,7 +85,7 @@ jobs:
 
           echo "Building and deploying StoryBook static site"
 
-          # Deploy the customer on Vercel using the customer ref
+          # Deploy the storybook static export on Vercel
           # Store the output in a variable so we can extract metadata from it
           VERCEL_DEPLOYMENT_OUTPUT=`yarn deploy:sb:gha --token $VERCEL_TOKEN`
 
@@ -115,6 +124,18 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }} # Passing github's secret to the worker
           # Passing exposed GitHub environment variables - See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
           GITHUB_REF_SLUG: ${{ env.GITHUB_REF_SLUG }}
+
+      # Update the previously created GitHub deployment, and link it to our Vercel deployment
+      - name: Link GitHub deployment to Vercel
+        uses: bobheadxi/deployments@v0.4.3 # See https://github.com/bobheadxi/deployments
+        id: link-github-deployment-to-vercel
+        if: always()
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.start-github-deployment.outputs.deployment_id }}
+          env_url: ${{ env.VERCEL_DEPLOYMENT_URL }} # Link the Vercel deployment url to the GitHub environment
 
       # We need to find the PR id. Will be used later to comment on that PR.
       - name: Finding Pull Request ID


### PR DESCRIPTION
Vercel deployments can easily be seen from the Vercel UI, but it requires a Vercel account.

GitHub provides an "Environment" feature, where one can tag Deployments as part of an environment.
Automatically creating a GitHub deployment when triggering a Vercel deployment would allow all users (even those without a Vercel account) to see the deployment history.

This can be useful for various use-cases. 

This PR automatically creates a GitHub deployment per customer/stage for the Next.js site, and another one for the storybook site. 

See https://github.com/UnlyEd/next-right-now/deployments