### PR TITLE
Fix rel="alternate" - Must use absolute url (with "https://" prefix)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -71,6 +71,7 @@ module.exports = withBundleAnalyzer(withSourceMaps({
    * @see https://nextjs.org/docs/api-reference/next.config.js/environment-variables
    */
   env: {
+    VERCEL_URL: process.env.VERCEL_URL,
     NEXT_PUBLIC_VERCEL_URL: process.env.NEXT_PUBLIC_VERCEL_URL,
     GITHUB_DISPATCH_TOKEN: process.env.GITHUB_DISPATCH_TOKEN,
     GRAPHQL_API_ENDPOINT: process.env.GRAPHQL_API_ENDPOINT,

--- a/next.config.js
+++ b/next.config.js
@@ -71,8 +71,6 @@ module.exports = withBundleAnalyzer(withSourceMaps({
    * @see https://nextjs.org/docs/api-reference/next.config.js/environment-variables
    */
   env: {
-    VERCEL_URL: process.env.VERCEL_URL,
-    NEXT_PUBLIC_VERCEL_URL: process.env.NEXT_PUBLIC_VERCEL_URL,
     GITHUB_DISPATCH_TOKEN: process.env.GITHUB_DISPATCH_TOKEN,
     GRAPHQL_API_ENDPOINT: process.env.GRAPHQL_API_ENDPOINT,
     GRAPHQL_API_KEY: process.env.GRAPHQL_API_KEY,
@@ -80,6 +78,8 @@ module.exports = withBundleAnalyzer(withSourceMaps({
     SENTRY_DSN: process.env.SENTRY_DSN,
 
     // Dynamic env variables
+    VERCEL_DOMAIN: process.env.VERCEL_URL, // Injected by Vercel, see https://vercel.com/docs/environment-variables#system-environment-variables
+    NEXT_PUBLIC_APP_BASE_URL: process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:8888',
     NEXT_PUBLIC_APP_BUILD_TIME: date.toString(),
     NEXT_PUBLIC_APP_BUILD_TIMESTAMP: +date,
     NEXT_PUBLIC_APP_NAME: packageJson.name,

--- a/next.config.js
+++ b/next.config.js
@@ -77,8 +77,14 @@ module.exports = withBundleAnalyzer(withSourceMaps({
     LOCIZE_API_KEY: process.env.LOCIZE_API_KEY,
     SENTRY_DSN: process.env.SENTRY_DSN,
 
+    // Vercel env variables - See https://vercel.com/docs/environment-variables#system-environment-variables
+    VERCEL: process.env.VERCEL,
+    VERCEL_ENV: process.env.VERCEL_ENV,
+    VERCEL_URL: process.env.VERCEL_URL,
+    CI: process.env.CI,
+
     // Dynamic env variables
-    VERCEL_DOMAIN: process.env.VERCEL_URL, // Injected by Vercel, see https://vercel.com/docs/environment-variables#system-environment-variables
+    NEXT_PUBLIC_APP_DOMAIN: process.env.VERCEL_URL, // Alias
     NEXT_PUBLIC_APP_BASE_URL: process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:8888',
     NEXT_PUBLIC_APP_BUILD_TIME: date.toString(),
     NEXT_PUBLIC_APP_BUILD_TIMESTAMP: +date,

--- a/next.config.js
+++ b/next.config.js
@@ -71,6 +71,7 @@ module.exports = withBundleAnalyzer(withSourceMaps({
    * @see https://nextjs.org/docs/api-reference/next.config.js/environment-variables
    */
   env: {
+    NEXT_PUBLIC_VERCEL_URL: process.env.NEXT_PUBLIC_VERCEL_URL,
     GITHUB_DISPATCH_TOKEN: process.env.GITHUB_DISPATCH_TOKEN,
     GRAPHQL_API_ENDPOINT: process.env.GRAPHQL_API_ENDPOINT,
     GRAPHQL_API_KEY: process.env.GRAPHQL_API_KEY,

--- a/process.env.d.ts
+++ b/process.env.d.ts
@@ -20,6 +20,7 @@ declare global {
       NEXT_PUBLIC_AMPLITUDE_API_KEY: string;
       NEXT_PUBLIC_APP_BASE_URL: string;
       NEXT_PUBLIC_APP_BUILD_ID: string;
+      NEXT_PUBLIC_APP_DOMAIN: string;
       NEXT_PUBLIC_APP_NAME: string;
       NEXT_PUBLIC_APP_NAME_VERSION: string;
       NEXT_PUBLIC_APP_VERSION_RELEASE: string;
@@ -30,7 +31,6 @@ declare global {
       NEXT_PUBLIC_LOCIZE_PROJECT_ID: string;
       NEXT_PUBLIC_NRN_PRESET: string;
       SENTRY_DSN: string;
-      VERCEL_DOMAIN: string;
 
       // Git env variables
       GIT_COMMIT_SHA_SHORT: string;
@@ -42,7 +42,11 @@ declare global {
       AWS_EXECUTION_ENV: string;
       AWS_LAMBDA_FUNCTION_MEMORY_SIZE: string;
       AWS_REGION: string;
-      VERCEL_REGION: string;
+      VERCEL: string; // An indicator that the app is deployed and running on Vercel. Example: '1'.
+      VERCEL_ENV: string; // The Environment that the app is deployed an running on. The value can be either 'production', 'preview', or 'development'.
+      VERCEL_REGION: string; // The ID of the Region where the app is running. Example: 'cdg1'. XXX: This Variable is only exposed during Runtime for Serverless Functions.
+      VERCEL_URL: string; // The URL of the deployment. Example: 'my-site-7q03y4pi5.vercel.app'. XXX Do not use. Using NEXT_PUBLIC_APP_DOMAIN is preferred (alias)
+      CI: string; // An indicator that the code is running in a Continuous Integration environment. Example: '1'. XXX: This Variable is only exposed during Build Step.
 
       // Other
       TZ: string; // TimeZone (":UTC")

--- a/process.env.d.ts
+++ b/process.env.d.ts
@@ -18,6 +18,7 @@ declare global {
       LOCIZE_API_KEY: string;
       NODE_ENV: 'development' | 'production';
       NEXT_PUBLIC_AMPLITUDE_API_KEY: string;
+      NEXT_PUBLIC_APP_BASE_URL: string;
       NEXT_PUBLIC_APP_BUILD_ID: string;
       NEXT_PUBLIC_APP_NAME: string;
       NEXT_PUBLIC_APP_NAME_VERSION: string;
@@ -29,6 +30,7 @@ declare global {
       NEXT_PUBLIC_LOCIZE_PROJECT_ID: string;
       NEXT_PUBLIC_NRN_PRESET: string;
       SENTRY_DSN: string;
+      VERCEL_DOMAIN: string;
 
       // Git env variables
       GIT_COMMIT_SHA_SHORT: string;
@@ -36,7 +38,7 @@ declare global {
       GIT_COMMIT_REF: string;
       GIT_COMMIT_TAGS: string;
 
-      // Vendor env variables
+      // Vercel (+ AWS) env variables - See https://vercel.com/docs/environment-variables#system-environment-variables
       AWS_EXECUTION_ENV: string;
       AWS_LAMBDA_FUNCTION_MEMORY_SIZE: string;
       AWS_REGION: string;

--- a/src/layouts/demo/components/DemoHead.tsx
+++ b/src/layouts/demo/components/DemoHead.tsx
@@ -93,8 +93,8 @@ const DemoHead: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
   const format = config?.format || 'woff2';
   const fontFile = config?.fontFile || `${fontName}-variable-latin.${format}`;
 
-  console.log('VERCEL_URL', process.env.VERCEL_URL);
-  console.log('NEXT_PUBLIC_VERCEL_URL', process.env.NEXT_PUBLIC_VERCEL_URL);
+  console.log('VERCEL_DOMAIN', process.env.VERCEL_DOMAIN);
+  console.log('NEXT_PUBLIC_APP_BASE_URL', process.env.NEXT_PUBLIC_APP_BASE_URL);
 
   return (
     <NextHead>

--- a/src/layouts/demo/components/DemoHead.tsx
+++ b/src/layouts/demo/components/DemoHead.tsx
@@ -126,7 +126,12 @@ const DemoHead: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
           // See https://stackoverflow.com/questions/28291574/are-relative-links-valid-in-link-rel-alternate-hreflang-tags
           // See https://webmasters.googleblog.com/2013/04/5-common-mistakes-with-relcanonical.html
           return (
-            <link key={supportedLocale?.name} rel="alternate" hrefLang={supportedLocale?.name || 'en'} href={`/${supportedLocale?.name || 'en'}`} />
+            <link
+              key={supportedLocale?.name}
+              rel="alternate"
+              hrefLang={supportedLocale?.name || 'en'}
+              href={`/${supportedLocale?.name || 'en'}`} // TODO must use absolute url
+            />
           );
         })
       }

--- a/src/layouts/demo/components/DemoHead.tsx
+++ b/src/layouts/demo/components/DemoHead.tsx
@@ -94,6 +94,7 @@ const DemoHead: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
   const fontFile = config?.fontFile || `${fontName}-variable-latin.${format}`;
 
   console.log('VERCEL_URL', process.env.VERCEL_URL);
+  console.log('NEXT_PUBLIC_VERCEL_URL', process.env.NEXT_PUBLIC_VERCEL_URL);
 
   return (
     <NextHead>

--- a/src/layouts/demo/components/DemoHead.tsx
+++ b/src/layouts/demo/components/DemoHead.tsx
@@ -93,6 +93,8 @@ const DemoHead: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
   const format = config?.format || 'woff2';
   const fontFile = config?.fontFile || `${fontName}-variable-latin.${format}`;
 
+  console.log('VERCEL_URL', process.env.VERCEL_URL);
+
   return (
     <NextHead>
       <meta charSet="UTF-8" />

--- a/src/layouts/demo/components/DemoHead.tsx
+++ b/src/layouts/demo/components/DemoHead.tsx
@@ -93,9 +93,6 @@ const DemoHead: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
   const format = config?.format || 'woff2';
   const fontFile = config?.fontFile || `${fontName}-variable-latin.${format}`;
 
-  console.log('VERCEL_DOMAIN', process.env.VERCEL_DOMAIN);
-  console.log('NEXT_PUBLIC_APP_BASE_URL', process.env.NEXT_PUBLIC_APP_BASE_URL);
-
   return (
     <NextHead>
       <meta charSet="UTF-8" />
@@ -133,7 +130,7 @@ const DemoHead: React.FunctionComponent<HeadProps> = (props): JSX.Element => {
               key={supportedLocale?.name}
               rel="alternate"
               hrefLang={supportedLocale?.name || 'en'}
-              href={`/${supportedLocale?.name || 'en'}`} // TODO must use absolute url
+              href={`${process.env.NEXT_PUBLIC_APP_BASE_URL}/${supportedLocale?.name || 'en'}`}
             />
           );
         })

--- a/src/modules/core/sentry/sentry.ts
+++ b/src/modules/core/sentry/sentry.ts
@@ -34,6 +34,7 @@ if (process.env.SENTRY_DSN) {
     scope.setTag('customerRef', process.env.NEXT_PUBLIC_CUSTOMER_REF);
     scope.setTag('appStage', process.env.NEXT_PUBLIC_APP_STAGE);
     scope.setTag('appName', process.env.NEXT_PUBLIC_APP_NAME);
+    scope.setTag('appBaseUrl', process.env.NEXT_PUBLIC_APP_BASE_URL);
     scope.setTag('appVersion', process.env.NEXT_PUBLIC_APP_VERSION);
     scope.setTag('appNameVersion', process.env.NEXT_PUBLIC_APP_NAME_VERSION);
     scope.setTag('appBuildTime', process.env.NEXT_PUBLIC_APP_BUILD_TIME);

--- a/src/modules/core/testing/tests/env.test.ts
+++ b/src/modules/core/testing/tests/env.test.ts
@@ -2,9 +2,11 @@
  * This test is meant to detect quickly when required ENV variables are missing.
  * We encourage you to list all your env variables to make sure you detect misconfiguration early.
  *
- * It was added after encountering this particular issue https://github.com/vercel/next.js/issues/13780
- * Where a missing env var would crash the "next build" locally, because of the particular behaviour of the "fetch" package
- * It can be hard to track down such misconfiguration, and it's a good practice to detect those as early as possible (and avoid deploying a misconfigured release)
+ * It was added after encountering this particular issue https://github.com/vercel/next.js/issues/13780.
+ * Where a missing env var would crash the "next build" locally, because of the particular behaviour of the "fetch" package.
+ * It can be hard to track down such misconfiguration, and it's a good practice to detect those as early as possible (and avoid deploying a misconfigured release).
+ *
+ * XXX This test file is not executed on Vercel, only locally. ("integration" tests aren't executed on Vercel)
  *
  * @group integration
  * @group utils
@@ -29,6 +31,15 @@ describe(`utils/env/env.ts`, () => {
         expect(process.env.NEXT_PUBLIC_APP_BUILD_ID, 'NEXT_PUBLIC_APP_BUILD_ID must be defined but is not').toBeDefined();
       } else {
         expect(process.env.NEXT_PUBLIC_APP_BUILD_ID, 'NEXT_PUBLIC_APP_BUILD_ID should not be defined when building a non-production release').not.toBeDefined();
+      }
+    });
+
+    test(`NEXT_PUBLIC_APP_BASE_URL`, async () => {
+      // This ENV var is injected by Webpack and not available when running the tests suite when building a local build (because webpack hasn't been executed yet)
+      if (process.env.NODE_ENV === 'production') {
+        expect(process.env.NEXT_PUBLIC_APP_BASE_URL, 'NEXT_PUBLIC_APP_BASE_URL must be defined but is not').toBeDefined();
+      } else {
+        expect(process.env.NEXT_PUBLIC_APP_BASE_URL, 'NEXT_PUBLIC_APP_BASE_URL should not be defined when building a non-production release').not.toBeDefined();
       }
     });
 

--- a/src/pages/api/status.ts
+++ b/src/pages/api/status.ts
@@ -45,7 +45,6 @@ export const status = async (req: NextApiRequest, res: NextApiResponse): Promise
       GIT_COMMIT_SHA: process.env.GIT_COMMIT_SHA,
       GIT_COMMIT_REF: process.env.GIT_COMMIT_REF,
       GIT_COMMIT_TAGS: process.env.GIT_COMMIT_TAGS,
-      VERCEL_DOMAIN: process.env.VERCEL_DOMAIN,
       NEXT_PUBLIC_APP_BASE_URL: process.env.NEXT_PUBLIC_APP_BASE_URL,
     });
   } catch (e) {

--- a/src/pages/api/status.ts
+++ b/src/pages/api/status.ts
@@ -45,6 +45,7 @@ export const status = async (req: NextApiRequest, res: NextApiResponse): Promise
       GIT_COMMIT_SHA: process.env.GIT_COMMIT_SHA,
       GIT_COMMIT_REF: process.env.GIT_COMMIT_REF,
       GIT_COMMIT_TAGS: process.env.GIT_COMMIT_TAGS,
+      VERCEL_URL: process.env.VERCEL_URL,
     });
   } catch (e) {
     Sentry.captureException(e);

--- a/src/pages/api/status.ts
+++ b/src/pages/api/status.ts
@@ -45,8 +45,8 @@ export const status = async (req: NextApiRequest, res: NextApiResponse): Promise
       GIT_COMMIT_SHA: process.env.GIT_COMMIT_SHA,
       GIT_COMMIT_REF: process.env.GIT_COMMIT_REF,
       GIT_COMMIT_TAGS: process.env.GIT_COMMIT_TAGS,
-      VERCEL_URL: process.env.VERCEL_URL,
-      NEXT_PUBLIC_VERCEL_URL: process.env.NEXT_PUBLIC_VERCEL_URL,
+      VERCEL_DOMAIN: process.env.VERCEL_DOMAIN,
+      NEXT_PUBLIC_APP_BASE_URL: process.env.NEXT_PUBLIC_APP_BASE_URL,
     });
   } catch (e) {
     Sentry.captureException(e);

--- a/src/pages/api/status.ts
+++ b/src/pages/api/status.ts
@@ -46,6 +46,7 @@ export const status = async (req: NextApiRequest, res: NextApiResponse): Promise
       GIT_COMMIT_REF: process.env.GIT_COMMIT_REF,
       GIT_COMMIT_TAGS: process.env.GIT_COMMIT_TAGS,
       VERCEL_URL: process.env.VERCEL_URL,
+      NEXT_PUBLIC_VERCEL_URL: process.env.NEXT_PUBLIC_VERCEL_URL,
     });
   } catch (e) {
     Sentry.captureException(e);


### PR DESCRIPTION
See https://github.com/GoogleChrome/lighthouse/issues/12458#issuecomment-836839610

Issue: Not sure how to get the hostname, not available there, would need to be provided from getStaticProps? (but that wouldn't be a valid host name if generated at build time), not sure how to do that.

Solution: Use `VERCEL_URL` env variable that's injected during build, and make it available to the whole app.