### PR TITLE
Fixed Getting Started link in use-airtable.md

### DIFF
--- a/guides/airtable-api/use-airtable.md
+++ b/guides/airtable-api/use-airtable.md
@@ -19,7 +19,7 @@ Advices and "must-know" things regarding Airtable usage.
 
 ## Overview
 
-[Getting started(https://support.airtable.com/hc/en-us/sections/360003922433)
+[Getting started](https://support.airtable.com/hc/en-us/sections/360003922433)
 
 Airtable is very similar to Excel and Google Sheets. It's more user-friendly than both, but not as powerful sometimes.
 


### PR DESCRIPTION
Fixed Overview > Getting Started link. Only added the closing bracket.

Since only adding a single closing brackets, I've skipped the Create Issue step. I hope that is alright.