### PR TITLE
[Beta] Playing around with Stitches as a replacement for Emotion lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@fortawesome/react-fontawesome": "0.1.14",
     "@sentry/browser": "6.3.6",
     "@sentry/node": "6.3.6",
+    "@stitches/react": "0.2.2",
     "@types/lodash.isequal": "4.5.5",
     "@unly/simple-logger": "1.0.0",
     "@unly/universal-language-detector": "2.0.3",

--- a/src/modules/core/css/stitches.config.ts
+++ b/src/modules/core/css/stitches.config.ts
@@ -1,0 +1,26 @@
+import { createCss } from '@stitches/react';
+
+export const {
+  styled,
+  css,
+  global,
+  keyframes,
+  getCssString,
+  theme,
+} = createCss({
+  theme: { // TODO Need to have part of our theme configured dynamically (based on the Customer.theme)
+    colors: {
+      gray400: 'gainsboro',
+      gray500: 'lightgray',
+    },
+  },
+  media: {
+    bp1: '(min-width: 480px)',
+  },
+  utils: {
+    marginX: (config) => (value) => ({
+      marginLeft: value,
+      marginRight: value,
+    }),
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,6 +2681,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@stitches/react@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-0.2.2.tgz#8a2f8256835510c265ab20820f54a5bb0376bac6"
+  integrity sha512-/qRSX+ANPJg/0eLNr5bEywjkdvIfLbsaG2d8p83wPlI0MA7Yi9FzaRLk2H6DMAdJHuyu6ThY4HfHQIL35buY9g==
+
 "@storybook/addon-a11y@6.2.9":
   version "6.2.9"
   resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-6.2.9.tgz#8386d73343db03c15d07f6bf927a4030d441d1ff"


### PR DESCRIPTION
See https://github.com/UnlyEd/next-right-now/discussions/324#discussioncomment-891115

See https://stitches.dev/docs/installation

## Issues:
- Don't know how to replace Emotion `ThemeProvider` using Stitches. 
  - ⚠️ Blocking, because part of our theme is dynamic and cannot be defined statically. Examples and best practices would be great. 
  - Not sure if that's actually blocking since we use "preload", it should "just work", theoretically.
  - Possible to use https://github.com/callstack/react-theme-provider as an alternative
- ⚠️ The `@stitches/react` lib is currently in beta