### PR TITLE
Optimize .vercelignore configuration

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,16 +1,21 @@
 # Optimize speed/size of deployments by not uploading those files
 .idea/
+.github/
 node_modules/
 cypress/
+docs/
 coverage/
+scripts/
+svg-to-react/
 .codeclimate.yml
 .editorconfig
-.env.build.example
-buildspec.yml
-README.md
-yarn.lock
+.env*
+.hybrid-cache-*.cache
+.jest-test-results.json
+*.md
+LICENSE
 yarn-error.log
 
-# Avoid tests being deployed as Vercel Serverless Functions (increases bundle size, and count towards limits)
+# Avoid tests being deployed as Vercel Serverless Functions (they would increase bundle size, and count towards Vercel's limits)
 src/pages/api/*.test.ts
 src/pages/api/**/*.test.ts


### PR DESCRIPTION
Ignore more useless files + **don't ignore yarn.lock**

#### Before
![image](https://user-images.githubusercontent.com/3807458/121491801-9383ba00-c9d6-11eb-8a5a-1e3999ab63e5.png)

![image](https://user-images.githubusercontent.com/3807458/121492845-85826900-c9d7-11eb-8d4f-cb14f43bfe7b.png)



#### After
![image](https://user-images.githubusercontent.com/3807458/121491891-a7c7b700-c9d6-11eb-95be-3a5dc31581c8.png)

![image](https://user-images.githubusercontent.com/3807458/121492617-4e13bc80-c9d7-11eb-932e-46bd67bfdaa5.png)

---

We could also optimize even more by ignoring all storybook-related files when deploying the app (`.storybook` and `src/stories`). But that seems like an overhead of configuration complexity which would yield very little gain.