### PR TITLE
[GHA] Upgrade github-action-store-variable from 1.0.1 to v2.1.1

### DIFF
--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -39,6 +39,7 @@ on:
       - 'master'
       - 'main'
       - 'v2-mst-aptd-at-lcz-sty' # XXX Name of the NRN preset branch, acting as a main branch (all commits pushed to the preset branch are deployed to production)
+      - 'gha-update-store-variable' # Actual branch used to test
 
     # Runs the deployment workflow only when there are changes made to specific files, in any of the below paths
     # Optimizes our CI/CD by not deploying the Next.js site needlessly (faster deploy, lower cost)
@@ -183,7 +184,7 @@ jobs:
       # At the end of the job, store all variables we will need in the following jobs
       # The variables will be stored in and retrieved from a GitHub Artifact (each variable is stored in a different file)
       - name: Store variables for next jobs
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         with:
           variables: |
             CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
@@ -203,7 +204,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           variables: |
@@ -216,11 +217,11 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEl_TOKEN }}
         with:
-          deployment-url: ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_DOMAIN }} # Must only contain the domain name (no http prefix, etc.)
+          deployment-url: ${{ env.VERCEL_DEPLOYMENT_DOMAIN }} # Must only contain the domain name (no http prefix, etc.)
           timeout: 90 # Wait for 90 seconds before failing
 
       - name: Display deployment status
-        run: "echo The deployment is ${{ fromJson(steps.await-vercel.outputs.deploymentDetails).readyState }}"
+        run: "echo The deployment is ${{ env.readyState }}"
 
   # Send a HTTP call to the webhook url that's provided in the customer configuration file (vercel.*.json)
   send-webhook-callback-once-deployment-ready:
@@ -235,7 +236,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           variables: |
@@ -255,40 +256,8 @@ jobs:
           # Checking if a webhook url is defined
           if [ -n "$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK" ]; then
             # Run script that populates git-related variables as ENV variables
-            echo "Running script populate-git-env.sh"
-            . ./scripts/populate-git-env.sh
-
-            echo "Resolved git variables:"
-            echo "'GIT_COMMIT_SHA': $GIT_COMMIT_SHA"
-            echo "'GIT_COMMIT_REF': $GIT_COMMIT_REF"
-            echo "'GIT_COMMIT_TAGS': $GIT_COMMIT_TAGS"
-
-            # Generates JSON using a bash function - See https://stackoverflow.com/a/57369772/2391795
-            # "End Of File" must be at the beginning of the line with no space/tab before or after - See https://stackoverflow.com/a/12909284/2391795
-            # But, when executed by GitHub Action, it must be inside the "run" section instead
-            generate_post_data() {
-              cat <<EOF
-            {
-              "MANUAL_TRIGGER_CUSTOMER": "${MANUAL_TRIGGER_CUSTOMER}",
-              "CUSTOMER_REF": "${CUSTOMER_REF_TO_DEPLOY}",
-              "STAGE": "production",
-              "GIT_COMMIT_SHA": "${GIT_COMMIT_SHA}",
-              "GIT_COMMIT_REF": "${GIT_COMMIT_REF}",
-              "GIT_COMMIT_TAGS": "${GIT_COMMIT_TAGS}",
-              "GITHUB_REF_SLUG": "${GITHUB_REF_SLUG}",
-              "GITHUB_HEAD_REF_SLUG": "${GITHUB_HEAD_REF_SLUG}",
-              "GITHUB_BASE_REF_SLUG": "${GITHUB_BASE_REF_SLUG}",
-              "GITHUB_EVENT_REF_SLUG": "${GITHUB_EVENT_REF_SLUG}",
-              "GITHUB_REPOSITORY_SLUG": "${GITHUB_REPOSITORY_SLUG}",
-              "GITHUB_REF_SLUG_URL": "${GITHUB_REF_SLUG_URL}",
-              "GITHUB_HEAD_REF_SLUG_URL": "${GITHUB_HEAD_REF_SLUG_URL}",
-              "GITHUB_BASE_REF_SLUG_URL": "${GITHUB_BASE_REF_SLUG_URL}",
-              "GITHUB_EVENT_REF_SLUG_URL": "${GITHUB_EVENT_REF_SLUG_URL}",
-              "GITHUB_REPOSITORY_SLUG_URL": "${GITHUB_REPOSITORY_SLUG_URL}",
-              "GITHUB_SHA_SHORT": "${GITHUB_SHA_SHORT}"
-            }
-          EOF
-            }
+            echo "Running script generate-post-data"
+            . ./scripts/generate-post-data.sh
 
             echo "Print generate_post_data():"
             echo "$(generate_post_data)"
@@ -316,21 +285,8 @@ jobs:
             echo "No webhook url defined in 'vercel.$CUSTOMER_REF_TO_DEPLOY.production.json:.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK' (found '$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')"
           fi
         env:
-          CUSTOMER_REF_TO_DEPLOY: ${{ fromJson(steps.restore-variable.outputs.variables).CUSTOMER_REF_TO_DEPLOY }}
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker
           GIT_COMMIT_SHA: ${{ github.sha }} # Passing current commit SHA to the worker
-          # Passing exposed GitHub environment variables - See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
-          GITHUB_REF_SLUG: ${{ env.GITHUB_REF_SLUG }}
-          GITHUB_HEAD_REF_SLUG: ${{ env.GITHUB_HEAD_REF_SLUG }}
-          GITHUB_BASE_REF_SLUG: ${{ env.GITHUB_BASE_REF_SLUG }}
-          GITHUB_EVENT_REF_SLUG: ${{ env.GITHUB_EVENT_REF_SLUG }}
-          GITHUB_REPOSITORY_SLUG: ${{ env.GITHUB_REPOSITORY_SLUG }}
-          GITHUB_REF_SLUG_URL: ${{ env.GITHUB_REF_SLUG_URL }}
-          GITHUB_HEAD_REF_SLUG_URL: ${{ env.GITHUB_HEAD_REF_SLUG_URL }}
-          GITHUB_BASE_REF_SLUG_URL: ${{ env.GITHUB_BASE_REF_SLUG_URL }}
-          GITHUB_EVENT_REF_SLUG_URL: ${{ env.GITHUB_EVENT_REF_SLUG_URL }}
-          GITHUB_REPOSITORY_SLUG_URL: ${{ env.GITHUB_REPOSITORY_SLUG_URL }}
-          GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
 
   # Runs E2E tests against the Vercel deployment
   run-2e2-tests:
@@ -346,7 +302,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           variables: |
@@ -359,7 +315,7 @@ jobs:
           # XXX We disabled "wait-on" option, because it's useless. Cypress will fail anyway, because it gets redirected to some internal Vercel URL if the domain isn't yet available - See https://github.com/cypress-io/github-action/issues/270
           # wait-on: '${{ env.VERCEL_DEPLOYMENT_URL }}' # Be sure that the endpoint is ready by pinging it before starting tests, using a default timeout of 60 seconds
           config-file: 'cypress/config-customer-ci-cd.json' # Use Cypress config file for CI/CD, and override it below
-          config: baseUrl=${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
+          config: baseUrl=${{ env.VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
         env:
           # Enables Cypress debugging logs, very useful if Cypress crashes, like out-of-memory issues.
           # DEBUG: "cypress:*" # Enable all logs. See https://docs.cypress.io/guides/references/troubleshooting.html#Print-DEBUG-logs
@@ -396,7 +352,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           variables: VERCEL_DEPLOYMENT_URL
@@ -410,7 +366,7 @@ jobs:
           # XXX We don't enable comments, because there is no branch to write them into
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           emulatedFormFactor: all # Run LightHouse against "mobile", "desktop", or "all" devices
-          urls: ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}, ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}/en, ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}/fr, ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}/en
+          urls: ${{ env.VERCEL_DEPLOYMENT_URL }}, ${{ env.VERCEL_DEPLOYMENT_URL }}/en, ${{ env.VERCEL_DEPLOYMENT_URL }}/fr
           locale: en
 
       # Upload HTML report created by lighthouse as an artifact.

--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -39,7 +39,6 @@ on:
       - 'master'
       - 'main'
       - 'v2-mst-aptd-at-lcz-sty' # XXX Name of the NRN preset branch, acting as a main branch (all commits pushed to the preset branch are deployed to production)
-      #- 'gha-update-store-variable' # Actual branch used to test
 
     # Runs the deployment workflow only when there are changes made to specific files, in any of the below paths
     # Optimizes our CI/CD by not deploying the Next.js site needlessly (faster deploy, lower cost)
@@ -187,7 +186,7 @@ jobs:
       # At the end of the job, store all variables we will need in the following jobs
       # The variables will be stored in and retrieved from a GitHub Artifact (each variable is stored in a different file)
       - name: Store variables for next jobs
-        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         with:
           variables: |
             CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
@@ -207,7 +206,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -240,7 +239,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -320,7 +319,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -371,7 +370,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true

--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -184,7 +184,7 @@ jobs:
       # At the end of the job, store all variables we will need in the following jobs
       # The variables will be stored in and retrieved from a GitHub Artifact (each variable is stored in a different file)
       - name: Store variables for next jobs
-        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
         with:
           variables: |
             CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
@@ -204,7 +204,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -237,7 +237,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -304,7 +304,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -355,7 +355,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true

--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -207,6 +207,7 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
+          failIfNotFound: true
           variables: |
             VERCEL_DEPLOYMENT_DOMAIN
 
@@ -239,6 +240,7 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
+          failIfNotFound: true
           variables: |
             MANUAL_TRIGGER_CUSTOMER
             CUSTOMER_REF_TO_DEPLOY
@@ -305,6 +307,7 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
+          failIfNotFound: true
           variables: |
             VERCEL_DEPLOYMENT_URL
 
@@ -355,6 +358,7 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
+          failIfNotFound: true
           variables: VERCEL_DEPLOYMENT_URL
 
       # Runs LightHouse for a given url and create HTML reports in the specified directory (outputDirectory)

--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -21,7 +21,7 @@
 # - See https://github.com/jwalton/gh-find-current-pr https://github.com/jwalton/gh-find-current-pr/tree/v1
 # - See https://github.com/peter-evans/create-or-update-comment https://github.com/peter-evans/create-or-update-comment/tree/v1
 # - See https://github.com/UnlyEd/github-action-await-vercel https://github.com/UnlyEd/github-action-await-vercel/tree/v1.1.1
-# - See https://github.com/UnlyEd/github-action-store-variable https://github.com/UnlyEd/github-action-store-variable/tree/v1.0.1
+# - See https://github.com/UnlyEd/github-action-store-variable https://github.com/UnlyEd/github-action-store-variable/tree/v2.1.1
 # - See https://github.com/cypress-io/github-action https://github.com/cypress-io/github-action/tree/v2
 # - See https://github.com/foo-software/lighthouse-check-action https://github.com/foo-software/lighthouse-check-action/tree/v1.0.1
 # - See https://github.com/bobheadxi/deployments https://github.com/bobheadxi/deployments/tree/v0.4.3

--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -116,10 +116,10 @@ jobs:
         with:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ env.CUSTOMER_REF_TO_DEPLOY }}-production # Uses "$customer-$env" as GitHub environment name, because it's easier this way to see what has changed per customer, per stage
+          env: ${{ env.CUSTOMER_REF_TO_DEPLOY }}-${{ env.STAGE }} # Uses "$customer-$env" as GitHub environment name, because it's easier this way to see what has changed per customer, per stage
           no_override: true # Disables auto marking previous environments as "inactive", as they're still active (Vercel deployments don't auto-deactivate) and it would remove the previous deployment links needlessly
 
-      - name: Deploying on Vercel (production)
+      - name: Deploying on Vercel (${{ env.STAGE }})
         # Workflow overview:
         #   - Deploys the customer and resolves the $VERCEL_DEPLOYMENT_URL from Vercel deployment output
         #   - Creates multiple deployment aliases based on the "alias" property defined in the vercel.json file, and link them to the deployment
@@ -140,12 +140,12 @@ jobs:
           echo "VERCEL_DEPLOYMENT_DOMAIN=${VERCEL_DEPLOYMENT_URL#https://}" >> $GITHUB_ENV
 
           # Find all custom aliases configured in the customer deployment configuration file (vercel.json)
-          VERCEL_DEPLOYMENT_ALIASES_JSON=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.production.json | jq --raw-output '.alias')
+          VERCEL_DEPLOYMENT_ALIASES_JSON=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.${{ env.STAGE }}.json | jq --raw-output '.alias')
           echo "Custom aliases: " $VERCEL_DEPLOYMENT_ALIASES_JSON
 
           if [[ "$VERCEL_DEPLOYMENT_ALIASES_JSON" != "null" ]]; then
             # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
-            readarray -t VERCEL_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < vercel.$CUSTOMER_REF_TO_DEPLOY.production.json)
+            readarray -t VERCEL_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < vercel.$CUSTOMER_REF_TO_DEPLOY.${{ env.STAGE }}.json)
 
             # Count the number of element in the array, will be 0 if it's an empty array, or if the "alias" key wasn't defined
             VERCEL_DEPLOYMENT_ALIASES_COUNT=${#VERCEL_DEPLOYMENT_ALIASES[@]}
@@ -255,7 +255,7 @@ jobs:
         #  - Prints the headers of the POST HTTP request (curl)
         # TODO Convert this into an external bash script if possible, to simplify this step as much as possible
         run: |
-          VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.production.json | jq --raw-output '.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')
+          VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.${{ env.STAGE }}.json | jq --raw-output '.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')
           echo "Vercel deployment webhook url: " $VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK
 
           # Checking if a webhook url is defined
@@ -287,11 +287,12 @@ jobs:
             #   s/< // - remove '< ' prefix
 
           else
-            echo "No webhook url defined in 'vercel.$CUSTOMER_REF_TO_DEPLOY.production.json:.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK' (found '$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')"
+            echo "No webhook url defined in 'vercel.$CUSTOMER_REF_TO_DEPLOY.${{ env.STAGE }}.json:.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK' (found '$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')"
           fi
         env:
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker
           GIT_COMMIT_SHA: ${{ github.sha }} # Passing current commit SHA to the worker
+          # Passing exposed GitHub environment variables - See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
           DEPLOYMENT_STAGE: ${{ env.STAGE }}
           GITHUB_REF_SLUG: ${{ env.GITHUB_REF_SLUG }}
           GITHUB_HEAD_REF_SLUG: ${{ env.GITHUB_HEAD_REF_SLUG }}

--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -39,7 +39,7 @@ on:
       - 'master'
       - 'main'
       - 'v2-mst-aptd-at-lcz-sty' # XXX Name of the NRN preset branch, acting as a main branch (all commits pushed to the preset branch are deployed to production)
-      - 'gha-update-store-variable' # Actual branch used to test
+      #- 'gha-update-store-variable' # Actual branch used to test
 
     # Runs the deployment workflow only when there are changes made to specific files, in any of the below paths
     # Optimizes our CI/CD by not deploying the Next.js site needlessly (faster deploy, lower cost)
@@ -69,6 +69,9 @@ on:
       customer:
         description: 'Customer to deploy'
         required: true
+
+env:
+  STAGE: production
 
 jobs:
   # Configures the deployment environment, install dependencies (like node, npm, etc.) that are requirements for the upcoming jobs
@@ -289,6 +292,18 @@ jobs:
         env:
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker
           GIT_COMMIT_SHA: ${{ github.sha }} # Passing current commit SHA to the worker
+          DEPLOYMENT_STAGE: ${{ env.STAGE }}
+          GITHUB_REF_SLUG: ${{ env.GITHUB_REF_SLUG }}
+          GITHUB_HEAD_REF_SLUG: ${{ env.GITHUB_HEAD_REF_SLUG }}
+          GITHUB_BASE_REF_SLUG: ${{ env.GITHUB_BASE_REF_SLUG }}
+          GITHUB_EVENT_REF_SLUG: ${{ env.GITHUB_EVENT_REF_SLUG }}
+          GITHUB_REPOSITORY_SLUG: ${{ env.GITHUB_REPOSITORY_SLUG }}
+          GITHUB_REF_SLUG_URL: ${{ env.GITHUB_REF_SLUG_URL }}
+          GITHUB_HEAD_REF_SLUG_URL: ${{ env.GITHUB_HEAD_REF_SLUG_URL }}
+          GITHUB_BASE_REF_SLUG_URL: ${{ env.GITHUB_BASE_REF_SLUG_URL }}
+          GITHUB_EVENT_REF_SLUG_URL: ${{ env.GITHUB_EVENT_REF_SLUG_URL }}
+          GITHUB_REPOSITORY_SLUG_URL: ${{ env.GITHUB_REPOSITORY_SLUG_URL }}
+          GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
 
   # Runs E2E tests against the Vercel deployment
   run-2e2-tests:

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -273,6 +273,7 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
+          failIfNotFound: true
           variables: |
             VERCEL_DEPLOYMENT_DOMAIN
 
@@ -305,6 +306,7 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
+          failIfNotFound: true
           variables: |
             MANUAL_TRIGGER_CUSTOMER
             CUSTOMER_REF_TO_DEPLOY
@@ -371,6 +373,7 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
+          failIfNotFound: true
           variables: |
             VERCEL_DEPLOYMENT_URL
             GITHUB_PULL_REQUEST_ID
@@ -445,6 +448,7 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
+          failIfNotFound: true
           variables: VERCEL_DEPLOYMENT_URL
 
       # Runs LightHouse for a given url and create HTML reports in the specified directory (outputDirectory)

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -26,7 +26,10 @@
 # - See https://github.com/foo-software/lighthouse-check-action https://github.com/foo-software/lighthouse-check-action/tree/v1.0.1
 # - See https://github.com/bobheadxi/deployments https://github.com/bobheadxi/deployments/tree/v0.4.3
 
-name: Deploy to Vercel (staging)
+env:
+  STAGE: staging
+
+name: Deploy to Vercel (${{ env.STAGE }})
 
 on:
   # There are several ways to trigger Github actions - See https://help.github.com/en/actions/reference/events-that-trigger-workflows#example-using-a-single-event for a comprehensive list:
@@ -69,9 +72,6 @@ on:
         description: 'Customer to deploy'
         required: true
 
-env:
-  STAGE: staging
-
 jobs:
   # Configures the deployment environment, install dependencies (like node, npm, etc.) that are requirements for the upcoming jobs
   # Ex: Necessary to run `yarn deploy`
@@ -88,7 +88,7 @@ jobs:
   # The default institution is the one defined in the `vercel.json` file (which is a symlink to the actual file)
   # N.B: It's Vercel that will perform the actual deployment
   start-staging-deployment:
-    name: Starts Vercel deployment (staging) (Ubuntu 18.04)
+    name: Starts Vercel deployment (${{ env.STAGE }}) (Ubuntu 18.04)
     runs-on: ubuntu-18.04
     needs: setup-environment
     timeout-minutes: 40 # Limit current job timeout https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
@@ -115,10 +115,10 @@ jobs:
         with:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ env.CUSTOMER_REF_TO_DEPLOY }}-staging # Uses "$customer-$env" as GitHub environment name, because it's easier this way to see what has changed per customer, per stage
+          env: ${{ env.CUSTOMER_REF_TO_DEPLOY }}-${{ env.STAGE }} # Uses "$customer-$env" as GitHub environment name, because it's easier this way to see what has changed per customer, per stage
           no_override: true # Disables auto marking previous environments as "inactive", as they're still active (Vercel deployments don't auto-deactivate) and it would remove the previous deployment links needlessly
 
-      - name: Deploying on Vercel (staging)
+      - name: Deploying on Vercel (${{ env.STAGE }})
         # Workflow overview:
         #   - Deploys the customer and resolves the $VERCEL_DEPLOYMENT_URL from Vercel deployment output
         #   - Creates a deployment alias based on the branch name, and link it to the deployment (so that each branch has its own domain automatically aliased to the latest commit)
@@ -145,7 +145,7 @@ jobs:
           if [[ ${GIT_COMMIT_REF##*/} =~ ^v[0-9]{1,}- ]]; then # Checking if pattern matches with "vX-" where X is a number
             VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS=${GIT_COMMIT_REF##*/}
           else
-            VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.name')-${GIT_COMMIT_REF##*/}
+            VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.${{ env.STAGE }}.json | jq --raw-output '.name')-${GIT_COMMIT_REF##*/}
           fi
           echo "Resolved domain alias: " $VERCEL_DEPLOYMENT_AUTO_BRANCH_ALIAS
 
@@ -174,12 +174,12 @@ jobs:
           # TODO Resolve whether the aliasing has worked and change the GitHub comment "Comment PR (Deployment success)"
 
           # Find all custom aliases configured in the customer deployment configuration file (vercel.json)
-          VERCEL_DEPLOYMENT_ALIASES_JSON=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.alias')
+          VERCEL_DEPLOYMENT_ALIASES_JSON=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.${{ env.STAGE }}.json | jq --raw-output '.alias')
           echo "Custom aliases: " $VERCEL_DEPLOYMENT_ALIASES_JSON
 
           if [[ "$VERCEL_DEPLOYMENT_ALIASES_JSON" != "null" ]]; then
             # Convert the JSON array into a bash array - See https://unix.stackexchange.com/a/615717/60329
-            readarray -t VERCEL_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json)
+            readarray -t VERCEL_DEPLOYMENT_ALIASES < <(jq --raw-output '.alias[]' < vercel.$CUSTOMER_REF_TO_DEPLOY.${{ env.STAGE }}.json)
 
             # Count the number of element in the array, will be 0 if it's an empty array, or if the "alias" key wasn't defined
             VERCEL_DEPLOYMENT_ALIASES_COUNT=${#VERCEL_DEPLOYMENT_ALIASES[@]}
@@ -266,7 +266,7 @@ jobs:
   await-for-vercel-deployment:
     name: Await current deployment to be ready (Ubuntu 18.04)
     runs-on: ubuntu-18.04
-    needs: start-staging-deployment
+    needs: start-${{ env.STAGE }}-deployment
     timeout-minutes: 5 # Limit current job timeout (including action timeout setup down there) https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout
@@ -321,7 +321,7 @@ jobs:
         #  - Prints the headers of the POST HTTP request (curl)
         # TODO Convert this into an external bash script if possible, to simplify this step as much as possible
         run: |
-          VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json | jq --raw-output '.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')
+          VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK=$(cat vercel.$CUSTOMER_REF_TO_DEPLOY.${{ env.STAGE }}.json | jq --raw-output '.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')
           echo "Vercel deployment webhook url: " $VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK
 
           # Checking if a webhook url is defined
@@ -353,7 +353,7 @@ jobs:
             #   s/< // - remove '< ' prefix
 
           else
-            echo "No webhook url defined in 'vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json:.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK' (found '$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')"
+            echo "No webhook url defined in 'vercel.$CUSTOMER_REF_TO_DEPLOY.${{ env.STAGE }}.json:.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK' (found '$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')"
           fi
         env:
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -359,6 +359,7 @@ jobs:
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker
           GIT_COMMIT_SHA: ${{ github.sha }} # Passing current commit SHA to the worker
           # Passing exposed GitHub environment variables - See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
+          DEPLOYMENT_STAGE: ${{ env.STAGE }}
           GITHUB_REF_SLUG: ${{ env.GITHUB_REF_SLUG }}
           GITHUB_HEAD_REF_SLUG: ${{ env.GITHUB_HEAD_REF_SLUG }}
           GITHUB_BASE_REF_SLUG: ${{ env.GITHUB_BASE_REF_SLUG }}

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -250,7 +250,7 @@ jobs:
       # At the end of the job, store all variables we will need in the following jobs
       # The variables will be stored in and retrieved from a GitHub Artifact (each variable is stored in a different file)
       - name: Store variables for next jobs
-        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
         with:
           variables: |
             CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
@@ -270,7 +270,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -303,7 +303,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -370,7 +370,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -445,7 +445,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -26,9 +26,6 @@
 # - See https://github.com/foo-software/lighthouse-check-action https://github.com/foo-software/lighthouse-check-action/tree/v1.0.1
 # - See https://github.com/bobheadxi/deployments https://github.com/bobheadxi/deployments/tree/v0.4.3
 
-env:
-  STAGE: staging
-
 name: Deploy to Vercel (staging)
 
 on:
@@ -71,6 +68,9 @@ on:
       customer:
         description: 'Customer to deploy'
         required: true
+
+env:
+  STAGE: staging
 
 jobs:
   # Configures the deployment environment, install dependencies (like node, npm, etc.) that are requirements for the upcoming jobs

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -253,7 +253,7 @@ jobs:
       # At the end of the job, store all variables we will need in the following jobs
       # The variables will be stored in and retrieved from a GitHub Artifact (each variable is stored in a different file)
       - name: Store variables for next jobs
-        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         with:
           variables: |
             CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
@@ -273,7 +273,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -306,7 +306,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -386,7 +386,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -461,7 +461,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v2.0.0 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -29,7 +29,7 @@
 env:
   STAGE: staging
 
-name: Deploy to Vercel (${{ env.STAGE }})
+name: Deploy to Vercel (staging)
 
 on:
   # There are several ways to trigger Github actions - See https://help.github.com/en/actions/reference/events-that-trigger-workflows#example-using-a-single-event for a comprehensive list:
@@ -88,7 +88,7 @@ jobs:
   # The default institution is the one defined in the `vercel.json` file (which is a symlink to the actual file)
   # N.B: It's Vercel that will perform the actual deployment
   start-staging-deployment:
-    name: Starts Vercel deployment (${{ env.STAGE }}) (Ubuntu 18.04)
+    name: Starts Vercel deployment (staging) (Ubuntu 18.04)
     runs-on: ubuntu-18.04
     needs: setup-environment
     timeout-minutes: 40 # Limit current job timeout https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -250,7 +250,7 @@ jobs:
       # At the end of the job, store all variables we will need in the following jobs
       # The variables will be stored in and retrieved from a GitHub Artifact (each variable is stored in a different file)
       - name: Store variables for next jobs
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         with:
           variables: |
             CUSTOMER_REF_TO_DEPLOY=${{ env.CUSTOMER_REF_TO_DEPLOY }}
@@ -270,7 +270,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           variables: |
@@ -283,11 +283,11 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEl_TOKEN }}
         with:
-          deployment-url: ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_DOMAIN }} # Must only contain the domain name (no http prefix, etc.)
+          deployment-url: ${{ env.VERCEL_DEPLOYMENT_DOMAIN }} # Must only contain the domain name (no http prefix, etc.)
           timeout: 90 # Wait for 90 seconds before failing
 
       - name: Display deployment status
-        run: "echo The deployment is ${{ fromJson(steps.await-vercel.outputs.deploymentDetails).readyState }}"
+        run: "echo The deployment is ${{ env.readyState }}"
 
   # Send a HTTP call to the webhook url that's provided in the customer configuration file (vercel.*.json)
   send-webhook-callback-once-deployment-ready:
@@ -302,7 +302,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           variables: |
@@ -322,40 +322,8 @@ jobs:
           # Checking if a webhook url is defined
           if [ -n "$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK" ]; then
             # Run script that populates git-related variables as ENV variables
-            echo "Running script populate-git-env.sh"
-            . ./scripts/populate-git-env.sh
-
-            echo "Resolved git variables:"
-            echo "'GIT_COMMIT_SHA': $GIT_COMMIT_SHA"
-            echo "'GIT_COMMIT_REF': $GIT_COMMIT_REF"
-            echo "'GIT_COMMIT_TAGS': $GIT_COMMIT_TAGS"
-
-            # Generates JSON using a bash function - See https://stackoverflow.com/a/57369772/2391795
-            # "End Of File" must be at the beginning of the line with no space/tab before or after - See https://stackoverflow.com/a/12909284/2391795
-            # But, when executed by GitHub Action, it must be inside the "run" section instead
-            generate_post_data() {
-              cat <<EOF
-            {
-              "MANUAL_TRIGGER_CUSTOMER": "${MANUAL_TRIGGER_CUSTOMER}",
-              "CUSTOMER_REF": "${CUSTOMER_REF_TO_DEPLOY}",
-              "STAGE": "staging",
-              "GIT_COMMIT_SHA": "${GIT_COMMIT_SHA}",
-              "GIT_COMMIT_REF": "${GIT_COMMIT_REF}",
-              "GIT_COMMIT_TAGS": "${GIT_COMMIT_TAGS}",
-              "GITHUB_REF_SLUG": "${GITHUB_REF_SLUG}",
-              "GITHUB_HEAD_REF_SLUG": "${GITHUB_HEAD_REF_SLUG}",
-              "GITHUB_BASE_REF_SLUG": "${GITHUB_BASE_REF_SLUG}",
-              "GITHUB_EVENT_REF_SLUG": "${GITHUB_EVENT_REF_SLUG}",
-              "GITHUB_REPOSITORY_SLUG": "${GITHUB_REPOSITORY_SLUG}",
-              "GITHUB_REF_SLUG_URL": "${GITHUB_REF_SLUG_URL}",
-              "GITHUB_HEAD_REF_SLUG_URL": "${GITHUB_HEAD_REF_SLUG_URL}",
-              "GITHUB_BASE_REF_SLUG_URL": "${GITHUB_BASE_REF_SLUG_URL}",
-              "GITHUB_EVENT_REF_SLUG_URL": "${GITHUB_EVENT_REF_SLUG_URL}",
-              "GITHUB_REPOSITORY_SLUG_URL": "${GITHUB_REPOSITORY_SLUG_URL}",
-              "GITHUB_SHA_SHORT": "${GITHUB_SHA_SHORT}"
-            }
-          EOF
-            }
+            echo "Running script generate-post-data"
+            . ./scripts/generate-post-data.sh
 
             echo "Print generate_post_data():"
             echo "$(generate_post_data)"
@@ -383,21 +351,8 @@ jobs:
             echo "No webhook url defined in 'vercel.$CUSTOMER_REF_TO_DEPLOY.staging.json:.build.env.VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK' (found '$VERCEL_DEPLOYMENT_COMPLETED_WEBHOOK')"
           fi
         env:
-          CUSTOMER_REF_TO_DEPLOY: ${{ fromJson(steps.restore-variable.outputs.variables).CUSTOMER_REF_TO_DEPLOY }}
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker
           GIT_COMMIT_SHA: ${{ github.sha }} # Passing current commit SHA to the worker
-          # Passing exposed GitHub environment variables - See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
-          GITHUB_REF_SLUG: ${{ env.GITHUB_REF_SLUG }}
-          GITHUB_HEAD_REF_SLUG: ${{ env.GITHUB_HEAD_REF_SLUG }}
-          GITHUB_BASE_REF_SLUG: ${{ env.GITHUB_BASE_REF_SLUG }}
-          GITHUB_EVENT_REF_SLUG: ${{ env.GITHUB_EVENT_REF_SLUG }}
-          GITHUB_REPOSITORY_SLUG: ${{ env.GITHUB_REPOSITORY_SLUG }}
-          GITHUB_REF_SLUG_URL: ${{ env.GITHUB_REF_SLUG_URL }}
-          GITHUB_HEAD_REF_SLUG_URL: ${{ env.GITHUB_HEAD_REF_SLUG_URL }}
-          GITHUB_BASE_REF_SLUG_URL: ${{ env.GITHUB_BASE_REF_SLUG_URL }}
-          GITHUB_EVENT_REF_SLUG_URL: ${{ env.GITHUB_EVENT_REF_SLUG_URL }}
-          GITHUB_REPOSITORY_SLUG_URL: ${{ env.GITHUB_REPOSITORY_SLUG_URL }}
-          GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
 
   # Runs E2E tests against the Vercel deployment
   run-2e2-tests:
@@ -413,7 +368,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           variables: |
@@ -427,7 +382,7 @@ jobs:
           # XXX We disabled "wait-on" option, because it's useless. Cypress will fail anyway, because it gets redirected to some internal Vercel URL if the domain isn't yet available - See https://github.com/cypress-io/github-action/issues/270
           # wait-on: '${{ env.VERCEL_DEPLOYMENT_URL }}' # Be sure that the endpoint is ready by pinging it before starting tests, using a default timeout of 60 seconds
           config-file: 'cypress/config-customer-ci-cd.json' # Use Cypress config file for CI/CD, and override it below
-          config: baseUrl=${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
+          config: baseUrl=${{ env.VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
         env:
           # Enables Cypress debugging logs, very useful if Cypress crashes, like out-of-memory issues.
           # DEBUG: "cypress:*" # Enable all logs. See https://docs.cypress.io/guides/references/troubleshooting.html#Print-DEBUG-logs
@@ -452,23 +407,23 @@ jobs:
       # On E2E failure, add a comment to the PR with additional information, if there is an open PR for the current branch
       - name: Comment PR (E2E failure)
         uses: peter-evans/create-or-update-comment@v1 # See https://github.com/peter-evans/create-or-update-comment
-        if: fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID && failure()
+        if: env.GITHUB_PULL_REQUEST_ID && failure()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID }}
+          issue-number: ${{ env.GITHUB_PULL_REQUEST_ID }}
           body: |
-            :x:&nbsp; E2E tests **FAILED** for commit ${{ github.sha }} previously deployed at [${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}](${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }})
-            Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID }}/checks) section
+            :x:&nbsp; E2E tests **FAILED** for commit ${{ github.sha }} previously deployed at [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
+            Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ env.GITHUB_PULL_REQUEST_ID }}/checks) section
 
       # On E2E success, add a comment to the PR, if there is an open PR for the current branch
       - name: Comment PR (E2E success)
         uses: peter-evans/create-or-update-comment@v1 # See https://github.com/peter-evans/create-or-update-comment
-        if: fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID && success()
+        if: env.GITHUB_PULL_REQUEST_ID && success()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID }}
+          issue-number: ${{ env.GITHUB_PULL_REQUEST_ID }}
           body: |
-            :white_check_mark:&nbsp; E2E tests **SUCCESS** for commit ${{ github.sha }} previously deployed at [${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}](${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }})
+            :white_check_mark:&nbsp; E2E tests **SUCCESS** for commit ${{ github.sha }} previously deployed at [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -487,7 +442,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           variables: VERCEL_DEPLOYMENT_URL
@@ -504,7 +459,7 @@ jobs:
           prCommentSaveOld: true # If true, then add a new comment for each commit. Otherwise, update the latest comment (default: false).
           outputDirectory: /tmp/lighthouse-artifacts # Used to upload artifacts.
           emulatedFormFactor: all # Run LightHouse against "mobile", "desktop", or "all" devices
-          urls: ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}, ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}/en, ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}/fr
+          urls: ${{ env.VERCEL_DEPLOYMENT_URL }}, ${{ env.VERCEL_DEPLOYMENT_URL }}/en, ${{ env.VERCEL_DEPLOYMENT_URL }}/fr
           locale: en
 
       # Upload HTML report created by lighthouse as an artifact.

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -21,7 +21,7 @@
 # - See https://github.com/jwalton/gh-find-current-pr https://github.com/jwalton/gh-find-current-pr/tree/v1
 # - See https://github.com/peter-evans/create-or-update-comment https://github.com/peter-evans/create-or-update-comment/tree/v1
 # - See https://github.com/UnlyEd/github-action-await-vercel https://github.com/UnlyEd/github-action-await-vercel/tree/v1.1.1
-# - See https://github.com/UnlyEd/github-action-store-variable https://github.com/UnlyEd/github-action-store-variable/tree/v1.0.1
+# - See https://github.com/UnlyEd/github-action-store-variable https://github.com/UnlyEd/github-action-store-variable/tree/v2.1.1
 # - See https://github.com/cypress-io/github-action https://github.com/cypress-io/github-action/tree/v2
 # - See https://github.com/foo-software/lighthouse-check-action https://github.com/foo-software/lighthouse-check-action/tree/v1.0.1
 # - See https://github.com/bobheadxi/deployments https://github.com/bobheadxi/deployments/tree/v0.4.3

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -69,6 +69,9 @@ on:
         description: 'Customer to deploy'
         required: true
 
+env:
+  STAGE: staging
+
 jobs:
   # Configures the deployment environment, install dependencies (like node, npm, etc.) that are requirements for the upcoming jobs
   # Ex: Necessary to run `yarn deploy`
@@ -355,6 +358,18 @@ jobs:
         env:
           GIT_COMMIT_REF: ${{ github.ref }} # Passing current branch/tag to the worker
           GIT_COMMIT_SHA: ${{ github.sha }} # Passing current commit SHA to the worker
+          # Passing exposed GitHub environment variables - See https://github.com/rlespinasse/github-slug-action#exposed-github-environment-variables
+          GITHUB_REF_SLUG: ${{ env.GITHUB_REF_SLUG }}
+          GITHUB_HEAD_REF_SLUG: ${{ env.GITHUB_HEAD_REF_SLUG }}
+          GITHUB_BASE_REF_SLUG: ${{ env.GITHUB_BASE_REF_SLUG }}
+          GITHUB_EVENT_REF_SLUG: ${{ env.GITHUB_EVENT_REF_SLUG }}
+          GITHUB_REPOSITORY_SLUG: ${{ env.GITHUB_REPOSITORY_SLUG }}
+          GITHUB_REF_SLUG_URL: ${{ env.GITHUB_REF_SLUG_URL }}
+          GITHUB_HEAD_REF_SLUG_URL: ${{ env.GITHUB_HEAD_REF_SLUG_URL }}
+          GITHUB_BASE_REF_SLUG_URL: ${{ env.GITHUB_BASE_REF_SLUG_URL }}
+          GITHUB_EVENT_REF_SLUG_URL: ${{ env.GITHUB_EVENT_REF_SLUG_URL }}
+          GITHUB_REPOSITORY_SLUG_URL: ${{ env.GITHUB_REPOSITORY_SLUG_URL }}
+          GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
 
   # Runs E2E tests against the Vercel deployment
   run-2e2-tests:

--- a/.github/workflows/deploy-vercel-staging.yml
+++ b/.github/workflows/deploy-vercel-staging.yml
@@ -266,7 +266,7 @@ jobs:
   await-for-vercel-deployment:
     name: Await current deployment to be ready (Ubuntu 18.04)
     runs-on: ubuntu-18.04
-    needs: start-${{ env.STAGE }}-deployment
+    needs: start-staging-deployment
     timeout-minutes: 5 # Limit current job timeout (including action timeout setup down there) https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed - See https://github.com/actions/checkout

--- a/.github/workflows/deploy-vercel-storybook.yml
+++ b/.github/workflows/deploy-vercel-storybook.yml
@@ -11,7 +11,7 @@
 # - See https://github.com/jwalton/gh-find-current-pr https://github.com/jwalton/gh-find-current-pr/tree/v1
 # - See https://github.com/peter-evans/create-or-update-comment https://github.com/peter-evans/create-or-update-comment/tree/v1
 # - See https://github.com/UnlyEd/github-action-await-vercel https://github.com/UnlyEd/github-action-await-vercel/tree/v1.1.1
-# - See https://github.com/UnlyEd/github-action-store-variable https://github.com/UnlyEd/github-action-store-variable/tree/v1.0.1
+# - See https://github.com/UnlyEd/github-action-store-variable https://github.com/UnlyEd/github-action-store-variable/tree/v2.1.1
 # - See https://github.com/cypress-io/github-action https://github.com/cypress-io/github-action/tree/v2
 
 name: Deploy Storybook static site to Vercel
@@ -186,7 +186,7 @@ jobs:
       # At the end of the job, store all variables we will need in the following jobs
       # The variables will be stored in and retrieved from a GitHub Artifact (each variable is stored in a different file)
       - name: Store variables for next jobs
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         with:
           variables: |
             VERCEL_DEPLOYMENT_URL=${{ env.VERCEL_DEPLOYMENT_URL }}
@@ -204,7 +204,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -238,7 +238,7 @@ jobs:
 
       # Restore variables stored by previous jobs
       - name: Restore variables
-        uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
+        uses: UnlyEd/github-action-store-variable@v2.1.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
           failIfNotFound: true
@@ -253,7 +253,7 @@ jobs:
           # XXX We disabled "wait-on" option, because it's useless. Cypress will fail anyway, because it gets redirected to some internal Vercel URL if the domain isn't yet available - See https://github.com/cypress-io/github-action/issues/270
           # wait-on: '${{ env.VERCEL_DEPLOYMENT_URL }}' # Be sure that the endpoint is ready by pinging it before starting tests, using a default timeout of 60 seconds
           config-file: 'cypress/config-storybook.json' # Use Cypress config file for Storybook, and override it below
-          config: baseUrl=${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
+          config: baseUrl=${{ env.VERCEL_DEPLOYMENT_URL }} # Overriding baseUrl provided by config file to test the new deployment
         env:
           # Enables Cypress debugging logs, very useful if Cypress crashes, like out-of-memory issues.
           # DEBUG: "cypress:*" # Enable all logs. See https://docs.cypress.io/guides/references/troubleshooting.html#Print-DEBUG-logs
@@ -278,22 +278,22 @@ jobs:
       # On E2E failure, add a comment to the PR with additional information, if there is an open PR for the current branch
       - name: Comment PR (E2E failure)
         uses: peter-evans/create-or-update-comment@v1 # See https://github.com/peter-evans/create-or-update-comment
-        if: fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID && failure()
+        if: env.GITHUB_PULL_REQUEST_ID && failure()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID }}
+          issue-number: ${{ env.GITHUB_PULL_REQUEST_ID }}
           body: |
-            :x:&nbsp; E2E tests **FAILED** for commit ${{ github.sha }} previously deployed **Storybook static site** at [${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}](${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }})
-            Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID }}/checks) section
+            :x:&nbsp; E2E tests **FAILED** for commit ${{ github.sha }} previously deployed **Storybook static site** at [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
+            Download artifacts (screenshots + videos) from [`checks`](https://github.com/UnlyEd/next-right-now/pull/${{ env.GITHUB_PULL_REQUEST_ID }}/checks) section
 
       # On E2E success, add a comment to the PR, if there is an open PR for the current branch
       - name: Comment PR (E2E success)
         uses: peter-evans/create-or-update-comment@v1 # See https://github.com/peter-evans/create-or-update-comment
-        if: fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID && success()
+        if: env.GITHUB_PULL_REQUEST_ID && success()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ fromJson(steps.restore-variable.outputs.variables).GITHUB_PULL_REQUEST_ID }}
+          issue-number: ${{ env.GITHUB_PULL_REQUEST_ID }}
           body: |
-            :white_check_mark:&nbsp; E2E tests **SUCCESS** for commit ${{ github.sha }} previously deployed **Storybook static site** at [${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }}](${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_URL }})
+            :white_check_mark:&nbsp; E2E tests **SUCCESS** for commit ${{ github.sha }} previously deployed **Storybook static site** at [${{ env.VERCEL_DEPLOYMENT_URL }}](${{ env.VERCEL_DEPLOYMENT_URL }})
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-vercel-storybook.yml
+++ b/.github/workflows/deploy-vercel-storybook.yml
@@ -218,7 +218,7 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEl_TOKEN }}
         with:
-          deployment-url: ${{ fromJson(steps.restore-variable.outputs.variables).VERCEL_DEPLOYMENT_DOMAIN }} # Must only contain the domain name (no http prefix, etc.)
+          deployment-url: ${{ env.VERCEL_DEPLOYMENT_DOMAIN }} # Must only contain the domain name (no http prefix, etc.)
           timeout: 90 # Wait for 90 seconds before failing
 
       - name: Display deployment status

--- a/.github/workflows/deploy-vercel-storybook.yml
+++ b/.github/workflows/deploy-vercel-storybook.yml
@@ -207,6 +207,7 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
+          failIfNotFound: true
           variables: |
             VERCEL_DEPLOYMENT_DOMAIN
 
@@ -240,6 +241,7 @@ jobs:
         uses: UnlyEd/github-action-store-variable@v1.0.1 # See https://github.com/UnlyEd/github-action-store-variable
         id: restore-variable
         with:
+          failIfNotFound: true
           variables: |
             VERCEL_DEPLOYMENT_URL
             GITHUB_PULL_REQUEST_ID

--- a/scripts/generate-post-data.sh
+++ b/scripts/generate-post-data.sh
@@ -9,7 +9,7 @@ generate_post_data() {
   {
     "MANUAL_TRIGGER_CUSTOMER": "${MANUAL_TRIGGER_CUSTOMER}",
     "CUSTOMER_REF": "${CUSTOMER_REF_TO_DEPLOY}",
-    "STAGE": "staging",
+    "STAGE": "${DEPLOYMENT_STAGE}",
     "GIT_COMMIT_SHA": "${GIT_COMMIT_SHA}",
     "GIT_COMMIT_REF": "${GIT_COMMIT_REF}",
     "GIT_COMMIT_TAGS": "${GIT_COMMIT_TAGS}",

--- a/scripts/generate-post-data.sh
+++ b/scripts/generate-post-data.sh
@@ -1,0 +1,29 @@
+# Generates JSON using a bash function - See https://stackoverflow.com/a/57369772/2391795
+# "End Of File" must be at the beginning of the line with no space/tab before or after - See https://stackoverflow.com/a/12909284/2391795
+# But, when executed by GitHub Action, it must be inside the "run" section instead
+
+. ./scripts/populate-git-env.sh
+
+generate_post_data() {
+  cat <<EndOfMessage
+  {
+    "MANUAL_TRIGGER_CUSTOMER": "${MANUAL_TRIGGER_CUSTOMER}",
+    "CUSTOMER_REF": "${CUSTOMER_REF_TO_DEPLOY}",
+    "STAGE": "staging",
+    "GIT_COMMIT_SHA": "${GIT_COMMIT_SHA}",
+    "GIT_COMMIT_REF": "${GIT_COMMIT_REF}",
+    "GIT_COMMIT_TAGS": "${GIT_COMMIT_TAGS}",
+    "GITHUB_REF_SLUG": "${GITHUB_REF_SLUG}",
+    "GITHUB_HEAD_REF_SLUG": "${GITHUB_HEAD_REF_SLUG}",
+    "GITHUB_BASE_REF_SLUG": "${GITHUB_BASE_REF_SLUG}",
+    "GITHUB_EVENT_REF_SLUG": "${GITHUB_EVENT_REF_SLUG}",
+    "GITHUB_REPOSITORY_SLUG": "${GITHUB_REPOSITORY_SLUG}",
+    "GITHUB_REF_SLUG_URL": "${GITHUB_REF_SLUG_URL}",
+    "GITHUB_HEAD_REF_SLUG_URL": "${GITHUB_HEAD_REF_SLUG_URL}",
+    "GITHUB_BASE_REF_SLUG_URL": "${GITHUB_BASE_REF_SLUG_URL}",
+    "GITHUB_EVENT_REF_SLUG_URL": "${GITHUB_EVENT_REF_SLUG_URL}",
+    "GITHUB_REPOSITORY_SLUG_URL": "${GITHUB_REPOSITORY_SLUG_URL}",
+    "GITHUB_SHA_SHORT": "${GITHUB_SHA_SHORT}"
+  }
+EndOfMessage
+}

--- a/scripts/generate-post-data.sh
+++ b/scripts/generate-post-data.sh
@@ -1,7 +1,7 @@
 # Generates JSON using a bash function - See https://stackoverflow.com/a/57369772/2391795
 # "End Of File" must be at the beginning of the line with no space/tab before or after - See https://stackoverflow.com/a/12909284/2391795
 # But, when executed by GitHub Action, it must be inside the "run" section instead
-
+# You can find more details here: https://stackoverflow.com/questions/2500436/how-does-cat-eof-work-in-bash
 . ./scripts/populate-git-env.sh
 
 generate_post_data() {


### PR DESCRIPTION
Reduce differences between production and staging scripts by adding a `STAGE` environment variable that is local to the file. (avoids diff, avoids conflicts with forks, avoids manual mistakes)

Update github-action-store-variable@v1.0.1 to github-action-store-variable@v2.1.1 and use its simpler API.